### PR TITLE
Fix container CPU utilization metric name

### DIFF
--- a/container-metrics/docker/container-metrics-by-host.json
+++ b/container-metrics/docker/container-metrics-by-host.json
@@ -104,10 +104,10 @@
                         {
                             "aggregateAttribute": {
                                 "dataType": "float64",
-                                "id": "container_cpu_percent--float64--Gauge--true",
+                                "id": "container_cpu_utilization--float64--Gauge--true",
                                 "isColumn": true,
                                 "isJSON": false,
-                                "key": "container_cpu_percent",
+                                "key": "container_cpu_utilization",
                                 "type": "Gauge"
                             },
                             "aggregateOperator": "avg",


### PR DESCRIPTION
The previous name didn't work with `signoz/signoz-otel-collector:0.102.12` as the version of the OpenTelemetry collector. The updated name seems to be the correct one, according to this page: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/dockerstatsreceiver/documentation.md#containercpuutilization (also tested locally and confirmed working).