### PR TITLE
fix(pvc-metrics): volume used

### DIFF
--- a/k8s-infra-metrics/kubernetes-pvc-metrics.json
+++ b/k8s-infra-metrics/kubernetes-pvc-metrics.json
@@ -1,613 +1,933 @@
 {
-    "description": "",
-    "layout": [
-      {
-        "h": 4,
-        "i": "b1a1b62d-bbaa-4c49-a240-20e6f3a5c59d",
-        "moved": false,
-        "static": false,
-        "w": 6,
-        "x": 0,
-        "y": 2
-      },
-      {
-        "h": 4,
-        "i": "8a17665f-d533-4591-a2e8-9ea5ada56f78",
-        "moved": false,
-        "static": false,
-        "w": 6,
-        "x": 0,
-        "y": 4
-      },
-      {
-        "h": 4,
-        "i": "3ddd26f4-886a-4e89-97a0-04e330e8647d",
-        "moved": false,
-        "static": false,
-        "w": 6,
-        "x": 6,
-        "y": 2
-      },
-      {
-        "h": 4,
-        "i": "378ee8aa-898c-4de2-b710-ff747ce1614b",
-        "moved": false,
-        "static": false,
-        "w": 6,
-        "x": 6,
-        "y": 0
-      },
-      {
-        "h": 4,
-        "i": "94774ddd-6c72-4988-a7ed-07af51fab210",
-        "moved": false,
-        "static": false,
-        "w": 6,
-        "x": 0,
-        "y": 0
-      }
-    ],
-    "tags": [],
-    "title": "Kubernetes PVC Metrics",
-    "variables": {
-      "namespace_name": {
-        "allSelected": false,
-        "customValue": "",
-        "description": "",
-        "modificationUUID": "54d953a6-c1c4-4518-b44f-d1579dccf343",
-        "multiSelect": false,
-        "name": "namespace_name",
-        "queryValue": "SELECT DISTINCT JSONExtractString(labels, 'k8s_namespace_name') AS k8s_namespace_name\nFROM signoz_metrics.distributed_time_series_v2\nWHERE metric_name = 'k8s_pod_cpu_time' and JSONExtractString(labels, 'k8s_node_name') IN {{.node_name}}",
-        "selectedValue": "default",
-        "showALLOption": false,
-        "sort": "DISABLED",
-        "textboxValue": "",
-        "type": "QUERY",
-        "order": 0,
-        "id": "9a32bb87-d8b4-498f-88cf-65dfd25cd579"
-      },
-      "node_name": {
-        "allSelected": true,
-        "customValue": "",
-        "description": "",
-        "modificationUUID": "24efc483-9666-4feb-9a47-9d707b17da1f",
-        "multiSelect": true,
-        "name": "node_name",
-        "queryValue": "SELECT DISTINCT JSONExtractString(labels, 'k8s_node_name') AS k8s_node_name\nFROM signoz_metrics.distributed_time_series_v2\nWHERE metric_name = 'k8s_node_cpu_time'",
-        "selectedValue": ["default"],
-        "showALLOption": true,
-        "sort": "ASC",
-        "textboxValue": "",
-        "type": "QUERY",
-        "order": 1,
-        "id": "6a787b99-95f6-4d96-b667-eb74a65446ef"
-      }
+  "description": "",
+  "layout": [
+    {
+      "h": 4,
+      "i": "3b10447f-cd3d-4492-bf7c-9e9acb0a65ac",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 0
     },
-    "widgets": [
-      {
-        "description": "",
-        "id": "94774ddd-6c72-4988-a7ed-07af51fab210",
-        "isStacked": false,
-        "nullZeroValues": "zero",
-        "opacity": "1",
-        "panelTypes": "graph",
-        "query": {
-          "builder": {
-            "queryData": [
-              {
-                "aggregateAttribute": {
-                  "dataType": "float64",
-                  "id": "k8s_volume_available--float64----true",
-                  "isColumn": true,
-                  "key": "k8s_volume_available",
-                  "type": ""
-                },
-                "aggregateOperator": "avg",
-                "dataSource": "metrics",
-                "disabled": false,
-                "expression": "A",
-                "filters": {
-                  "items": [
-                    {
-                      "id": "b7fc6f79",
-                      "key": {
-                        "dataType": "string",
-                        "id": "k8s_namespace_name--string--tag--false",
-                        "isColumn": false,
-                        "key": "k8s_namespace_name",
-                        "type": "tag"
-                      },
-                      "op": "in",
-                      "value": [
-                        "{{.namespace_name}}"
-                      ]
-                    },
-                    {
-                      "id": "b2462589",
-                      "key": {
-                        "dataType": "string",
-                        "id": "k8s_volume_type--string--tag--false",
-                        "isColumn": false,
-                        "key": "k8s_volume_type",
-                        "type": "tag"
-                      },
-                      "op": "in",
-                      "value": [
-                        "persistentVolumeClaim"
-                      ]
-                    }
-                  ],
-                  "op": "AND"
-                },
-                "groupBy": [
+    {
+      "h": 4,
+      "i": "94774ddd-6c72-4988-a7ed-07af51fab210",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 0
+    },
+    {
+      "h": 4,
+      "i": "378ee8aa-898c-4de2-b710-ff747ce1614b",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 4
+    },
+    {
+      "h": 4,
+      "i": "3ddd26f4-886a-4e89-97a0-04e330e8647d",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 4
+    },
+    {
+      "h": 4,
+      "i": "b1a1b62d-bbaa-4c49-a240-20e6f3a5c59d",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 8
+    },
+    {
+      "h": 4,
+      "i": "8a17665f-d533-4591-a2e8-9ea5ada56f78",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 8
+    }
+  ],
+  "panelMap": {},
+  "tags": [],
+  "title": "Kubernetes PVC Metrics",
+  "uploadedGrafana": false,
+  "variables": {
+    "namespace_name": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "",
+      "id": "9a32bb87-d8b4-498f-88cf-65dfd25cd579",
+      "modificationUUID": "54d953a6-c1c4-4518-b44f-d1579dccf343",
+      "multiSelect": false,
+      "name": "namespace_name",
+      "order": 0,
+      "queryValue": "SELECT DISTINCT JSONExtractString(labels, 'k8s_namespace_name') AS k8s_namespace_name\nFROM signoz_metrics.distributed_time_series_v2\nWHERE metric_name = 'k8s_pod_cpu_time' and JSONExtractString(labels, 'k8s_node_name') IN {{.node_name}}",
+      "selectedValue": "signoz",
+      "showALLOption": false,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "node_name": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "",
+      "id": "6a787b99-95f6-4d96-b667-eb74a65446ef",
+      "modificationUUID": "24efc483-9666-4feb-9a47-9d707b17da1f",
+      "multiSelect": true,
+      "name": "node_name",
+      "order": 1,
+      "queryValue": "SELECT DISTINCT JSONExtractString(labels, 'k8s_node_name') AS k8s_node_name\nFROM signoz_metrics.distributed_time_series_v2\nWHERE metric_name = 'k8s_node_cpu_time'",
+      "selectedValue": [
+        "nubos-agent-large-dly",
+        "nubos-agent-large-jeo",
+        "nubos-agent-large-qfd",
+        "nubos-agent-large-tdp",
+        "nubos-control-plane-fsn1-bmg",
+        "nubos-control-plane-hel1-eme",
+        "nubos-control-plane-nbg1-xco"
+      ],
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "widgets": [
+    {
+      "description": "Volume available",
+      "fillSpans": false,
+      "id": "94774ddd-6c72-4988-a7ed-07af51fab210",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "k8s_volume_available--float64----true",
+                "isColumn": true,
+                "key": "k8s_volume_available",
+                "type": ""
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
                   {
-                    "dataType": "string",
-                    "id": "k8s_namespace_name--string--tag--false",
-                    "isColumn": false,
-                    "key": "k8s_namespace_name",
-                    "type": "tag"
+                    "id": "b7fc6f79",
+                    "key": {
+                      "dataType": "string",
+                      "id": "k8s_namespace_name--string--tag--false",
+                      "isColumn": false,
+                      "key": "k8s_namespace_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.namespace_name}}"
+                    ]
                   },
                   {
-                    "dataType": "string",
-                    "id": "k8s_pod_name--string--tag--false",
-                    "isColumn": false,
-                    "key": "k8s_pod_name",
-                    "type": "tag"
+                    "id": "b2462589",
+                    "key": {
+                      "dataType": "string",
+                      "id": "k8s_volume_type--string--tag--false",
+                      "isColumn": false,
+                      "key": "k8s_volume_type",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "persistentVolumeClaim"
+                    ]
                   }
                 ],
-                "having": [],
-                "legend": "{{k8s_namespace_name}}-{{k8s_pod_name}}",
-                "limit": null,
-                "orderBy": [],
-                "queryName": "A",
-                "reduceTo": "sum",
-                "stepInterval": 60
-              }
-            ],
-            "queryFormulas": []
-          },
-          "clickhouse_sql": [
-            {
-              "disabled": false,
-              "legend": "",
-              "name": "A",
-              "query": ""
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "k8s_namespace_name--string--tag--false",
+                  "isColumn": false,
+                  "key": "k8s_namespace_name",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "k8s_pod_name--string--tag--false",
+                  "isColumn": false,
+                  "key": "k8s_pod_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{k8s_namespace_name}}-{{k8s_pod_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
             }
           ],
-          "id": "cedd62ed-a048-4c17-8b49-8ffc0f914226",
-          "promql": [
-            {
-              "disabled": false,
-              "legend": "",
-              "name": "A",
-              "query": ""
-            }
-          ],
-          "queryType": "builder"
+          "queryFormulas": []
         },
-        "timePreferance": "GLOBAL_TIME",
-        "title": "Volume available",
-        "yAxisUnit": "bytes"
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "cedd62ed-a048-4c17-8b49-8ffc0f914226",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
       },
-      {
-        "description": "",
-        "id": "378ee8aa-898c-4de2-b710-ff747ce1614b",
-        "isStacked": false,
-        "nullZeroValues": "zero",
-        "opacity": "1",
-        "panelTypes": "graph",
-        "query": {
-          "builder": {
-            "queryData": [
-              {
-                "aggregateAttribute": {
-                  "dataType": "float64",
-                  "id": "k8s_volume_capacity--float64----true",
-                  "isColumn": true,
-                  "key": "k8s_volume_capacity",
-                  "type": ""
-                },
-                "aggregateOperator": "avg",
-                "dataSource": "metrics",
-                "disabled": false,
-                "expression": "A",
-                "filters": {
-                  "items": [
-                    {
-                      "id": "e983d60e",
-                      "key": {
-                        "dataType": "string",
-                        "id": "k8s_namespace_name--string--tag--false",
-                        "isColumn": false,
-                        "key": "k8s_namespace_name",
-                        "type": "tag"
-                      },
-                      "op": "in",
-                      "value": [
-                        "{{.namespace_name}}"
-                      ]
-                    },
-                    {
-                      "id": "dbe57891",
-                      "key": {
-                        "dataType": "string",
-                        "id": "k8s_volume_type--string--tag--false",
-                        "isColumn": false,
-                        "key": "k8s_volume_type",
-                        "type": "tag"
-                      },
-                      "op": "in",
-                      "value": [
-                        "persistentVolumeClaim"
-                      ]
-                    }
-                  ],
-                  "op": "AND"
-                },
-                "groupBy": [
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Volume available",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "Volume capacity",
+      "fillSpans": false,
+      "id": "378ee8aa-898c-4de2-b710-ff747ce1614b",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "k8s_volume_capacity--float64----true",
+                "isColumn": true,
+                "key": "k8s_volume_capacity",
+                "type": ""
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
                   {
-                    "dataType": "string",
-                    "id": "k8s_namespace_name--string--tag--false",
-                    "isColumn": false,
-                    "key": "k8s_namespace_name",
-                    "type": "tag"
+                    "id": "e983d60e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "k8s_namespace_name--string--tag--false",
+                      "isColumn": false,
+                      "key": "k8s_namespace_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.namespace_name}}"
+                    ]
                   },
                   {
-                    "dataType": "string",
-                    "id": "k8s_pod_name--string--tag--false",
-                    "isColumn": false,
-                    "key": "k8s_pod_name",
-                    "type": "tag"
+                    "id": "dbe57891",
+                    "key": {
+                      "dataType": "string",
+                      "id": "k8s_volume_type--string--tag--false",
+                      "isColumn": false,
+                      "key": "k8s_volume_type",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "persistentVolumeClaim"
+                    ]
                   }
                 ],
-                "having": [],
-                "legend": "{{k8s_namespace_name}}-{{k8s_pod_name}}",
-                "limit": null,
-                "orderBy": [],
-                "queryName": "A",
-                "reduceTo": "sum",
-                "stepInterval": 60
-              }
-            ],
-            "queryFormulas": []
-          },
-          "clickhouse_sql": [
-            {
-              "disabled": false,
-              "legend": "",
-              "name": "A",
-              "query": ""
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "k8s_namespace_name--string--tag--false",
+                  "isColumn": false,
+                  "key": "k8s_namespace_name",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "k8s_pod_name--string--tag--false",
+                  "isColumn": false,
+                  "key": "k8s_pod_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{k8s_namespace_name}}-{{k8s_pod_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
             }
           ],
-          "id": "4c846536-ee6c-4cc2-91ab-1978e0fabfb5",
-          "promql": [
-            {
-              "disabled": false,
-              "legend": "",
-              "name": "A",
-              "query": ""
-            }
-          ],
-          "queryType": "builder"
+          "queryFormulas": []
         },
-        "timePreferance": "GLOBAL_TIME",
-        "title": "Volume capacity",
-        "yAxisUnit": "bytes"
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "4c846536-ee6c-4cc2-91ab-1978e0fabfb5",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
       },
-      {
-        "description": "",
-        "id": "3ddd26f4-886a-4e89-97a0-04e330e8647d",
-        "isStacked": false,
-        "nullZeroValues": "zero",
-        "opacity": "1",
-        "panelTypes": "graph",
-        "query": {
-          "builder": {
-            "queryData": [
-              {
-                "aggregateAttribute": {
-                  "dataType": "float64",
-                  "id": "k8s_volume_inodes--float64----true",
-                  "isColumn": true,
-                  "key": "k8s_volume_inodes",
-                  "type": ""
-                },
-                "aggregateOperator": "avg",
-                "dataSource": "metrics",
-                "disabled": false,
-                "expression": "A",
-                "filters": {
-                  "items": [
-                    {
-                      "id": "5a604bad",
-                      "key": {
-                        "dataType": "string",
-                        "id": "k8s_namespace_name--string--tag--false",
-                        "isColumn": false,
-                        "key": "k8s_namespace_name",
-                        "type": "tag"
-                      },
-                      "op": "in",
-                      "value": [
-                        "{{.namespace_name}}"
-                      ]
-                    },
-                    {
-                      "id": "24b074f3",
-                      "key": {
-                        "dataType": "string",
-                        "id": "k8s_volume_type--string--tag--false",
-                        "isColumn": false,
-                        "key": "k8s_volume_type",
-                        "type": "tag"
-                      },
-                      "op": "in",
-                      "value": [
-                        "persistentVolumeClaim"
-                      ]
-                    }
-                  ],
-                  "op": "AND"
-                },
-                "groupBy": [
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Volume capacity",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "Volume inodes",
+      "fillSpans": false,
+      "id": "3ddd26f4-886a-4e89-97a0-04e330e8647d",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "k8s_volume_inodes--float64----true",
+                "isColumn": true,
+                "key": "k8s_volume_inodes",
+                "type": ""
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
                   {
-                    "dataType": "string",
-                    "id": "k8s_namespace_name--string--tag--false",
-                    "isColumn": false,
-                    "key": "k8s_namespace_name",
-                    "type": "tag"
+                    "id": "d2c9b374",
+                    "key": {
+                      "dataType": "string",
+                      "id": "k8s_namespace_name--string--tag--false",
+                      "isColumn": false,
+                      "key": "k8s_namespace_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.namespace_name}}"
+                    ]
                   },
                   {
-                    "dataType": "string",
-                    "id": "k8s_pod_name--string--tag--false",
-                    "isColumn": false,
-                    "key": "k8s_pod_name",
-                    "type": "tag"
+                    "id": "88732dea",
+                    "key": {
+                      "dataType": "string",
+                      "id": "k8s_volume_type--string--tag--false",
+                      "isColumn": false,
+                      "key": "k8s_volume_type",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "persistentVolumeClaim"
+                    ]
                   }
                 ],
-                "having": [],
-                "legend": "{{k8s_namespace_name}}-{{k8s_pod_name}}",
-                "limit": null,
-                "orderBy": [],
-                "queryName": "A",
-                "reduceTo": "sum",
-                "stepInterval": 60
-              }
-            ],
-            "queryFormulas": []
-          },
-          "clickhouse_sql": [
-            {
-              "disabled": false,
-              "legend": "",
-              "name": "A",
-              "query": ""
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "k8s_namespace_name--string--tag--false",
+                  "isColumn": false,
+                  "key": "k8s_namespace_name",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "k8s_pod_name--string--tag--false",
+                  "isColumn": false,
+                  "key": "k8s_pod_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{k8s_namespace_name}}-{{k8s_pod_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
             }
           ],
-          "id": "fe9f67bd-b820-48f1-8676-e7505fa28834",
-          "promql": [
-            {
-              "disabled": false,
-              "legend": "",
-              "name": "A",
-              "query": ""
-            }
-          ],
-          "queryType": "builder"
+          "queryFormulas": []
         },
-        "timePreferance": "GLOBAL_TIME",
-        "title": "Volume inodes",
-        "yAxisUnit": "short"
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "fe9f67bd-b820-48f1-8676-e7505fa28834",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
       },
-      {
-        "description": "",
-        "id": "8a17665f-d533-4591-a2e8-9ea5ada56f78",
-        "isStacked": false,
-        "nullZeroValues": "zero",
-        "opacity": "1",
-        "panelTypes": "graph",
-        "query": {
-          "builder": {
-            "queryData": [
-              {
-                "aggregateAttribute": {
-                  "dataType": "float64",
-                  "id": "k8s_volume_inodes_free--float64----true",
-                  "isColumn": true,
-                  "key": "k8s_volume_inodes_free",
-                  "type": ""
-                },
-                "aggregateOperator": "avg",
-                "dataSource": "metrics",
-                "disabled": false,
-                "expression": "A",
-                "filters": {
-                  "items": [
-                    {
-                      "id": "8f01b14d",
-                      "key": {
-                        "dataType": "string",
-                        "id": "k8s_namespace_name--string--tag--false",
-                        "isColumn": false,
-                        "key": "k8s_namespace_name",
-                        "type": "tag"
-                      },
-                      "op": "in",
-                      "value": [
-                        "{{.namespace_name}}"
-                      ]
-                    },
-                    {
-                      "id": "a72c99da",
-                      "key": {
-                        "dataType": "string",
-                        "id": "k8s_volume_type--string--tag--false",
-                        "isColumn": false,
-                        "key": "k8s_volume_type",
-                        "type": "tag"
-                      },
-                      "op": "in",
-                      "value": [
-                        "persistentVolumeClaim"
-                      ]
-                    }
-                  ],
-                  "op": "AND"
-                },
-                "groupBy": [
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Volume inodes",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "Volume inodes free",
+      "id": "8a17665f-d533-4591-a2e8-9ea5ada56f78",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "clickhouse_sql": [
+          {
+            "name": "A",
+            "legend": "",
+            "disabled": false,
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "name": "A",
+            "query": "",
+            "legend": "",
+            "disabled": false
+          }
+        ],
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "avg",
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "k8s_volume_inodes_free--float64----true",
+                "isColumn": true,
+                "key": "k8s_volume_inodes_free",
+                "type": ""
+              },
+              "timeAggregation": "rate",
+              "spaceAggregation": "sum",
+              "functions": [],
+              "filters": {
+                "items": [
                   {
-                    "dataType": "string",
-                    "id": "k8s_namespace_name--string--tag--false",
-                    "isColumn": false,
-                    "key": "k8s_namespace_name",
-                    "type": "tag"
+                    "id": "e08b7a80",
+                    "key": {
+                      "dataType": "string",
+                      "id": "k8s_namespace_name--string--tag--false",
+                      "isColumn": false,
+                      "key": "k8s_namespace_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.namespace_name}}"
+                    ]
                   },
                   {
-                    "dataType": "string",
-                    "id": "k8s_pod_name--string--tag--false",
-                    "isColumn": false,
-                    "key": "k8s_pod_name",
-                    "type": "tag"
+                    "id": "71caeb1c",
+                    "key": {
+                      "dataType": "string",
+                      "id": "k8s_volume_type--string--tag--false",
+                      "isColumn": false,
+                      "key": "k8s_volume_type",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "persistentVolumeClaim"
+                    ]
                   }
                 ],
-                "having": [],
-                "legend": "{{k8s_namespace_name}}-{{k8s_pod_name}}",
-                "limit": null,
-                "orderBy": [],
-                "queryName": "A",
-                "reduceTo": "sum",
-                "stepInterval": 60
-              }
-            ],
-            "queryFormulas": []
-          },
-          "clickhouse_sql": [
-            {
+                "op": "AND"
+              },
+              "expression": "A",
               "disabled": false,
-              "legend": "",
-              "name": "A",
-              "query": ""
+              "having": [],
+              "stepInterval": 60,
+              "limit": null,
+              "orderBy": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "k8s_namespace_name",
+                  "type": "tag",
+                  "id": "k8s_namespace_name--string--tag--false"
+                },
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "k8s_pod_name",
+                  "type": "tag",
+                  "id": "k8s_pod_name--string--tag--false"
+                }
+              ],
+              "legend": "{{k8s_namespace_name}}-{{k8s_pod_name}}",
+              "reduceTo": "sum"
             }
           ],
-          "id": "5662eaa7-159f-4007-b35d-08983d5c8602",
-          "promql": [
-            {
-              "disabled": false,
-              "legend": "",
-              "name": "A",
-              "query": ""
-            }
-          ],
-          "queryType": "builder"
+          "queryFormulas": []
         },
-        "timePreferance": "GLOBAL_TIME",
-        "title": "Volume inodes free",
-        "yAxisUnit": "short"
+        "id": "5662eaa7-159f-4007-b35d-08983d5c8602",
+        "queryType": "builder"
       },
-      {
-        "description": "",
-        "id": "b1a1b62d-bbaa-4c49-a240-20e6f3a5c59d",
-        "isStacked": false,
-        "nullZeroValues": "zero",
-        "opacity": "1",
-        "panelTypes": "graph",
-        "query": {
-          "builder": {
-            "queryData": [
-              {
-                "aggregateAttribute": {
-                  "dataType": "float64",
-                  "id": "k8s_volume_inodes_used--float64----true",
-                  "isColumn": true,
-                  "key": "k8s_volume_inodes_used",
-                  "type": ""
-                },
-                "aggregateOperator": "avg",
-                "dataSource": "metrics",
-                "disabled": false,
-                "expression": "A",
-                "filters": {
-                  "items": [
-                    {
-                      "id": "46393c61",
-                      "key": {
-                        "dataType": "string",
-                        "id": "k8s_namespace_name--string--tag--false",
-                        "isColumn": false,
-                        "key": "k8s_namespace_name",
-                        "type": "tag"
-                      },
-                      "op": "in",
-                      "value": [
-                        "{{.namespace_name}}"
-                      ]
-                    },
-                    {
-                      "id": "450ee3cb",
-                      "key": {
-                        "dataType": "string",
-                        "id": "k8s_volume_type--string--tag--false",
-                        "isColumn": false,
-                        "key": "k8s_volume_type",
-                        "type": "tag"
-                      },
-                      "op": "in",
-                      "value": [
-                        "persistentVolumeClaim"
-                      ]
-                    }
-                  ],
-                  "op": "AND"
-                },
-                "groupBy": [
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Volume inodes free",
+      "yAxisUnit": "short",
+      "thresholds": [],
+      "softMin": 0,
+      "softMax": 0,
+      "fillSpans": false,
+      "selectedLogFields": [],
+      "selectedTracesFields": []
+    },
+    {
+      "description": "Volume inodes used",
+      "fillSpans": false,
+      "id": "b1a1b62d-bbaa-4c49-a240-20e6f3a5c59d",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "k8s_volume_inodes_used--float64----true",
+                "isColumn": true,
+                "key": "k8s_volume_inodes_used",
+                "type": ""
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
                   {
-                    "dataType": "string",
-                    "id": "k8s_namespace_name--string--tag--false",
-                    "isColumn": false,
-                    "key": "k8s_namespace_name",
-                    "type": "tag"
+                    "id": "89c92291",
+                    "key": {
+                      "dataType": "string",
+                      "id": "k8s_namespace_name--string--tag--false",
+                      "isColumn": false,
+                      "key": "k8s_namespace_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.namespace_name}}"
+                    ]
                   },
                   {
-                    "dataType": "string",
-                    "id": "k8s_pod_name--string--tag--false",
-                    "isColumn": false,
-                    "key": "k8s_pod_name",
-                    "type": "tag"
+                    "id": "78968273",
+                    "key": {
+                      "dataType": "string",
+                      "id": "k8s_volume_type--string--tag--false",
+                      "isColumn": false,
+                      "key": "k8s_volume_type",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "persistentVolumeClaim"
+                    ]
                   }
                 ],
-                "having": [],
-                "legend": "{{k8s_namespace_name}}-{{k8s_pod_name}}",
-                "limit": null,
-                "orderBy": [],
-                "queryName": "A",
-                "reduceTo": "sum",
-                "stepInterval": 60
-              }
-            ],
-            "queryFormulas": []
-          },
-          "clickhouse_sql": [
-            {
-              "disabled": false,
-              "legend": "",
-              "name": "A",
-              "query": ""
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "k8s_namespace_name--string--tag--false",
+                  "isColumn": false,
+                  "key": "k8s_namespace_name",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "k8s_pod_name--string--tag--false",
+                  "isColumn": false,
+                  "key": "k8s_pod_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{k8s_namespace_name}}-{{k8s_pod_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
             }
           ],
-          "id": "4db01126-3a7f-4b27-8c91-fd822ac453e8",
-          "promql": [
-            {
-              "disabled": false,
-              "legend": "",
-              "name": "A",
-              "query": ""
-            }
-          ],
-          "queryType": "builder"
+          "queryFormulas": []
         },
-        "timePreferance": "GLOBAL_TIME",
-        "title": "Volume inodes used",
-        "yAxisUnit": "short"
-      }
-    ]
-  }
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "4db01126-3a7f-4b27-8c91-fd822ac453e8",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Volume inodes used",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "Volume used",
+      "fillSpans": false,
+      "id": "3b10447f-cd3d-4492-bf7c-9e9acb0a65ac",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "k8s_volume_available--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "k8s_volume_available",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "3f2e70ab",
+                    "key": {
+                      "dataType": "string",
+                      "id": "k8s_volume_type--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "k8s_volume_type",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "persistentVolumeClaim"
+                    ]
+                  },
+                  {
+                    "id": "493bebbe",
+                    "key": {
+                      "dataType": "string",
+                      "id": "k8s_namespace_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "k8s_namespace_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.namespace_name}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "k8s_namespace_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "k8s_namespace_name",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "k8s_pod_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "k8s_pod_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{k8s_namespace_name}}-{{k8s_pod_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "k8s_volume_capacity--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "k8s_volume_capacity",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "aebe6838",
+                    "key": {
+                      "dataType": "string",
+                      "id": "k8s_volume_type--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "k8s_volume_type",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "persistentVolumeClaim"
+                    ]
+                  },
+                  {
+                    "id": "8d520b32",
+                    "key": {
+                      "dataType": "string",
+                      "id": "k8s_namespace_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "k8s_namespace_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.namespace_name}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "k8s_namespace_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "k8s_namespace_name",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "k8s_pod_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "k8s_pod_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{k8s_namespace_name}}-{{k8s_pod_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "B-A",
+              "legend": "{{k8s_namespace_name}}-{{k8s_pod_name}}",
+              "queryName": "F1"
+            }
+          ]
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "bd0fc509-a476-4321-9a74-9207ad233aa2",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Volume used",
+      "yAxisUnit": "bytes"
+    }
+  ],
+  "uuid": "5810be0e-0367-427f-a0ca-76f75e2a06b2"
+}


### PR DESCRIPTION
Adds "Volume used" panel that gets the volume available metrics and substracts it from the volume capacity.

Also reorganized the panels and added descriptions for all of them (same as panel name).