### PR TITLE
Add Envoy OTLP dashboard and docs

### DIFF
--- a/envoy/envoy-otlp-v1.json
+++ b/envoy/envoy-otlp-v1.json
@@ -1,0 +1,3227 @@
+{
+    "description":  "",
+    "image":  "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE0Ljk0OTQgMTMuOTQyQzE2LjIzMTggMTIuNDI1OCAxNy4zMjY4IDkuNzAyMiAxNi4xOTU2IDYuNTc0ODdDMTUuNjQ0MyA1LjA1MjQ1IDE1LjAyMTkgNC4yMDI0OSAxNC4yOTY5IDMuNjYyNTJDMTMuODU1NyAzLjMzMzc5IDEyLjA5MzMgMi41MDYzMyA5Ljc1OTY1IDIuODY3NTZDOC4wNTM0OSAzLjEzMjU1IDUuNzc0ODcgNC4yMDg3NCA0LjI5MzY5IDUuOTU5OUMyLjg1NzUyIDcuNjYxMDYgMS43NDg4MyA5LjAwNDc0IDEuNjk3NTggMTAuMzA5N0MxLjYzMTMzIDExLjk4ODMgMi44OTYyNyAxMy40MzA4IDMuMDUwMDEgMTMuNjY0NUMzLjMyMzc0IDE0LjA3OTUgNS4xOTExNSAxNi40NTE4IDguNjk5NzEgMTYuNTczMUMxMS43OTcgMTYuNjc5MyAxMy44MTQ0IDE1LjI4NDQgMTQuOTQ5NCAxMy45NDJaIiBmaWxsPSIjNDAzRDNFIi8+CjxwYXRoIGQ9Ik00LjU1MzYzIDIuNzM3NDdDMi45Mzc0NiAzLjg5MTE2IDEuMTIxMzEgNi4yNTEwMyAxLjQ0NzU0IDkuNTYwODZDMS42MDYyOCAxMS4xNzIgMi4wMDI1MSAxMi4xNDk1IDIuNTcxMjMgMTIuODUwN0MyLjkxNzQ2IDEzLjI3ODIgNC40MTk4OCAxNC41NDkzIDYuNzczNTEgMTQuNzM2OEM5LjE0NTg4IDE0LjkyNTYgMTAuOTQ5NSAxNC4zOTQ0IDEyLjgzMzIgMTMuMDg0NEMxNi42NjE3IDEwLjQyMDggMTYuMDk4IDYuMzkzNTMgMTUuOTM0MyA1LjkyNDhDMTUuNzcwNSA1LjQ1NjA3IDE0LjU0NDQgMi42OTYyMiAxMS4xNzMzIDEuNzE1MDJDOC4xOTg0NCAwLjg1MDA2OCA1Ljk4MzU1IDEuNzE1MDIgNC41NTM2MyAyLjczNzQ3WiIgZmlsbD0iIzVFNjM2NyIvPgo8cGF0aCBkPSJNNy4zOTM1MyAyLjk2MTA5QzUuNjE3MzcgMi44OTczNCAzLjkxOTk2IDQuMjg4NTIgMy43NTYyMiA2LjAwNTkzQzMuNTkyNDggNy43MjIwOSA0LjY1NDkyIDkuMDI5NTIgNi4zMDk4MyA5LjI5NTc2QzcuOTY0NzUgOS41NjA3NCA5Ljg3ODM5IDguNTU1OCAxMC4yNjM0IDYuNDUwOTFDMTAuNjYwOSA0LjI4MjI3IDkuMDg5NjkgMy4wMjIzNCA3LjM5MzUzIDIuOTYxMDlaIiBmaWxsPSJ3aGl0ZSIvPgo8cGF0aCBkPSJNNy45NDIxNyA1LjkwMTE1QzcuOTQyMTcgNS45MDExNSA4LjM2OTY1IDUuODEyNCA4LjQ1NDY1IDUuMTgyNDRDOC41MzgzOSA0LjU2MjQ3IDguMjMwOTEgNC4wMzM3NSA3LjUxMzQ1IDMuODQzNzZDNi43MzM0OSAzLjYzNzUyIDYuMjA0NzcgNC4wNjYyNSA2LjA2NzI3IDQuNTE3NDdDNS44NzYwMyA1LjE0NDk0IDYuMTU4NTIgNS40NDM2NyA2LjE1ODUyIDUuNDQzNjdDNi4xNTg1MiA1LjQ0MzY3IDUuMzkzNTYgNS42Mjc0MSA1LjMzMjMxIDYuNTI5ODdDNS4yNzQ4MSA3LjM4MTA3IDUuODU2MDMgNy44Mzg1NSA2LjQzOTc1IDcuOTc4NTRDNy4xNjA5NiA4LjE1MjI4IDcuOTc4NDIgNy45NTQ3OSA4LjE3ODQxIDcuMDM0ODRDOC4zNDQ2NSA2LjI3NzM4IDcuOTQyMTcgNS45MDExNSA3Ljk0MjE3IDUuOTAxMTVaIiBmaWxsPSIjMzAzMDMwIi8+CjxwYXRoIGQ9Ik02LjczOTgzIDQuNzUzNjJDNi42NzEwOSA1LjAxMjM1IDYuODA4NTggNS4yNjIzNCA3LjA3ODU3IDUuMzMxMDlDNy4zNjk4IDUuNDA0ODMgNy42MzQ3OSA1LjMwODU5IDcuNzA2MDMgNS4wMTExQzcuNzY4NTMgNC43NDczNyA3LjY0MzU0IDQuNTE0ODggNy4zMzYwNSA0LjQzOTg4QzcuMDgzNTcgNC4zNzczOSA2LjgxNDgzIDQuNDcxMTMgNi43Mzk4MyA0Ljc1MzYyWiIgZmlsbD0id2hpdGUiLz4KPHBhdGggZD0iTTYuOTU5NzggNi4wMzk3NEM2LjYzMjMgNS45Mzg0OSA2LjE5OTgyIDYuMDY0NzMgNi4xMzEwNyA2LjUwNDcxQzYuMDYyMzMgNi45NDQ2OSA2LjMyNjA2IDcuMTY5NjggNi42NzEwNCA3LjIzMjE3QzcuMDE2MDMgNy4yOTQ2NyA3LjM0MjI2IDcuMTEzNDMgNy40MDYwMSA2Ljc2MDk1QzcuNDY4NSA2LjQwOTcyIDcuMjg2MDEgNi4xMzk3MyA2Ljk1OTc4IDYuMDM5NzRaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K",
+    "layout":  [
+                   {
+                       "h":  1,
+                       "i":  "4e1207c8-0747-4e59-8079-2a1981963797",
+                       "maxH":  1,
+                       "minH":  1,
+                       "minW":  12,
+                       "moved":  false,
+                       "static":  false,
+                       "w":  12,
+                       "x":  0,
+                       "y":  0
+                   },
+                   {
+                       "h":  6,
+                       "i":  "90a010f9-862f-469a-a0fa-1d9c17ac163e",
+                       "moved":  false,
+                       "static":  false,
+                       "w":  6,
+                       "x":  0,
+                       "y":  1
+                   },
+                   {
+                       "h":  6,
+                       "i":  "6d29c494-0d60-472b-80bb-c1a3ea37391b",
+                       "moved":  false,
+                       "static":  false,
+                       "w":  6,
+                       "x":  6,
+                       "y":  1
+                   },
+                   {
+                       "h":  7,
+                       "i":  "e8545106-f988-4c6d-84ca-f91d1faf93f0",
+                       "moved":  false,
+                       "static":  false,
+                       "w":  6,
+                       "x":  0,
+                       "y":  7
+                   },
+                   {
+                       "h":  1,
+                       "i":  "17906702-5329-462d-82a2-d259cbd7e8d0",
+                       "maxH":  1,
+                       "minH":  1,
+                       "minW":  12,
+                       "moved":  false,
+                       "static":  false,
+                       "w":  12,
+                       "x":  0,
+                       "y":  14
+                   },
+                   {
+                       "h":  6,
+                       "i":  "914a1a60-cca6-46eb-b349-8183f7cb7c57",
+                       "moved":  false,
+                       "static":  false,
+                       "w":  6,
+                       "x":  0,
+                       "y":  15
+                   },
+                   {
+                       "h":  6,
+                       "i":  "26fcba5b-25f5-42c8-b41b-6a4a3d8e9e37",
+                       "moved":  false,
+                       "static":  false,
+                       "w":  6,
+                       "x":  6,
+                       "y":  15
+                   },
+                   {
+                       "h":  6,
+                       "i":  "203721b2-697c-457d-87d5-cee8116a1571",
+                       "moved":  false,
+                       "static":  false,
+                       "w":  6,
+                       "x":  0,
+                       "y":  21
+                   },
+                   {
+                       "h":  1,
+                       "i":  "9491b435-4d70-4cea-94f6-4a7f2284356e",
+                       "maxH":  1,
+                       "minH":  1,
+                       "minW":  12,
+                       "moved":  false,
+                       "static":  false,
+                       "w":  12,
+                       "x":  0,
+                       "y":  27
+                   },
+                   {
+                       "h":  6,
+                       "i":  "14088819-33b1-4dca-a38b-39fcf0aa190b",
+                       "moved":  false,
+                       "static":  false,
+                       "w":  6,
+                       "x":  0,
+                       "y":  28
+                   },
+                   {
+                       "h":  6,
+                       "i":  "81c64192-ff05-4f51-819b-3ecb11dcf0bb",
+                       "moved":  false,
+                       "static":  false,
+                       "w":  6,
+                       "x":  6,
+                       "y":  28
+                   },
+                   {
+                       "h":  6,
+                       "i":  "5ba52f28-7ef0-4dc0-8905-6fc97b6ced1f",
+                       "moved":  false,
+                       "static":  false,
+                       "w":  6,
+                       "x":  0,
+                       "y":  34
+                   },
+                   {
+                       "h":  1,
+                       "i":  "6a05745f-f734-4d13-af3e-ca2bb8da0a32",
+                       "maxH":  1,
+                       "minH":  1,
+                       "minW":  12,
+                       "moved":  false,
+                       "static":  false,
+                       "w":  12,
+                       "x":  0,
+                       "y":  40
+                   },
+                   {
+                       "h":  6,
+                       "i":  "c8393303-fddf-4b9f-849f-18f7738841ce",
+                       "moved":  false,
+                       "static":  false,
+                       "w":  6,
+                       "x":  0,
+                       "y":  41
+                   },
+                   {
+                       "h":  6,
+                       "i":  "2267a26c-a943-4b2d-b495-69b8c3ee080e",
+                       "moved":  false,
+                       "static":  false,
+                       "w":  6,
+                       "x":  6,
+                       "y":  41
+                   },
+                   {
+                       "h":  6,
+                       "i":  "9afc65b5-b399-470f-b663-56e96d8c7af5",
+                       "moved":  false,
+                       "static":  false,
+                       "w":  6,
+                       "x":  0,
+                       "y":  47
+                   },
+                   {
+                       "h":  1,
+                       "i":  "a20c3a78-e363-4f11-a4a7-98ef530c1d08",
+                       "maxH":  1,
+                       "minH":  1,
+                       "minW":  12,
+                       "moved":  false,
+                       "static":  false,
+                       "w":  12,
+                       "x":  0,
+                       "y":  53
+                   },
+                   {
+                       "h":  6,
+                       "i":  "0e7a6c2b-2798-4cd9-8601-434863251c7d",
+                       "moved":  false,
+                       "static":  false,
+                       "w":  6,
+                       "x":  0,
+                       "y":  54
+                   },
+                   {
+                       "h":  6,
+                       "i":  "65c04550-ef09-42f7-bf60-2b62b8282848",
+                       "moved":  false,
+                       "static":  false,
+                       "w":  6,
+                       "x":  6,
+                       "y":  54
+                   },
+                   {
+                       "h":  6,
+                       "i":  "1ecf4f6b-ab70-4ac0-b133-702a5438717b",
+                       "moved":  false,
+                       "static":  false,
+                       "w":  6,
+                       "x":  0,
+                       "y":  60
+                   },
+                   {
+                       "h":  1,
+                       "i":  "9e8ba025-1e4f-4f7c-80db-03bde71624c7",
+                       "maxH":  1,
+                       "minH":  1,
+                       "minW":  12,
+                       "moved":  false,
+                       "static":  false,
+                       "w":  12,
+                       "x":  0,
+                       "y":  66
+                   },
+                   {
+                       "h":  6,
+                       "i":  "046d43cb-7747-4b94-af18-7c5829a351bd",
+                       "moved":  false,
+                       "static":  false,
+                       "w":  6,
+                       "x":  0,
+                       "y":  67
+                   },
+                   {
+                       "h":  6,
+                       "i":  "c54194a3-f8f9-4d2b-91b6-78183b5d5b32",
+                       "moved":  false,
+                       "static":  false,
+                       "w":  6,
+                       "x":  6,
+                       "y":  67
+                   },
+                   {
+                       "h":  6,
+                       "i":  "b1581fd0-4c3d-44b6-9581-02ba8d9d3ac6",
+                       "moved":  false,
+                       "static":  false,
+                       "w":  6,
+                       "x":  0,
+                       "y":  73
+                   },
+                   {
+                       "h":  1,
+                       "i":  "592c3994-7020-4829-9e75-30684e5071ed",
+                       "maxH":  1,
+                       "minH":  1,
+                       "minW":  12,
+                       "moved":  false,
+                       "static":  false,
+                       "w":  12,
+                       "x":  0,
+                       "y":  79
+                   },
+                   {
+                       "h":  6,
+                       "i":  "df785540-dddf-41c6-adc6-1bdc2cbc6f73",
+                       "moved":  false,
+                       "static":  false,
+                       "w":  6,
+                       "x":  0,
+                       "y":  80
+                   },
+                   {
+                       "h":  6,
+                       "i":  "8586305c-923f-42c5-bdee-833276abbb86",
+                       "moved":  false,
+                       "static":  false,
+                       "w":  6,
+                       "x":  6,
+                       "y":  80
+                   },
+                   {
+                       "h":  6,
+                       "i":  "a852060a-158a-4b3d-8d95-1b6983e120a7",
+                       "moved":  false,
+                       "static":  false,
+                       "w":  6,
+                       "x":  0,
+                       "y":  86
+                   },
+                   {
+                       "h":  1,
+                       "i":  "4cb8f819-1ab7-48e4-8295-1ba72fca42e9",
+                       "maxH":  1,
+                       "minH":  1,
+                       "minW":  12,
+                       "moved":  false,
+                       "static":  false,
+                       "w":  12,
+                       "x":  0,
+                       "y":  92
+                   },
+                   {
+                       "h":  6,
+                       "i":  "bb1e6a4e-da5c-4047-a8e8-8658c01c1dd5",
+                       "moved":  false,
+                       "static":  false,
+                       "w":  6,
+                       "x":  0,
+                       "y":  93
+                   },
+                   {
+                       "h":  6,
+                       "i":  "2928b11b-846e-4fe5-b58f-2bc05014b0c2",
+                       "moved":  false,
+                       "static":  false,
+                       "w":  6,
+                       "x":  6,
+                       "y":  93
+                   },
+                   {
+                       "h":  6,
+                       "i":  "8ed1e6e0-78ee-4ac1-a76a-4fb3642e4cc9",
+                       "moved":  false,
+                       "static":  false,
+                       "w":  6,
+                       "x":  0,
+                       "y":  99
+                   },
+                   {
+                       "h":  6,
+                       "i":  "838a79bb-d4a0-4629-9d9f-724333aca762",
+                       "moved":  false,
+                       "static":  false,
+                       "w":  6,
+                       "x":  6,
+                       "y":  99
+                   }
+               ],
+    "panelMap":  {
+                     "17906702-5329-462d-82a2-d259cbd7e8d0":  {
+                                                                  "collapsed":  false,
+                                                                  "widgets":  [
+
+                                                                              ]
+                                                              },
+                     "4cb8f819-1ab7-48e4-8295-1ba72fca42e9":  {
+                                                                  "collapsed":  false,
+                                                                  "widgets":  [
+                                                                                  {
+                                                                                      "h":  6,
+                                                                                      "i":  "bb1e6a4e-da5c-4047-a8e8-8658c01c1dd5",
+                                                                                      "moved":  false,
+                                                                                      "static":  false,
+                                                                                      "w":  6,
+                                                                                      "x":  0,
+                                                                                      "y":  14
+                                                                                  }
+                                                                              ]
+                                                              },
+                     "4e1207c8-0747-4e59-8079-2a1981963797":  {
+                                                                  "collapsed":  false,
+                                                                  "widgets":  [
+
+                                                                              ]
+                                                              },
+                     "592c3994-7020-4829-9e75-30684e5071ed":  {
+                                                                  "collapsed":  false,
+                                                                  "widgets":  [
+
+                                                                              ]
+                                                              },
+                     "6a05745f-f734-4d13-af3e-ca2bb8da0a32":  {
+                                                                  "collapsed":  false,
+                                                                  "widgets":  [
+
+                                                                              ]
+                                                              },
+                     "9491b435-4d70-4cea-94f6-4a7f2284356e":  {
+                                                                  "collapsed":  false,
+                                                                  "widgets":  [
+
+                                                                              ]
+                                                              },
+                     "9e8ba025-1e4f-4f7c-80db-03bde71624c7":  {
+                                                                  "collapsed":  false,
+                                                                  "widgets":  [
+
+                                                                              ]
+                                                              },
+                     "a20c3a78-e363-4f11-a4a7-98ef530c1d08":  {
+                                                                  "collapsed":  false,
+                                                                  "widgets":  [
+
+                                                                              ]
+                                                              }
+                 },
+    "tags":  [
+
+             ],
+    "title":  "Envoy Monitoring Dashboard",
+    "uploadedGrafana":  false,
+    "variables":  {
+                      "45483004-7d7a-4ab9-8bdb-e4d52eb8f4b5":  {
+                                                                   "customValue":  "",
+                                                                   "description":  "Select specific services within the envoy to filter metrics.",
+                                                                   "id":  "45483004-7d7a-4ab9-8bdb-e4d52eb8f4b5",
+                                                                   "key":  "45483004-7d7a-4ab9-8bdb-e4d52eb8f4b5",
+                                                                   "modificationUUID":  "f347916e-f964-42ac-ad3e-f6534a3d14c9",
+                                                                   "multiSelect":  false,
+                                                                   "name":  "service.name",
+                                                                   "order":  0,
+                                                                   "queryValue":  "",
+                                                                   "showALLOption":  false,
+                                                                   "sort":  "DISABLED",
+                                                                   "textboxValue":  ".*",
+                                                                   "type":  "TEXTBOX"
+                                                               },
+                      "4b737a9f-79fb-4ccd-95a5-4c5e8c9bf9eb":  {
+                                                                   "allSelected":  false,
+                                                                   "customValue":  "",
+                                                                   "description":  " For multi-cluster setups, filter metrics based on the Kubernetes cluster.",
+                                                                   "id":  "4b737a9f-79fb-4ccd-95a5-4c5e8c9bf9eb",
+                                                                   "modificationUUID":  "152833f4-6150-48e2-ae1e-8174ec52ca4b",
+                                                                   "multiSelect":  false,
+                                                                   "name":  "cluster",
+                                                                   "order":  0,
+                                                                   "queryValue":  "",
+                                                                   "showALLOption":  false,
+                                                                   "sort":  "DISABLED",
+                                                                   "textboxValue":  ".*",
+                                                                   "type":  "TEXTBOX"
+                                                               },
+                      "de190e8a-5c71-43bc-bd4d-ea62755a6539":  {
+                                                                   "customValue":  "",
+                                                                   "description":  "Environment of application (configured at Otel agent level) eg: prod, staging",
+                                                                   "id":  "de190e8a-5c71-43bc-bd4d-ea62755a6539",
+                                                                   "key":  "de190e8a-5c71-43bc-bd4d-ea62755a6539",
+                                                                   "modificationUUID":  "895419e9-51b2-4b3e-bcdf-8790e8f0bf00",
+                                                                   "multiSelect":  false,
+                                                                   "name":  "deployment.environment",
+                                                                   "order":  0,
+                                                                   "queryValue":  "",
+                                                                   "showALLOption":  false,
+                                                                   "sort":  "DISABLED",
+                                                                   "textboxValue":  ".*",
+                                                                   "type":  "TEXTBOX"
+                                                               },
+                      "ef23896b-90e7-4607-9379-4643624ffd81":  {
+                                                                   "customValue":  "",
+                                                                   "description":  "Filter metrics based on the Kubernetes namespace where Envoy is deployed.",
+                                                                   "id":  "ef23896b-90e7-4607-9379-4643624ffd81",
+                                                                   "key":  "ef23896b-90e7-4607-9379-4643624ffd81",
+                                                                   "modificationUUID":  "8d4f4dae-3c17-4448-ab42-5c8d601fea48",
+                                                                   "multiSelect":  false,
+                                                                   "name":  "namespace",
+                                                                   "order":  0,
+                                                                   "queryValue":  "",
+                                                                   "showALLOption":  false,
+                                                                   "sort":  "DISABLED",
+                                                                   "textboxValue":  ".*",
+                                                                   "type":  "TEXTBOX"
+                                                               }
+                  },
+    "version":  "v4",
+    "widgets":  [
+                    {
+                        "description":  "",
+                        "id":  "4cb8f819-1ab7-48e4-8295-1ba72fca42e9",
+                        "panelTypes":  "row",
+                        "title":  "General Overview"
+                    },
+                    {
+                        "description":  "",
+                        "id":  "592c3994-7020-4829-9e75-30684e5071ed",
+                        "panelTypes":  "row",
+                        "title":  "Request Metrics"
+                    },
+                    {
+                        "description":  "",
+                        "id":  "9e8ba025-1e4f-4f7c-80db-03bde71624c7",
+                        "panelTypes":  "row",
+                        "title":  "Response Metrics"
+                    },
+                    {
+                        "description":  "",
+                        "id":  "a20c3a78-e363-4f11-a4a7-98ef530c1d08",
+                        "panelTypes":  "row",
+                        "title":  "Latency Metrics"
+                    },
+                    {
+                        "description":  "",
+                        "id":  "6a05745f-f734-4d13-af3e-ca2bb8da0a32",
+                        "panelTypes":  "row",
+                        "title":  "Error Metrics"
+                    },
+                    {
+                        "description":  "",
+                        "id":  "9491b435-4d70-4cea-94f6-4a7f2284356e",
+                        "panelTypes":  "row",
+                        "title":  "Resource Usage"
+                    },
+                    {
+                        "description":  "",
+                        "id":  "17906702-5329-462d-82a2-d259cbd7e8d0",
+                        "panelTypes":  "row",
+                        "title":  "Network I/O"
+                    },
+                    {
+                        "description":  "",
+                        "id":  "4e1207c8-0747-4e59-8079-2a1981963797",
+                        "panelTypes":  "row",
+                        "title":  "Upstream and Downstream Metrics"
+                    },
+                    {
+                        "bucketCount":  30,
+                        "bucketWidth":  0,
+                        "columnUnits":  {
+
+                                        },
+                        "description":  "Displays the number of active connections currently managed by Envoy.",
+                        "fillSpans":  false,
+                        "id":  "bb1e6a4e-da5c-4047-a8e8-8658c01c1dd5",
+                        "isStacked":  false,
+                        "mergeAllActiveQueries":  false,
+                        "nullZeroValues":  "zero",
+                        "opacity":  "1",
+                        "panelTypes":  "value",
+                        "query":  {
+                                      "builder":  {
+                                                      "queryData":  [
+
+                                                                    ],
+                                                      "queryFormulas":  [
+
+                                                                        ]
+                                                  },
+                                      "clickhouse_sql":  [
+                                                             {
+                                                                 "disabled":  false,
+                                                                 "legend":  "",
+                                                                 "name":  "A",
+                                                                 "query":  ""
+                                                             }
+                                                         ],
+                                      "id":  "3dbd9abf-2586-4e43-b54b-5fb4130fea0e",
+                                      "promql":  [
+                                                     {
+                                                         "disabled":  false,
+                                                         "legend":  "",
+                                                         "name":  "A",
+                                                         "query":  "sum(envoy_http_downstream_cx_active{service_name=~\"$service.name\", namespace=~\"$namespace\", deployment_environment=~\"$deployment.environment\", cluster=~\"$cluster\"})"
+                                                     }
+                                                 ],
+                                      "queryType":  "promql"
+                                  },
+                        "selectedLogFields":  [
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "body",
+                                                      "type":  ""
+                                                  },
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "timestamp",
+                                                      "type":  ""
+                                                  }
+                                              ],
+                        "selectedTracesFields":  [
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "serviceName--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "serviceName",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "name--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "name",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "float64",
+                                                         "id":  "durationNano--float64--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "durationNano",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "httpMethod--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "httpMethod",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "responseStatusCode--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "responseStatusCode",
+                                                         "type":  "tag"
+                                                     }
+                                                 ],
+                        "softMax":  0,
+                        "softMin":  0,
+                        "stackedBarChart":  false,
+                        "thresholds":  [
+
+                                       ],
+                        "timePreferance":  "GLOBAL_TIME",
+                        "title":  "Active Connections",
+                        "yAxisUnit":  "none"
+                    },
+                    {
+                        "bucketCount":  30,
+                        "bucketWidth":  0,
+                        "columnUnits":  {
+
+                                        },
+                        "description":  "Shows the total number of requests handled by Envoy since the last restart.",
+                        "fillSpans":  false,
+                        "id":  "2928b11b-846e-4fe5-b58f-2bc05014b0c2",
+                        "isStacked":  false,
+                        "mergeAllActiveQueries":  false,
+                        "nullZeroValues":  "zero",
+                        "opacity":  "1",
+                        "panelTypes":  "value",
+                        "query":  {
+                                      "builder":  {
+                                                      "queryData":  [
+
+                                                                    ],
+                                                      "queryFormulas":  [
+
+                                                                        ]
+                                                  },
+                                      "clickhouse_sql":  [
+                                                             {
+                                                                 "disabled":  false,
+                                                                 "legend":  "",
+                                                                 "name":  "A",
+                                                                 "query":  ""
+                                                             }
+                                                         ],
+                                      "id":  "55a819cf-bee3-47da-8e1b-2a3906885c02",
+                                      "promql":  [
+                                                     {
+                                                         "disabled":  false,
+                                                         "legend":  "",
+                                                         "name":  "A",
+                                                         "query":  "sum(envoy_http_downstream_rq_total{service_name=~\"$service.name\", namespace=~\"$namespace\", deployment_environment=~\"$deployment.environment\", cluster=~\"$cluster\"})"
+                                                     }
+                                                 ],
+                                      "queryType":  "promql"
+                                  },
+                        "selectedLogFields":  [
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "body",
+                                                      "type":  ""
+                                                  },
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "timestamp",
+                                                      "type":  ""
+                                                  }
+                                              ],
+                        "selectedTracesFields":  [
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "serviceName--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "serviceName",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "name--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "name",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "float64",
+                                                         "id":  "durationNano--float64--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "durationNano",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "httpMethod--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "httpMethod",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "responseStatusCode--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "responseStatusCode",
+                                                         "type":  "tag"
+                                                     }
+                                                 ],
+                        "softMax":  0,
+                        "softMin":  0,
+                        "stackedBarChart":  false,
+                        "thresholds":  [
+
+                                       ],
+                        "timePreferance":  "GLOBAL_TIME",
+                        "title":  "Total Requests",
+                        "yAxisUnit":  "none"
+                    },
+                    {
+                        "bucketCount":  30,
+                        "bucketWidth":  0,
+                        "columnUnits":  {
+
+                                        },
+                        "description":  "Illustrates the rate of incoming requests per second.",
+                        "fillSpans":  false,
+                        "id":  "8ed1e6e0-78ee-4ac1-a76a-4fb3642e4cc9",
+                        "isStacked":  false,
+                        "mergeAllActiveQueries":  false,
+                        "nullZeroValues":  "zero",
+                        "opacity":  "1",
+                        "panelTypes":  "graph",
+                        "query":  {
+                                      "builder":  {
+                                                      "queryData":  [
+
+                                                                    ],
+                                                      "queryFormulas":  [
+
+                                                                        ]
+                                                  },
+                                      "clickhouse_sql":  [
+                                                             {
+                                                                 "disabled":  false,
+                                                                 "legend":  "",
+                                                                 "name":  "A",
+                                                                 "query":  ""
+                                                             }
+                                                         ],
+                                      "id":  "379bcf0b-9b6c-42d8-a4a5-aed9bccc34f8",
+                                      "promql":  [
+                                                     {
+                                                         "disabled":  false,
+                                                         "legend":  "{{envoy_http_conn_manager_prefix}}",
+                                                         "name":  "A",
+                                                         "query":  "sum(rate(envoy_http_downstream_rq_total{service_name=~\"$service.name\", namespace=~\"$namespace\", deployment_environment=~\"$deployment.environment\", cluster=~\"$cluster\"}[5m])) by (envoy_http_conn_manager_prefix)"
+                                                     }
+                                                 ],
+                                      "queryType":  "promql"
+                                  },
+                        "selectedLogFields":  [
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "body",
+                                                      "type":  ""
+                                                  },
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "timestamp",
+                                                      "type":  ""
+                                                  }
+                                              ],
+                        "selectedTracesFields":  [
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "serviceName--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "serviceName",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "name--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "name",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "float64",
+                                                         "id":  "durationNano--float64--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "durationNano",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "httpMethod--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "httpMethod",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "responseStatusCode--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "responseStatusCode",
+                                                         "type":  "tag"
+                                                     }
+                                                 ],
+                        "softMax":  0,
+                        "softMin":  0,
+                        "stackedBarChart":  false,
+                        "thresholds":  [
+
+                                       ],
+                        "timePreferance":  "GLOBAL_TIME",
+                        "title":  "Request rate",
+                        "yAxisUnit":  "none"
+                    },
+                    {
+                        "bucketCount":  30,
+                        "bucketWidth":  0,
+                        "columnUnits":  {
+
+                                        },
+                        "description":  "Displays the total uptime of the Envoy instance since the last restart.",
+                        "fillSpans":  false,
+                        "id":  "838a79bb-d4a0-4629-9d9f-724333aca762",
+                        "isStacked":  false,
+                        "mergeAllActiveQueries":  false,
+                        "nullZeroValues":  "zero",
+                        "opacity":  "1",
+                        "panelTypes":  "graph",
+                        "query":  {
+                                      "builder":  {
+                                                      "queryData":  [
+
+                                                                    ],
+                                                      "queryFormulas":  [
+
+                                                                        ]
+                                                  },
+                                      "clickhouse_sql":  [
+                                                             {
+                                                                 "disabled":  false,
+                                                                 "legend":  "",
+                                                                 "name":  "A",
+                                                                 "query":  ""
+                                                             }
+                                                         ],
+                                      "id":  "cd831dc8-6b87-4770-b7b1-c8161c58cf8c",
+                                      "promql":  [
+                                                     {
+                                                         "disabled":  false,
+                                                         "legend":  "",
+                                                         "name":  "A",
+                                                         "query":  "max(envoy_server_uptime{service_name=~\"$service.name\", namespace=~\"$namespace\", deployment_environment=~\"$deployment.environment\", cluster=~\"$cluster\"})"
+                                                     }
+                                                 ],
+                                      "queryType":  "promql"
+                                  },
+                        "selectedLogFields":  [
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "body",
+                                                      "type":  ""
+                                                  },
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "timestamp",
+                                                      "type":  ""
+                                                  }
+                                              ],
+                        "selectedTracesFields":  [
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "serviceName--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "serviceName",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "name--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "name",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "float64",
+                                                         "id":  "durationNano--float64--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "durationNano",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "httpMethod--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "httpMethod",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "responseStatusCode--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "responseStatusCode",
+                                                         "type":  "tag"
+                                                     }
+                                                 ],
+                        "softMax":  0,
+                        "softMin":  0,
+                        "stackedBarChart":  false,
+                        "thresholds":  [
+
+                                       ],
+                        "timePreferance":  "GLOBAL_TIME",
+                        "title":  "Uptime",
+                        "yAxisUnit":  "dthms"
+                    },
+                    {
+                        "bucketCount":  30,
+                        "bucketWidth":  0,
+                        "columnUnits":  {
+
+                                        },
+                        "description":  "Total number of HTTP requests processed, categorized by method.",
+                        "fillSpans":  false,
+                        "id":  "df785540-dddf-41c6-adc6-1bdc2cbc6f73",
+                        "isStacked":  false,
+                        "mergeAllActiveQueries":  false,
+                        "nullZeroValues":  "zero",
+                        "opacity":  "1",
+                        "panelTypes":  "graph",
+                        "query":  {
+                                      "builder":  {
+                                                      "queryData":  [
+
+                                                                    ],
+                                                      "queryFormulas":  [
+
+                                                                        ]
+                                                  },
+                                      "clickhouse_sql":  [
+                                                             {
+                                                                 "disabled":  false,
+                                                                 "legend":  "",
+                                                                 "name":  "A",
+                                                                 "query":  ""
+                                                             }
+                                                         ],
+                                      "id":  "65070e8f-2d1e-40f4-b09d-917c8a49c156",
+                                      "promql":  [
+                                                     {
+                                                         "disabled":  false,
+                                                         "legend":  "",
+                                                         "name":  "A",
+                                                         "query":  "sum(rate(envoy_http_downstream_rq_total{service_name=~\"$service.name\", namespace=~\"$namespace\", deployment_environment=~\"$deployment.environment\", cluster=~\"$cluster\"}[5m]))"
+                                                     }
+                                                 ],
+                                      "queryType":  "promql"
+                                  },
+                        "selectedLogFields":  [
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "body",
+                                                      "type":  ""
+                                                  },
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "timestamp",
+                                                      "type":  ""
+                                                  }
+                                              ],
+                        "selectedTracesFields":  [
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "serviceName--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "serviceName",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "name--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "name",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "float64",
+                                                         "id":  "durationNano--float64--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "durationNano",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "httpMethod--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "httpMethod",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "responseStatusCode--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "responseStatusCode",
+                                                         "type":  "tag"
+                                                     }
+                                                 ],
+                        "softMax":  0,
+                        "softMin":  0,
+                        "stackedBarChart":  false,
+                        "thresholds":  [
+
+                                       ],
+                        "timePreferance":  "GLOBAL_TIME",
+                        "title":  "HTTP Request Count",
+                        "yAxisUnit":  "none"
+                    },
+                    {
+                        "bucketCount":  30,
+                        "bucketWidth":  0,
+                        "columnUnits":  {
+
+                                        },
+                        "description":  "Average and total size of incoming requests.",
+                        "fillSpans":  false,
+                        "id":  "8586305c-923f-42c5-bdee-833276abbb86",
+                        "isStacked":  false,
+                        "mergeAllActiveQueries":  false,
+                        "nullZeroValues":  "zero",
+                        "opacity":  "1",
+                        "panelTypes":  "graph",
+                        "query":  {
+                                      "builder":  {
+                                                      "queryData":  [
+
+                                                                    ],
+                                                      "queryFormulas":  [
+
+                                                                        ]
+                                                  },
+                                      "clickhouse_sql":  [
+                                                             {
+                                                                 "disabled":  false,
+                                                                 "legend":  "",
+                                                                 "name":  "A",
+                                                                 "query":  ""
+                                                             }
+                                                         ],
+                                      "id":  "1c7d1550-c3ad-407e-9a39-a96da213d66d",
+                                      "promql":  [
+                                                     {
+                                                         "disabled":  false,
+                                                         "legend":  "{{envoy_http_conn_manager_prefix}}",
+                                                         "name":  "A",
+                                                         "query":  "sum(rate(envoy_http_downstream_cx_rx_bytes_total{service_name=~\"$service.name\", namespace=~\"$namespace\", deployment_environment=~\"$deployment.environment\", cluster=~\"$cluster\"}[5m])) by (envoy_http_conn_manager_prefix)"
+                                                     }
+                                                 ],
+                                      "queryType":  "promql"
+                                  },
+                        "selectedLogFields":  [
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "body",
+                                                      "type":  ""
+                                                  },
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "timestamp",
+                                                      "type":  ""
+                                                  }
+                                              ],
+                        "selectedTracesFields":  [
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "serviceName--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "serviceName",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "name--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "name",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "float64",
+                                                         "id":  "durationNano--float64--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "durationNano",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "httpMethod--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "httpMethod",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "responseStatusCode--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "responseStatusCode",
+                                                         "type":  "tag"
+                                                     }
+                                                 ],
+                        "softMax":  0,
+                        "softMin":  0,
+                        "stackedBarChart":  false,
+                        "thresholds":  [
+
+                                       ],
+                        "timePreferance":  "GLOBAL_TIME",
+                        "title":  "Request Size",
+                        "yAxisUnit":  "decbytes"
+                    },
+                    {
+                        "bucketCount":  30,
+                        "bucketWidth":  0,
+                        "columnUnits":  {
+
+                                        },
+                        "description":  "Average and total size of responses sent by Envoy.",
+                        "fillSpans":  false,
+                        "id":  "a852060a-158a-4b3d-8d95-1b6983e120a7",
+                        "isStacked":  false,
+                        "mergeAllActiveQueries":  false,
+                        "nullZeroValues":  "zero",
+                        "opacity":  "1",
+                        "panelTypes":  "graph",
+                        "query":  {
+                                      "builder":  {
+                                                      "queryData":  [
+
+                                                                    ],
+                                                      "queryFormulas":  [
+
+                                                                        ]
+                                                  },
+                                      "clickhouse_sql":  [
+                                                             {
+                                                                 "disabled":  false,
+                                                                 "legend":  "",
+                                                                 "name":  "A",
+                                                                 "query":  ""
+                                                             }
+                                                         ],
+                                      "id":  "5bc28245-8319-4de1-a6eb-7e31ced34536",
+                                      "promql":  [
+                                                     {
+                                                         "disabled":  false,
+                                                         "legend":  "",
+                                                         "name":  "A",
+                                                         "query":  "sum(rate(envoy_http_downstream_cx_tx_bytes_total{service_name=~\"$service.name\", namespace=~\"$namespace\", deployment_environment=~\"$deployment.environment\", cluster=~\"$cluster\"}[5m])) / sum(rate(envoy_http_downstream_rq_total{service_name=~\"$service.name\", namespace=~\"$namespace\", deployment_environment=~\"$deployment.environment\", cluster=~\"$cluster\"}[5m]))"
+                                                     }
+                                                 ],
+                                      "queryType":  "promql"
+                                  },
+                        "selectedLogFields":  [
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "body",
+                                                      "type":  ""
+                                                  },
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "timestamp",
+                                                      "type":  ""
+                                                  }
+                                              ],
+                        "selectedTracesFields":  [
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "serviceName--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "serviceName",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "name--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "name",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "float64",
+                                                         "id":  "durationNano--float64--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "durationNano",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "httpMethod--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "httpMethod",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "responseStatusCode--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "responseStatusCode",
+                                                         "type":  "tag"
+                                                     }
+                                                 ],
+                        "softMax":  0,
+                        "softMin":  0,
+                        "stackedBarChart":  false,
+                        "thresholds":  [
+
+                                       ],
+                        "timePreferance":  "GLOBAL_TIME",
+                        "title":  "Response Size",
+                        "yAxisUnit":  "decbytes"
+                    },
+                    {
+                        "bucketCount":  30,
+                        "bucketWidth":  0,
+                        "columnUnits":  {
+                                            "A":  "none"
+                                        },
+                        "description":  "Distribution of HTTP response codes returned by Envoy.",
+                        "fillSpans":  false,
+                        "id":  "046d43cb-7747-4b94-af18-7c5829a351bd",
+                        "isStacked":  false,
+                        "mergeAllActiveQueries":  false,
+                        "nullZeroValues":  "zero",
+                        "opacity":  "1",
+                        "panelTypes":  "table",
+                        "query":  {
+                                      "builder":  {
+                                                      "queryData":  [
+
+                                                                    ],
+                                                      "queryFormulas":  [
+
+                                                                        ]
+                                                  },
+                                      "clickhouse_sql":  [
+                                                             {
+                                                                 "disabled":  false,
+                                                                 "legend":  "",
+                                                                 "name":  "A",
+                                                                 "query":  ""
+                                                             }
+                                                         ],
+                                      "id":  "564831ce-fb68-497e-9d7d-a13fbd4d29b1",
+                                      "promql":  [
+                                                     {
+                                                         "disabled":  false,
+                                                         "legend":  "{{envoy_response_code_class}}",
+                                                         "name":  "A",
+                                                         "query":  "sum(rate(envoy_http_downstream_rq_xx{service_name=~\"$service.name\", namespace=~\"$namespace\", deployment_environment=~\"$deployment.environment\", cluster=~\"$cluster\"}[5m])) by (envoy_response_code_class)"
+                                                     }
+                                                 ],
+                                      "queryType":  "promql"
+                                  },
+                        "selectedLogFields":  [
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "body",
+                                                      "type":  ""
+                                                  },
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "timestamp",
+                                                      "type":  ""
+                                                  }
+                                              ],
+                        "selectedTracesFields":  [
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "serviceName--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "serviceName",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "name--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "name",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "float64",
+                                                         "id":  "durationNano--float64--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "durationNano",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "httpMethod--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "httpMethod",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "responseStatusCode--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "responseStatusCode",
+                                                         "type":  "tag"
+                                                     }
+                                                 ],
+                        "softMax":  0,
+                        "softMin":  0,
+                        "stackedBarChart":  false,
+                        "thresholds":  [
+
+                                       ],
+                        "timePreferance":  "GLOBAL_TIME",
+                        "title":  "HTTP Response Codes",
+                        "yAxisUnit":  "none"
+                    },
+                    {
+                        "bucketCount":  30,
+                        "bucketWidth":  0,
+                        "columnUnits":  {
+
+                                        },
+                        "description":  "Average and percentile response times for requests handled by Envoy.",
+                        "fillSpans":  false,
+                        "id":  "c54194a3-f8f9-4d2b-91b6-78183b5d5b32",
+                        "isStacked":  false,
+                        "mergeAllActiveQueries":  false,
+                        "nullZeroValues":  "zero",
+                        "opacity":  "1",
+                        "panelTypes":  "graph",
+                        "query":  {
+                                      "builder":  {
+                                                      "queryData":  [
+
+                                                                    ],
+                                                      "queryFormulas":  [
+
+                                                                        ]
+                                                  },
+                                      "clickhouse_sql":  [
+                                                             {
+                                                                 "disabled":  false,
+                                                                 "legend":  "",
+                                                                 "name":  "A",
+                                                                 "query":  ""
+                                                             }
+                                                         ],
+                                      "id":  "8df34038-b3b6-4efd-9104-b2144c5aa9ef",
+                                      "promql":  [
+                                                     {
+                                                         "disabled":  false,
+                                                         "legend":  "{{envoy_http_conn_manager_prefix}}",
+                                                         "name":  "A",
+                                                         "query":  "sum(rate(envoy_http_downstream_rq_time_sum{service_name=~\"$service.name\", namespace=~\"$namespace\", deployment_environment=~\"$deployment.environment\", cluster=~\"$cluster\"}[5m])) by (envoy_http_conn_manager_prefix) / sum(rate(envoy_http_downstream_rq_time_count{service_name=~\"$service.name\", namespace=~\"$namespace\", deployment_environment=~\"$deployment.environment\", cluster=~\"$cluster\"}[5m])) by (envoy_http_conn_manager_prefix)"
+                                                     }
+                                                 ],
+                                      "queryType":  "promql"
+                                  },
+                        "selectedLogFields":  [
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "body",
+                                                      "type":  ""
+                                                  },
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "timestamp",
+                                                      "type":  ""
+                                                  }
+                                              ],
+                        "selectedTracesFields":  [
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "serviceName--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "serviceName",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "name--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "name",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "float64",
+                                                         "id":  "durationNano--float64--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "durationNano",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "httpMethod--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "httpMethod",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "responseStatusCode--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "responseStatusCode",
+                                                         "type":  "tag"
+                                                     }
+                                                 ],
+                        "softMax":  0,
+                        "softMin":  0,
+                        "stackedBarChart":  false,
+                        "thresholds":  [
+
+                                       ],
+                        "timePreferance":  "GLOBAL_TIME",
+                        "title":  "Response Time",
+                        "yAxisUnit":  "none"
+                    },
+                    {
+                        "bucketCount":  30,
+                        "bucketWidth":  0,
+                        "columnUnits":  {
+
+                                        },
+                        "description":  "Distribution of response times across percentiles.",
+                        "fillSpans":  false,
+                        "id":  "b1581fd0-4c3d-44b6-9581-02ba8d9d3ac6",
+                        "isStacked":  false,
+                        "mergeAllActiveQueries":  false,
+                        "nullZeroValues":  "zero",
+                        "opacity":  "1",
+                        "panelTypes":  "histogram",
+                        "query":  {
+                                      "builder":  {
+                                                      "queryData":  [
+
+                                                                    ],
+                                                      "queryFormulas":  [
+
+                                                                        ]
+                                                  },
+                                      "clickhouse_sql":  [
+                                                             {
+                                                                 "disabled":  false,
+                                                                 "legend":  "",
+                                                                 "name":  "A",
+                                                                 "query":  ""
+                                                             }
+                                                         ],
+                                      "id":  "0deb32ee-c3fb-4035-b16d-3ef732549b5c",
+                                      "promql":  [
+                                                     {
+                                                         "disabled":  false,
+                                                         "legend":  "{{le}}",
+                                                         "name":  "A",
+                                                         "query":  "sum(rate(envoy_http_downstream_rq_time_bucket{service_name=~\"$service.name\", namespace=~\"$namespace\", deployment_environment=~\"$deployment.environment\", cluster=~\"$cluster\"}[5m])) by (le)"
+                                                     }
+                                                 ],
+                                      "queryType":  "promql"
+                                  },
+                        "selectedLogFields":  [
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "body",
+                                                      "type":  ""
+                                                  },
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "timestamp",
+                                                      "type":  ""
+                                                  }
+                                              ],
+                        "selectedTracesFields":  [
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "serviceName--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "serviceName",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "name--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "name",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "float64",
+                                                         "id":  "durationNano--float64--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "durationNano",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "httpMethod--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "httpMethod",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "responseStatusCode--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "responseStatusCode",
+                                                         "type":  "tag"
+                                                     }
+                                                 ],
+                        "softMax":  0,
+                        "softMin":  0,
+                        "stackedBarChart":  false,
+                        "thresholds":  [
+
+                                       ],
+                        "timePreferance":  "GLOBAL_TIME",
+                        "title":  "Response Time Histogram",
+                        "yAxisUnit":  "none"
+                    },
+                    {
+                        "bucketCount":  30,
+                        "bucketWidth":  0,
+                        "columnUnits":  {
+
+                                        },
+                        "description":  "Average time taken to process requests.",
+                        "fillSpans":  false,
+                        "id":  "0e7a6c2b-2798-4cd9-8601-434863251c7d",
+                        "isStacked":  false,
+                        "mergeAllActiveQueries":  false,
+                        "nullZeroValues":  "zero",
+                        "opacity":  "1",
+                        "panelTypes":  "graph",
+                        "query":  {
+                                      "builder":  {
+                                                      "queryData":  [
+
+                                                                    ],
+                                                      "queryFormulas":  [
+
+                                                                        ]
+                                                  },
+                                      "clickhouse_sql":  [
+                                                             {
+                                                                 "disabled":  false,
+                                                                 "legend":  "",
+                                                                 "name":  "A",
+                                                                 "query":  ""
+                                                             }
+                                                         ],
+                                      "id":  "117499ab-1974-4c6a-b5f8-c0b909398fbf",
+                                      "promql":  [
+                                                     {
+                                                         "disabled":  false,
+                                                         "legend":  "",
+                                                         "name":  "A",
+                                                         "query":  "sum(rate(envoy_http_downstream_rq_time_sum{service_name=~\"$service.name\", namespace=~\"$namespace\", deployment_environment=~\"$deployment.environment\", cluster=~\"$cluster\"}[5m])) / sum(rate(envoy_http_downstream_rq_time_count{service_name=~\"$service.name\", namespace=~\"$namespace\", deployment_environment=~\"$deployment.environment\", cluster=~\"$cluster\"}[5m]))"
+                                                     }
+                                                 ],
+                                      "queryType":  "promql"
+                                  },
+                        "selectedLogFields":  [
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "body",
+                                                      "type":  ""
+                                                  },
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "timestamp",
+                                                      "type":  ""
+                                                  }
+                                              ],
+                        "selectedTracesFields":  [
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "serviceName--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "serviceName",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "name--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "name",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "float64",
+                                                         "id":  "durationNano--float64--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "durationNano",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "httpMethod--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "httpMethod",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "responseStatusCode--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "responseStatusCode",
+                                                         "type":  "tag"
+                                                     }
+                                                 ],
+                        "softMax":  0,
+                        "softMin":  0,
+                        "stackedBarChart":  false,
+                        "thresholds":  [
+
+                                       ],
+                        "timePreferance":  "GLOBAL_TIME",
+                        "title":  "Average Latency",
+                        "yAxisUnit":  "s"
+                    },
+                    {
+                        "bucketCount":  30,
+                        "bucketWidth":  0,
+                        "columnUnits":  {
+
+                                        },
+                        "description":  "Latency percentiles (50th, 95th, 99th).",
+                        "fillSpans":  false,
+                        "id":  "65c04550-ef09-42f7-bf60-2b62b8282848",
+                        "isStacked":  false,
+                        "mergeAllActiveQueries":  false,
+                        "nullZeroValues":  "zero",
+                        "opacity":  "1",
+                        "panelTypes":  "graph",
+                        "query":  {
+                                      "builder":  {
+                                                      "queryData":  [
+
+                                                                    ],
+                                                      "queryFormulas":  [
+
+                                                                        ]
+                                                  },
+                                      "clickhouse_sql":  [
+                                                             {
+                                                                 "disabled":  false,
+                                                                 "legend":  "",
+                                                                 "name":  "A",
+                                                                 "query":  ""
+                                                             }
+                                                         ],
+                                      "id":  "dd4333f7-f96c-4712-99b4-8a94c2cb1a50",
+                                      "promql":  [
+                                                     {
+                                                         "disabled":  false,
+                                                         "legend":  "{{envoy_http_conn_manager_prefix}}",
+                                                         "name":  "A",
+                                                         "query":  "histogram_quantile(0.95, sum(rate(envoy_http_downstream_rq_time_bucket{service_name=~\"$service.name\", namespace=~\"$namespace\", deployment_environment=~\"$deployment.environment\", cluster=~\"$cluster\"}[5m])) by (le, envoy_http_conn_manager_prefix))"
+                                                     }
+                                                 ],
+                                      "queryType":  "promql"
+                                  },
+                        "selectedLogFields":  [
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "body",
+                                                      "type":  ""
+                                                  },
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "timestamp",
+                                                      "type":  ""
+                                                  }
+                                              ],
+                        "selectedTracesFields":  [
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "serviceName--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "serviceName",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "name--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "name",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "float64",
+                                                         "id":  "durationNano--float64--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "durationNano",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "httpMethod--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "httpMethod",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "responseStatusCode--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "responseStatusCode",
+                                                         "type":  "tag"
+                                                     }
+                                                 ],
+                        "softMax":  0,
+                        "softMin":  0,
+                        "stackedBarChart":  false,
+                        "thresholds":  [
+
+                                       ],
+                        "timePreferance":  "GLOBAL_TIME",
+                        "title":  "Latency Percentiles",
+                        "yAxisUnit":  "none"
+                    },
+                    {
+                        "bucketCount":  30,
+                        "bucketWidth":  0,
+                        "columnUnits":  {
+
+                                        },
+                        "description":  " Lists endpoints with the highest latency.",
+                        "fillSpans":  false,
+                        "id":  "1ecf4f6b-ab70-4ac0-b133-702a5438717b",
+                        "isStacked":  false,
+                        "mergeAllActiveQueries":  false,
+                        "nullZeroValues":  "zero",
+                        "opacity":  "1",
+                        "panelTypes":  "table",
+                        "query":  {
+                                      "builder":  {
+                                                      "queryData":  [
+                                                                        {
+                                                                            "aggregateAttribute":  {
+                                                                                                       "dataType":  "",
+                                                                                                       "id":  "topk(10, sum(rate(envoy_http_downstream_response_time_seconds[5m])) by (uri))------false",
+                                                                                                       "isColumn":  false,
+                                                                                                       "key":  "topk(10, sum(rate(envoy_http_downstream_response_time_seconds[5m])) by (uri))",
+                                                                                                       "type":  ""
+                                                                                                   },
+                                                                            "aggregateOperator":  "count",
+                                                                            "dataSource":  "metrics",
+                                                                            "disabled":  false,
+                                                                            "expression":  "A",
+                                                                            "filters":  {
+                                                                                            "items":  [
+
+                                                                                                      ],
+                                                                                            "op":  "AND"
+                                                                                        },
+                                                                            "functions":  [
+
+                                                                                          ],
+                                                                            "groupBy":  [
+
+                                                                                        ],
+                                                                            "having":  [
+
+                                                                                       ],
+                                                                            "legend":  "",
+                                                                            "limit":  null,
+                                                                            "orderBy":  [
+
+                                                                                        ],
+                                                                            "queryName":  "A",
+                                                                            "reduceTo":  "avg",
+                                                                            "spaceAggregation":  "",
+                                                                            "stepInterval":  60,
+                                                                            "timeAggregation":  ""
+                                                                        }
+                                                                    ],
+                                                      "queryFormulas":  [
+
+                                                                        ]
+                                                  },
+                                      "clickhouse_sql":  [
+                                                             {
+                                                                 "disabled":  false,
+                                                                 "legend":  "",
+                                                                 "name":  "A",
+                                                                 "query":  ""
+                                                             }
+                                                         ],
+                                      "id":  "332db514-8f67-4794-a991-567404204f6f",
+                                      "promql":  [
+                                                     {
+                                                         "disabled":  false,
+                                                         "legend":  "",
+                                                         "name":  "A",
+                                                         "query":  ""
+                                                     }
+                                                 ],
+                                      "queryType":  "builder"
+                                  },
+                        "selectedLogFields":  [
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "body",
+                                                      "type":  ""
+                                                  },
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "timestamp",
+                                                      "type":  ""
+                                                  }
+                                              ],
+                        "selectedTracesFields":  [
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "serviceName--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "serviceName",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "name--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "name",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "float64",
+                                                         "id":  "durationNano--float64--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "durationNano",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "httpMethod--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "httpMethod",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "responseStatusCode--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "responseStatusCode",
+                                                         "type":  "tag"
+                                                     }
+                                                 ],
+                        "softMax":  0,
+                        "softMin":  0,
+                        "stackedBarChart":  false,
+                        "thresholds":  [
+
+                                       ],
+                        "timePreferance":  "GLOBAL_TIME",
+                        "title":  "Slowest Endpoints",
+                        "yAxisUnit":  "none"
+                    },
+                    {
+                        "bucketCount":  30,
+                        "bucketWidth":  0,
+                        "columnUnits":  {
+
+                                        },
+                        "description":  "Total number of errors encountered by Envoy.",
+                        "fillSpans":  false,
+                        "id":  "c8393303-fddf-4b9f-849f-18f7738841ce",
+                        "isStacked":  false,
+                        "mergeAllActiveQueries":  false,
+                        "nullZeroValues":  "zero",
+                        "opacity":  "1",
+                        "panelTypes":  "value",
+                        "query":  {
+                                      "builder":  {
+                                                      "queryData":  [
+
+                                                                    ],
+                                                      "queryFormulas":  [
+
+                                                                        ]
+                                                  },
+                                      "clickhouse_sql":  [
+                                                             {
+                                                                 "disabled":  false,
+                                                                 "legend":  "",
+                                                                 "name":  "A",
+                                                                 "query":  ""
+                                                             }
+                                                         ],
+                                      "id":  "cb87db25-c853-41f4-8944-c452d87090a0",
+                                      "promql":  [
+                                                     {
+                                                         "disabled":  false,
+                                                         "legend":  "",
+                                                         "name":  "A",
+                                                         "query":  "sum(envoy_http_downstream_rq_xx{service_name=~\"$service.name\", namespace=~\"$namespace\", deployment_environment=~\"$deployment.environment\", cluster=~\"$cluster\", envoy_response_code_class=~\"4|5\"})"
+                                                     }
+                                                 ],
+                                      "queryType":  "promql"
+                                  },
+                        "selectedLogFields":  [
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "body",
+                                                      "type":  ""
+                                                  },
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "timestamp",
+                                                      "type":  ""
+                                                  }
+                                              ],
+                        "selectedTracesFields":  [
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "serviceName--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "serviceName",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "name--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "name",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "float64",
+                                                         "id":  "durationNano--float64--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "durationNano",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "httpMethod--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "httpMethod",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "responseStatusCode--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "responseStatusCode",
+                                                         "type":  "tag"
+                                                     }
+                                                 ],
+                        "softMax":  0,
+                        "softMin":  0,
+                        "stackedBarChart":  false,
+                        "thresholds":  [
+
+                                       ],
+                        "timePreferance":  "GLOBAL_TIME",
+                        "title":  "Total Errors\t",
+                        "yAxisUnit":  "none"
+                    },
+                    {
+                        "bucketCount":  30,
+                        "bucketWidth":  0,
+                        "columnUnits":  {
+
+                                        },
+                        "description":  "Rate of errors per second.",
+                        "fillSpans":  false,
+                        "id":  "2267a26c-a943-4b2d-b495-69b8c3ee080e",
+                        "isStacked":  false,
+                        "mergeAllActiveQueries":  false,
+                        "nullZeroValues":  "zero",
+                        "opacity":  "1",
+                        "panelTypes":  "graph",
+                        "query":  {
+                                      "builder":  {
+                                                      "queryData":  [
+
+                                                                    ],
+                                                      "queryFormulas":  [
+
+                                                                        ]
+                                                  },
+                                      "clickhouse_sql":  [
+                                                             {
+                                                                 "disabled":  false,
+                                                                 "legend":  "",
+                                                                 "name":  "A",
+                                                                 "query":  ""
+                                                             }
+                                                         ],
+                                      "id":  "02260981-07f5-40d4-96d1-8f696343a771",
+                                      "promql":  [
+                                                     {
+                                                         "disabled":  false,
+                                                         "legend":  "{{envoy_response_code_class}}",
+                                                         "name":  "A",
+                                                         "query":  "sum(rate(envoy_http_downstream_rq_xx{service_name=~\"$service.name\", namespace=~\"$namespace\", deployment_environment=~\"$deployment.environment\", cluster=~\"$cluster\", envoy_response_code_class=~\"4|5\"}[5m])) by (envoy_response_code_class, envoy_http_conn_manager_prefix)"
+                                                     }
+                                                 ],
+                                      "queryType":  "promql"
+                                  },
+                        "selectedLogFields":  [
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "body",
+                                                      "type":  ""
+                                                  },
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "timestamp",
+                                                      "type":  ""
+                                                  }
+                                              ],
+                        "selectedTracesFields":  [
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "serviceName--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "serviceName",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "name--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "name",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "float64",
+                                                         "id":  "durationNano--float64--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "durationNano",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "httpMethod--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "httpMethod",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "responseStatusCode--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "responseStatusCode",
+                                                         "type":  "tag"
+                                                     }
+                                                 ],
+                        "softMax":  0,
+                        "softMin":  0,
+                        "stackedBarChart":  false,
+                        "thresholds":  [
+
+                                       ],
+                        "timePreferance":  "GLOBAL_TIME",
+                        "title":  "Error Rate",
+                        "yAxisUnit":  "none"
+                    },
+                    {
+                        "bucketCount":  30,
+                        "bucketWidth":  0,
+                        "columnUnits":  {
+
+                                        },
+                        "description":  "Lists most common types of errors.",
+                        "fillSpans":  false,
+                        "id":  "9afc65b5-b399-470f-b663-56e96d8c7af5",
+                        "isStacked":  false,
+                        "mergeAllActiveQueries":  false,
+                        "nullZeroValues":  "zero",
+                        "opacity":  "1",
+                        "panelTypes":  "table",
+                        "query":  {
+                                      "builder":  {
+                                                      "queryData":  [
+                                                                        {
+                                                                            "aggregateAttribute":  {
+                                                                                                       "dataType":  "",
+                                                                                                       "id":  "topk(10, sum(rate(envoy_http_downstream_response_total{response_code=~\"5.*\"}[5m])) by (response_code))------false",
+                                                                                                       "isColumn":  false,
+                                                                                                       "key":  "topk(10, sum(rate(envoy_http_downstream_response_total{response_code=~\"5.*\"}[5m])) by (response_code))",
+                                                                                                       "type":  ""
+                                                                                                   },
+                                                                            "aggregateOperator":  "count",
+                                                                            "dataSource":  "metrics",
+                                                                            "disabled":  false,
+                                                                            "expression":  "A",
+                                                                            "filters":  {
+                                                                                            "items":  [
+
+                                                                                                      ],
+                                                                                            "op":  "AND"
+                                                                                        },
+                                                                            "functions":  [
+
+                                                                                          ],
+                                                                            "groupBy":  [
+
+                                                                                        ],
+                                                                            "having":  [
+
+                                                                                       ],
+                                                                            "legend":  "",
+                                                                            "limit":  null,
+                                                                            "orderBy":  [
+
+                                                                                        ],
+                                                                            "queryName":  "A",
+                                                                            "reduceTo":  "avg",
+                                                                            "spaceAggregation":  "",
+                                                                            "stepInterval":  60,
+                                                                            "timeAggregation":  ""
+                                                                        }
+                                                                    ],
+                                                      "queryFormulas":  [
+
+                                                                        ]
+                                                  },
+                                      "clickhouse_sql":  [
+                                                             {
+                                                                 "disabled":  false,
+                                                                 "legend":  "",
+                                                                 "name":  "A",
+                                                                 "query":  ""
+                                                             }
+                                                         ],
+                                      "id":  "477350d3-c105-4cc7-85e6-418b72aacde1",
+                                      "promql":  [
+                                                     {
+                                                         "disabled":  false,
+                                                         "legend":  "",
+                                                         "name":  "A",
+                                                         "query":  ""
+                                                     }
+                                                 ],
+                                      "queryType":  "builder"
+                                  },
+                        "selectedLogFields":  [
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "body",
+                                                      "type":  ""
+                                                  },
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "timestamp",
+                                                      "type":  ""
+                                                  }
+                                              ],
+                        "selectedTracesFields":  [
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "serviceName--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "serviceName",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "name--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "name",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "float64",
+                                                         "id":  "durationNano--float64--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "durationNano",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "httpMethod--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "httpMethod",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "responseStatusCode--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "responseStatusCode",
+                                                         "type":  "tag"
+                                                     }
+                                                 ],
+                        "softMax":  0,
+                        "softMin":  0,
+                        "stackedBarChart":  false,
+                        "thresholds":  [
+
+                                       ],
+                        "timePreferance":  "GLOBAL_TIME",
+                        "title":  "Top Error Types",
+                        "yAxisUnit":  "none"
+                    },
+                    {
+                        "bucketCount":  30,
+                        "bucketWidth":  0,
+                        "columnUnits":  {
+
+                                        },
+                        "description":  "CPU usage by the Envoy process",
+                        "fillSpans":  false,
+                        "id":  "14088819-33b1-4dca-a38b-39fcf0aa190b",
+                        "isStacked":  false,
+                        "mergeAllActiveQueries":  false,
+                        "nullZeroValues":  "zero",
+                        "opacity":  "1",
+                        "panelTypes":  "graph",
+                        "query":  {
+                                      "builder":  {
+                                                      "queryData":  [
+
+                                                                    ],
+                                                      "queryFormulas":  [
+
+                                                                        ]
+                                                  },
+                                      "clickhouse_sql":  [
+                                                             {
+                                                                 "disabled":  false,
+                                                                 "legend":  "",
+                                                                 "name":  "A",
+                                                                 "query":  ""
+                                                             }
+                                                         ],
+                                      "id":  "3f921542-a6a4-4e7a-9d1e-6516274c0221",
+                                      "promql":  [
+                                                     {
+                                                         "disabled":  false,
+                                                         "legend":  "",
+                                                         "name":  "A",
+                                                         "query":  "rate(process_cpu_seconds_total{service_name=~\"$service.name\", namespace=~\"$namespace\", deployment_environment=~\"$deployment.environment\", cluster=~\"$cluster\"}[5m])"
+                                                     }
+                                                 ],
+                                      "queryType":  "promql"
+                                  },
+                        "selectedLogFields":  [
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "body",
+                                                      "type":  ""
+                                                  },
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "timestamp",
+                                                      "type":  ""
+                                                  }
+                                              ],
+                        "selectedTracesFields":  [
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "serviceName--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "serviceName",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "name--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "name",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "float64",
+                                                         "id":  "durationNano--float64--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "durationNano",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "httpMethod--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "httpMethod",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "responseStatusCode--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "responseStatusCode",
+                                                         "type":  "tag"
+                                                     }
+                                                 ],
+                        "softMax":  0,
+                        "softMin":  0,
+                        "stackedBarChart":  false,
+                        "thresholds":  [
+
+                                       ],
+                        "timePreferance":  "GLOBAL_TIME",
+                        "title":  "CPU Usage",
+                        "yAxisUnit":  "s"
+                    },
+                    {
+                        "bucketCount":  30,
+                        "bucketWidth":  0,
+                        "columnUnits":  {
+
+                                        },
+                        "description":  " Memory consumption of Envoy.",
+                        "fillSpans":  false,
+                        "id":  "81c64192-ff05-4f51-819b-3ecb11dcf0bb",
+                        "isStacked":  false,
+                        "mergeAllActiveQueries":  false,
+                        "nullZeroValues":  "zero",
+                        "opacity":  "1",
+                        "panelTypes":  "graph",
+                        "query":  {
+                                      "builder":  {
+                                                      "queryData":  [
+
+                                                                    ],
+                                                      "queryFormulas":  [
+
+                                                                        ]
+                                                  },
+                                      "clickhouse_sql":  [
+                                                             {
+                                                                 "disabled":  false,
+                                                                 "legend":  "",
+                                                                 "name":  "A",
+                                                                 "query":  ""
+                                                             }
+                                                         ],
+                                      "id":  "6ee66f91-4276-49ce-b492-485d15971ffc",
+                                      "promql":  [
+                                                     {
+                                                         "disabled":  false,
+                                                         "legend":  "",
+                                                         "name":  "A",
+                                                         "query":  "max(envoy_server_memory_allocated{service_name=~\"$service.name\", namespace=~\"$namespace\", deployment_environment=~\"$deployment.environment\", cluster=~\"$cluster\"})"
+                                                     }
+                                                 ],
+                                      "queryType":  "promql"
+                                  },
+                        "selectedLogFields":  [
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "body",
+                                                      "type":  ""
+                                                  },
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "timestamp",
+                                                      "type":  ""
+                                                  }
+                                              ],
+                        "selectedTracesFields":  [
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "serviceName--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "serviceName",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "name--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "name",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "float64",
+                                                         "id":  "durationNano--float64--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "durationNano",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "httpMethod--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "httpMethod",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "responseStatusCode--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "responseStatusCode",
+                                                         "type":  "tag"
+                                                     }
+                                                 ],
+                        "softMax":  0,
+                        "softMin":  0,
+                        "stackedBarChart":  false,
+                        "thresholds":  [
+
+                                       ],
+                        "timePreferance":  "GLOBAL_TIME",
+                        "title":  "Memory Usage",
+                        "yAxisUnit":  "decbytes"
+                    },
+                    {
+                        "bucketCount":  30,
+                        "bucketWidth":  0,
+                        "columnUnits":  {
+
+                                        },
+                        "description":  "Monitors disk input/output operations.",
+                        "fillSpans":  false,
+                        "id":  "5ba52f28-7ef0-4dc0-8905-6fc97b6ced1f",
+                        "isStacked":  false,
+                        "mergeAllActiveQueries":  false,
+                        "nullZeroValues":  "zero",
+                        "opacity":  "1",
+                        "panelTypes":  "graph",
+                        "query":  {
+                                      "builder":  {
+                                                      "queryData":  [
+
+                                                                    ],
+                                                      "queryFormulas":  [
+
+                                                                        ]
+                                                  },
+                                      "clickhouse_sql":  [
+                                                             {
+                                                                 "disabled":  false,
+                                                                 "legend":  "",
+                                                                 "name":  "A",
+                                                                 "query":  ""
+                                                             }
+                                                         ],
+                                      "id":  "b7649682-c50a-40f2-851a-c44a2eb5958b",
+                                      "promql":  [
+                                                     {
+                                                         "disabled":  false,
+                                                         "legend":  "",
+                                                         "name":  "A",
+                                                         "query":  "sum(rate(container_fs_reads_bytes_total{namespace=~\"$namespace\", pod=~\".*envoy.*\"}[5m])) + sum(rate(container_fs_writes_bytes_total{namespace=~\"$namespace\", pod=~\".*envoy.*\"}[5m]))"
+                                                     }
+                                                 ],
+                                      "queryType":  "promql"
+                                  },
+                        "selectedLogFields":  [
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "body",
+                                                      "type":  ""
+                                                  },
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "timestamp",
+                                                      "type":  ""
+                                                  }
+                                              ],
+                        "selectedTracesFields":  [
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "serviceName--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "serviceName",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "name--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "name",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "float64",
+                                                         "id":  "durationNano--float64--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "durationNano",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "httpMethod--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "httpMethod",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "responseStatusCode--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "responseStatusCode",
+                                                         "type":  "tag"
+                                                     }
+                                                 ],
+                        "softMax":  0,
+                        "softMin":  0,
+                        "stackedBarChart":  false,
+                        "thresholds":  [
+
+                                       ],
+                        "timePreferance":  "GLOBAL_TIME",
+                        "title":  "Disk I/O",
+                        "yAxisUnit":  "none"
+                    },
+                    {
+                        "bucketCount":  30,
+                        "bucketWidth":  0,
+                        "columnUnits":  {
+
+                                        },
+                        "description":  "Incoming and outgoing network traffic.",
+                        "fillSpans":  false,
+                        "id":  "914a1a60-cca6-46eb-b349-8183f7cb7c57",
+                        "isStacked":  false,
+                        "mergeAllActiveQueries":  false,
+                        "nullZeroValues":  "zero",
+                        "opacity":  "1",
+                        "panelTypes":  "graph",
+                        "query":  {
+                                      "builder":  {
+                                                      "queryData":  [
+
+                                                                    ],
+                                                      "queryFormulas":  [
+
+                                                                        ]
+                                                  },
+                                      "clickhouse_sql":  [
+                                                             {
+                                                                 "disabled":  false,
+                                                                 "legend":  "",
+                                                                 "name":  "A",
+                                                                 "query":  ""
+                                                             }
+                                                         ],
+                                      "id":  "e8da05ab-057a-43c5-b638-f8f2ed2fb3bc",
+                                      "promql":  [
+                                                     {
+                                                         "disabled":  false,
+                                                         "legend":  "",
+                                                         "name":  "A",
+                                                         "query":  "sum(rate(envoy_cluster_upstream_cx_tx_bytes_total{service_name=~\"$service.name\", namespace=~\"$namespace\", deployment_environment=~\"$deployment.environment\", cluster=~\"$cluster\"}[5m]) + rate(envoy_cluster_upstream_cx_rx_bytes_total{service_name=~\"$service.name\", namespace=~\"$namespace\", deployment_environment=~\"$deployment.environment\", cluster=~\"$cluster\"}[5m]))"
+                                                     }
+                                                 ],
+                                      "queryType":  "promql"
+                                  },
+                        "selectedLogFields":  [
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "body",
+                                                      "type":  ""
+                                                  },
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "timestamp",
+                                                      "type":  ""
+                                                  }
+                                              ],
+                        "selectedTracesFields":  [
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "serviceName--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "serviceName",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "name--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "name",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "float64",
+                                                         "id":  "durationNano--float64--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "durationNano",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "httpMethod--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "httpMethod",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "responseStatusCode--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "responseStatusCode",
+                                                         "type":  "tag"
+                                                     }
+                                                 ],
+                        "softMax":  0,
+                        "softMin":  0,
+                        "stackedBarChart":  false,
+                        "thresholds":  [
+
+                                       ],
+                        "timePreferance":  "GLOBAL_TIME",
+                        "title":  "Network Throughput",
+                        "yAxisUnit":  "decbytes"
+                    },
+                    {
+                        "bucketCount":  30,
+                        "bucketWidth":  0,
+                        "columnUnits":  {
+
+                                        },
+                        "description":  "Rate of new connections being established.",
+                        "fillSpans":  false,
+                        "id":  "26fcba5b-25f5-42c8-b41b-6a4a3d8e9e37",
+                        "isStacked":  false,
+                        "mergeAllActiveQueries":  false,
+                        "nullZeroValues":  "zero",
+                        "opacity":  "1",
+                        "panelTypes":  "graph",
+                        "query":  {
+                                      "builder":  {
+                                                      "queryData":  [
+
+                                                                    ],
+                                                      "queryFormulas":  [
+
+                                                                        ]
+                                                  },
+                                      "clickhouse_sql":  [
+                                                             {
+                                                                 "disabled":  false,
+                                                                 "legend":  "",
+                                                                 "name":  "A",
+                                                                 "query":  ""
+                                                             }
+                                                         ],
+                                      "id":  "17164cd8-1094-48d8-8e98-28e24e118f85",
+                                      "promql":  [
+                                                     {
+                                                         "disabled":  false,
+                                                         "legend":  "",
+                                                         "name":  "A",
+                                                         "query":  "sum(rate(envoy_cluster_upstream_cx_total{service_name=~\"$service.name\", namespace=~\"$namespace\", deployment_environment=~\"$deployment.environment\", cluster=~\"$cluster\"}[5m]))"
+                                                     }
+                                                 ],
+                                      "queryType":  "promql"
+                                  },
+                        "selectedLogFields":  [
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "body",
+                                                      "type":  ""
+                                                  },
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "timestamp",
+                                                      "type":  ""
+                                                  }
+                                              ],
+                        "selectedTracesFields":  [
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "serviceName--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "serviceName",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "name--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "name",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "float64",
+                                                         "id":  "durationNano--float64--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "durationNano",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "httpMethod--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "httpMethod",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "responseStatusCode--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "responseStatusCode",
+                                                         "type":  "tag"
+                                                     }
+                                                 ],
+                        "softMax":  0,
+                        "softMin":  0,
+                        "stackedBarChart":  false,
+                        "thresholds":  [
+
+                                       ],
+                        "timePreferance":  "GLOBAL_TIME",
+                        "title":  "Connection Rate",
+                        "yAxisUnit":  "none"
+                    },
+                    {
+                        "bucketCount":  30,
+                        "bucketWidth":  0,
+                        "columnUnits":  {
+
+                                        },
+                        "description":  "Number of connection attempts rejected by Envoy.",
+                        "fillSpans":  false,
+                        "id":  "203721b2-697c-457d-87d5-cee8116a1571",
+                        "isStacked":  false,
+                        "mergeAllActiveQueries":  false,
+                        "nullZeroValues":  "zero",
+                        "opacity":  "1",
+                        "panelTypes":  "value",
+                        "query":  {
+                                      "builder":  {
+                                                      "queryData":  [
+
+                                                                    ],
+                                                      "queryFormulas":  [
+
+                                                                        ]
+                                                  },
+                                      "clickhouse_sql":  [
+                                                             {
+                                                                 "disabled":  false,
+                                                                 "legend":  "",
+                                                                 "name":  "A",
+                                                                 "query":  ""
+                                                             }
+                                                         ],
+                                      "id":  "6aa7239f-07ec-4989-8760-5e0269159fde",
+                                      "promql":  [
+                                                     {
+                                                         "disabled":  false,
+                                                         "legend":  "",
+                                                         "name":  "A",
+                                                         "query":  "sum(rate(envoy_cluster_upstream_cx_connect_fail{service_name=~\"$service.name\", namespace=~\"$namespace\", deployment_environment=~\"$deployment.environment\", cluster=~\"$cluster\"}[5m])) + sum(rate(envoy_cluster_upstream_cx_connect_timeout{service_name=~\"$service.name\", namespace=~\"$namespace\", deployment_environment=~\"$deployment.environment\", cluster=~\"$cluster\"}[5m]))"
+                                                     }
+                                                 ],
+                                      "queryType":  "promql"
+                                  },
+                        "selectedLogFields":  [
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "body",
+                                                      "type":  ""
+                                                  },
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "timestamp",
+                                                      "type":  ""
+                                                  }
+                                              ],
+                        "selectedTracesFields":  [
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "serviceName--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "serviceName",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "name--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "name",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "float64",
+                                                         "id":  "durationNano--float64--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "durationNano",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "httpMethod--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "httpMethod",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "responseStatusCode--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "responseStatusCode",
+                                                         "type":  "tag"
+                                                     }
+                                                 ],
+                        "softMax":  0,
+                        "softMin":  0,
+                        "stackedBarChart":  false,
+                        "thresholds":  [
+
+                                       ],
+                        "timePreferance":  "GLOBAL_TIME",
+                        "title":  "Rejected Connections",
+                        "yAxisUnit":  "none"
+                    },
+                    {
+                        "bucketCount":  30,
+                        "bucketWidth":  0,
+                        "columnUnits":  {
+
+                                        },
+                        "description":  "Number of requests forwarded to upstream services.",
+                        "fillSpans":  false,
+                        "id":  "90a010f9-862f-469a-a0fa-1d9c17ac163e",
+                        "isStacked":  false,
+                        "mergeAllActiveQueries":  false,
+                        "nullZeroValues":  "zero",
+                        "opacity":  "1",
+                        "panelTypes":  "graph",
+                        "query":  {
+                                      "builder":  {
+                                                      "queryData":  [
+
+                                                                    ],
+                                                      "queryFormulas":  [
+
+                                                                        ]
+                                                  },
+                                      "clickhouse_sql":  [
+                                                             {
+                                                                 "disabled":  false,
+                                                                 "legend":  "",
+                                                                 "name":  "A",
+                                                                 "query":  ""
+                                                             }
+                                                         ],
+                                      "id":  "0bf9acf1-2e96-426d-929e-6d60f5ab83d0",
+                                      "promql":  [
+                                                     {
+                                                         "disabled":  false,
+                                                         "legend":  "{{envoy_cluster_name}}",
+                                                         "name":  "A",
+                                                         "query":  "sum(rate(envoy_cluster_upstream_rq_total{service_name=~\"$service.name\", namespace=~\"$namespace\", deployment_environment=~\"$deployment.environment\", cluster=~\"$cluster\"}[5m])) by (envoy_cluster_name)"
+                                                     }
+                                                 ],
+                                      "queryType":  "promql"
+                                  },
+                        "selectedLogFields":  [
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "body",
+                                                      "type":  ""
+                                                  },
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "timestamp",
+                                                      "type":  ""
+                                                  }
+                                              ],
+                        "selectedTracesFields":  [
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "serviceName--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "serviceName",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "name--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "name",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "float64",
+                                                         "id":  "durationNano--float64--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "durationNano",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "httpMethod--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "httpMethod",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "responseStatusCode--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "responseStatusCode",
+                                                         "type":  "tag"
+                                                     }
+                                                 ],
+                        "softMax":  0,
+                        "softMin":  0,
+                        "stackedBarChart":  false,
+                        "thresholds":  [
+
+                                       ],
+                        "timePreferance":  "GLOBAL_TIME",
+                        "title":  "Upstream Request Count",
+                        "yAxisUnit":  "none"
+                    },
+                    {
+                        "bucketCount":  30,
+                        "bucketWidth":  0,
+                        "columnUnits":  {
+
+                                        },
+                        "description":  "Rate of errors returned by upstream services.",
+                        "fillSpans":  false,
+                        "id":  "6d29c494-0d60-472b-80bb-c1a3ea37391b",
+                        "isStacked":  false,
+                        "mergeAllActiveQueries":  false,
+                        "nullZeroValues":  "zero",
+                        "opacity":  "1",
+                        "panelTypes":  "graph",
+                        "query":  {
+                                      "builder":  {
+                                                      "queryData":  [
+
+                                                                    ],
+                                                      "queryFormulas":  [
+
+                                                                        ]
+                                                  },
+                                      "clickhouse_sql":  [
+                                                             {
+                                                                 "disabled":  false,
+                                                                 "legend":  "",
+                                                                 "name":  "A",
+                                                                 "query":  ""
+                                                             }
+                                                         ],
+                                      "id":  "782c088d-df3c-4b01-b9eb-2a9f0f9e5ba9",
+                                      "promql":  [
+                                                     {
+                                                         "disabled":  false,
+                                                         "legend":  "{{envoy_cluster_name}}",
+                                                         "name":  "A",
+                                                         "query":  "sum(rate(envoy_cluster_upstream_rq_xx{service_name=~\"$service.name\", namespace=~\"$namespace\", deployment_environment=~\"$deployment.environment\", cluster=~\"$cluster\", envoy_response_code_class=~\"4|5\"}[5m])) by (envoy_cluster_name)"
+                                                     }
+                                                 ],
+                                      "queryType":  "promql"
+                                  },
+                        "selectedLogFields":  [
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "body",
+                                                      "type":  ""
+                                                  },
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "timestamp",
+                                                      "type":  ""
+                                                  }
+                                              ],
+                        "selectedTracesFields":  [
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "serviceName--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "serviceName",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "name--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "name",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "float64",
+                                                         "id":  "durationNano--float64--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "durationNano",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "httpMethod--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "httpMethod",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "responseStatusCode--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "responseStatusCode",
+                                                         "type":  "tag"
+                                                     }
+                                                 ],
+                        "softMax":  0,
+                        "softMin":  0,
+                        "stackedBarChart":  false,
+                        "thresholds":  [
+
+                                       ],
+                        "timePreferance":  "GLOBAL_TIME",
+                        "title":  "Upstream Error Rate",
+                        "yAxisUnit":  "none"
+                    },
+                    {
+                        "bucketCount":  30,
+                        "bucketWidth":  0,
+                        "columnUnits":  {
+
+                                        },
+                        "description":  "Distribution of requests from different downstream clients.",
+                        "fillSpans":  false,
+                        "id":  "e8545106-f988-4c6d-84ca-f91d1faf93f0",
+                        "isStacked":  false,
+                        "mergeAllActiveQueries":  false,
+                        "nullZeroValues":  "zero",
+                        "opacity":  "1",
+                        "panelTypes":  "pie",
+                        "query":  {
+                                      "builder":  {
+                                                      "queryData":  [
+
+                                                                    ],
+                                                      "queryFormulas":  [
+
+                                                                        ]
+                                                  },
+                                      "clickhouse_sql":  [
+                                                             {
+                                                                 "disabled":  false,
+                                                                 "legend":  "",
+                                                                 "name":  "A",
+                                                                 "query":  ""
+                                                             }
+                                                         ],
+                                      "id":  "d57b13dc-4305-4a18-a968-268946813b5a",
+                                      "promql":  [
+                                                     {
+                                                         "disabled":  false,
+                                                         "legend":  "{{envoy_http_conn_manager_prefix}}",
+                                                         "name":  "A",
+                                                         "query":  "sum(rate(envoy_http_downstream_rq_total{service_name=~\"$service.name\", namespace=~\"$namespace\", deployment_environment=~\"$deployment.environment\", cluster=~\"$cluster\"}[5m])) by (envoy_http_conn_manager_prefix)"
+                                                     }
+                                                 ],
+                                      "queryType":  "promql"
+                                  },
+                        "selectedLogFields":  [
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "body",
+                                                      "type":  ""
+                                                  },
+                                                  {
+                                                      "dataType":  "string",
+                                                      "name":  "timestamp",
+                                                      "type":  ""
+                                                  }
+                                              ],
+                        "selectedTracesFields":  [
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "serviceName--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "serviceName",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "name--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "name",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "float64",
+                                                         "id":  "durationNano--float64--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "durationNano",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "httpMethod--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "httpMethod",
+                                                         "type":  "tag"
+                                                     },
+                                                     {
+                                                         "dataType":  "string",
+                                                         "id":  "responseStatusCode--string--tag--true",
+                                                         "isColumn":  true,
+                                                         "isJSON":  false,
+                                                         "key":  "responseStatusCode",
+                                                         "type":  "tag"
+                                                     }
+                                                 ],
+                        "softMax":  0,
+                        "softMin":  0,
+                        "stackedBarChart":  false,
+                        "thresholds":  [
+
+                                       ],
+                        "timePreferance":  "GLOBAL_TIME",
+                        "title":  "Downstream Request Distribution",
+                        "yAxisUnit":  "none"
+                    }
+                ]
+}

--- a/envoy/readme.md
+++ b/envoy/readme.md
@@ -1,0 +1,113 @@
+# Envoy Dashboard - OTLP
+
+## Metrics Ingestion
+
+To emit OpenTelemetry metrics from Envoy you must enable the [OpenTelemetry stat sink](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/stat_sinks/open_telemetry_stat_sink). A minimal static bootstrap example that ships metrics to an OpenTelemetry Collector running at `otel-collector:4317` looks like this:
+
+```yaml
+stats_sinks:
+  - name: envoy.stat_sinks.open_telemetry
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.stat_sinks.open_telemetry.v3.SinkConfig
+      grpc_service:
+        envoy_grpc:
+          cluster_name: otel-collector
+static_resources:
+  clusters:
+    - name: otel-collector
+      type: STRICT_DNS
+      connect_timeout: 1s
+      load_assignment:
+        cluster_name: otel-collector
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: otel-collector
+                      port_value: 4317
+```
+
+On the SigNoz side you only need an OTLP receiver. The snippet below extends the default SigNoz Collector configuration to fan-in Envoy metrics:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  batch: {}
+
+exporters:
+  clickhouse: {}
+
+service:
+  pipelines:
+    metrics/standard:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [clickhouse]
+```
+
+Envoy’s stat names (for example `downstream_cx_active`, `downstream_rq_time`, `upstream_rq_total`, etc.) become OpenTelemetry metrics prefixed with the component that reported them, such as `envoy_http_downstream_cx_active` or `envoy_cluster_upstream_rq_total`. Refer to the [HTTP connection manager](https://www.envoyproxy.io/docs/envoy/latest/_sources/configuration/http/http_conn_man/stats.rst.txt) and [cluster manager](https://www.envoyproxy.io/docs/envoy/latest/_sources/configuration/upstream/cluster_manager/cluster_stats.rst.txt) statistics tables for the full catalogue.
+
+## Variables
+
+The dashboard exposes four resource-scoped variables so that the same template works across multi-tenant environments:
+
+- `namespace`: Kubernetes namespace (maps to `k8s.namespace.name`).
+- `deployment.environment`: Logical environment tag (`deployment.environment`).
+- `service.name`: OpenTelemetry service name reported by Envoy.
+- `cluster`: Cluster identifier (for example `prod-eu` or `staging`).
+
+Set each variable to `.*` to view aggregate metrics across all values or narrow the scope with an exact match/regex.
+
+## Sections & Panels
+
+### General Overview
+- **Active Connections** – `sum(envoy_http_downstream_cx_active)`
+- **Total Requests** – `sum(envoy_http_downstream_rq_total)`
+- **Request Rate** – `sum(rate(envoy_http_downstream_rq_total[5m]))` grouped by `envoy_http_conn_manager_prefix`
+- **Uptime** – `max(envoy_server_uptime)`
+
+### Request Metrics
+- **HTTP Request Throughput** – `sum(rate(envoy_http_downstream_rq_total[5m]))`
+- **Ingress Bytes** – `sum(rate(envoy_http_downstream_cx_rx_bytes_total[5m]))`
+- **Average Response Size** – `sum(rate(envoy_http_downstream_cx_tx_bytes_total[5m])) / sum(rate(envoy_http_downstream_rq_total[5m]))`
+
+### Response Metrics
+- **Response Code Class Breakdown** – `sum(rate(envoy_http_downstream_rq_xx[5m]))` by `envoy_response_code_class`
+- **Average Response Time per Listener** – `sum(rate(envoy_http_downstream_rq_time_sum[5m])) / sum(rate(envoy_http_downstream_rq_time_count[5m]))`
+- **Latency Histogram (LE buckets)** – `sum(rate(envoy_http_downstream_rq_time_bucket[5m]))` by `le`
+
+### Latency Metrics
+- **Overall Mean Latency** – same ratio of `_sum` to `_count`
+- **P95 Latency by Listener** – `histogram_quantile(0.95, rate(envoy_http_downstream_rq_time_bucket[5m]))`
+- **Downstream Distribution** – pie chart of `rate(envoy_http_downstream_rq_total[5m])` grouped by `envoy_http_conn_manager_prefix`
+
+### Error Metrics
+- **Total 4xx/5xx Errors** – `sum(envoy_http_downstream_rq_xx{envoy_response_code_class=~"4|5"})`
+- **Error Rate by Class** – `sum(rate(envoy_http_downstream_rq_xx{envoy_response_code_class=~"4|5"}[5m]))`
+
+### Resource Usage
+- **CPU Seconds / s** – `rate(process_cpu_seconds_total[5m])`
+- **Allocated Memory** – `max(envoy_server_memory_allocated)`
+- **Disk I/O Bytes / s** – host metrics `container_fs_reads_bytes_total` + `container_fs_writes_bytes_total` (scope to Envoy workload)
+
+### Network I/O
+- **Upstream Throughput** – `rate(envoy_cluster_upstream_cx_tx_bytes_total[5m]) + rate(envoy_cluster_upstream_cx_rx_bytes_total[5m])`
+- **Connection Establish Rate** – `sum(rate(envoy_cluster_upstream_cx_total[5m]))`
+- **Rejected Connections** – `rate(envoy_cluster_upstream_cx_connect_fail[5m]) + rate(envoy_cluster_upstream_cx_connect_timeout[5m])`
+
+### Upstream & Downstream
+- **Upstream Request Volume** – `sum(rate(envoy_cluster_upstream_rq_total[5m]))` by `envoy_cluster_name`
+- **Upstream Error Rate** – `sum(rate(envoy_cluster_upstream_rq_xx{envoy_response_code_class=~"4|5"}[5m]))` by `envoy_cluster_name`
+- **Downstream Distribution** – mirrored pie/table from latency section
+
+> Note:    All queries automatically inherit the four dashboard variables so the template can be dropped into any SigNoz tenant without manual rewiring.
+
+
+
+


### PR DESCRIPTION
## Summary
- add an Envoy monitoring dashboard that uses OTLP metrics for general, request/response, latency, error, resource and network views
- wire namespace, deployment.environment, service.name and cluster variables into every panel so the dashboard is reusable across environments
- document the ingestion prerequisites for Envoy’s OpenTelemetry stat sink and the dashboard variables

## Testing
- python -m json.tool envoy/envoy-otlp-v1.json

Closes SigNoz/signoz#6020
/claim #6020
