### PR TITLE
Add NATS Monitoring Dashboard for SigNoz

### DIFF
--- a/nats-dashboard/nats-signoz-dashboard.json
+++ b/nats-dashboard/nats-signoz-dashboard.json
@@ -1,0 +1,313 @@
+{
+  "createdAt": "2025-11-20T07:36:04.31696Z",
+  "description": "Full NATS server monitoring dashboard",
+  "id": "019aa031-full-nats-dashboard",
+  "lastUpdatedTime": "2025-11-20T07:36:05.03643Z",
+  "name": "NATS Full Monitoring",
+  "tags": ["nats", "messaging", "platform"],
+  "key": "019aa031-full-nats-dashboard",
+  "createdBy": "system",
+  "isLocked": false,
+  "lastUpdatedBy": "system",
+  "widgets": [
+    {
+      "id": "1",
+      "panelTypes": "graph",
+      "title": "Active Connections",
+      "queryType": "builder",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "nats_connz_num_connections",
+                  "spaceAggregation": "avg",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "groupBy": [],
+              "legend": "Connections",
+              "queryName": "A"
+            }
+          ],
+          "queryFormulas": []
+        }
+      }
+    },
+    {
+      "id": "2",
+      "panelTypes": "value",
+      "title": "Total Subscriptions",
+      "queryType": "builder",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "nats_connz_subscriptions",
+                  "spaceAggregation": "sum",
+                  "timeAggregation": "sum"
+                }
+              ],
+              "dataSource": "metrics",
+              "groupBy": [],
+              "legend": "Subscriptions",
+              "queryName": "A"
+            }
+          ],
+          "queryFormulas": []
+        }
+      }
+    },
+    {
+      "id": "3",
+      "panelTypes": "graph",
+      "title": "Message Rate",
+      "queryType": "builder",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "nats_connz_in_msgs",
+                  "spaceAggregation": "sum",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "legend": "In Msg/s",
+              "queryName": "A"
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "nats_connz_out_msgs",
+                  "spaceAggregation": "sum",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "legend": "Out Msg/s",
+              "queryName": "B"
+            }
+          ],
+          "queryFormulas": []
+        }
+      }
+    },
+    {
+      "id": "4",
+      "panelTypes": "graph",
+      "title": "Bytes Rate",
+      "queryType": "builder",
+      "yAxisUnit": "Bps",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "nats_connz_in_bytes",
+                  "spaceAggregation": "sum",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "legend": "In Bytes/s",
+              "queryName": "A"
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "nats_connz_out_bytes",
+                  "spaceAggregation": "sum",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "legend": "Out Bytes/s",
+              "queryName": "B"
+            }
+          ],
+          "queryFormulas": []
+        }
+      }
+    },
+    {
+      "id": "5",
+      "panelTypes": "value",
+      "title": "Resident Memory",
+      "yAxisUnit": "bytes",
+      "queryType": "builder",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "process_resident_memory_bytes",
+                  "spaceAggregation": "avg",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "legend": "Memory",
+              "queryName": "A"
+            }
+          ],
+          "queryFormulas": []
+        }
+      }
+    },
+    {
+      "id": "6",
+      "panelTypes": "graph",
+      "title": "CPU Usage",
+      "yAxisUnit": "percent",
+      "queryType": "builder",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "process_cpu_seconds_total",
+                  "spaceAggregation": "sum",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "legend": "CPU %",
+              "queryName": "A"
+            }
+          ],
+          "queryFormulas": [
+            {
+              "expression": "A * 100 / max(A)",
+              "legend": "CPU %",
+              "disabled": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "7",
+      "panelTypes": "value",
+      "title": "JetStream Streams",
+      "queryType": "builder",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "nats_jsz_streams",
+                  "spaceAggregation": "sum",
+                  "timeAggregation": "sum"
+                }
+              ],
+              "dataSource": "metrics",
+              "legend": "Streams",
+              "queryName": "A"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "8",
+      "panelTypes": "value",
+      "title": "JetStream Consumers",
+      "queryType": "builder",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "nats_jsz_consumers",
+                  "spaceAggregation": "sum",
+                  "timeAggregation": "sum"
+                }
+              ],
+              "dataSource": "metrics",
+              "legend": "Consumers",
+              "queryName": "A"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "9",
+      "panelTypes": "graph",
+      "title": "JetStream Storage",
+      "yAxisUnit": "bytes",
+      "queryType": "builder",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "nats_jsz_storage",
+                  "spaceAggregation": "sum",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "legend": "Storage",
+              "queryName": "A"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "10",
+      "panelTypes": "graph",
+      "title": "Latency",
+      "yAxisUnit": "ms",
+      "queryType": "builder",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "nats_latency",
+                  "spaceAggregation": "avg",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "legend": "Latency",
+              "queryName": "A"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "layout": [
+    { "i": "1", "x": 0, "y": 0, "w": 6, "h": 3 },
+    { "i": "2", "x": 6, "y": 0, "w": 6, "h": 3 },
+    { "i": "3", "x": 0, "y": 3, "w": 12, "h": 4 },
+    { "i": "4", "x": 0, "y": 7, "w": 12, "h": 4 },
+    { "i": "5", "x": 0, "y": 11, "w": 6, "h": 3 },
+    { "i": "6", "x": 6, "y": 11, "w": 6, "h": 3 },
+    { "i": "7", "x": 0, "y": 14, "w": 4, "h": 3 },
+    { "i": "8", "x": 4, "y": 14, "w": 4, "h": 3 },
+    { "i": "9", "x": 8, "y": 14, "w": 4, "h": 3 },
+    { "i": "10", "x": 0, "y": 17, "w": 12, "h": 4 }
+  ],
+  "panelMap": {},
+  "version": "v5",
+  "title": "NATS Full Monitoring"
+}
+


### PR DESCRIPTION
### Summary
This PR introduces a complete NATS Monitoring Dashboard for SigNoz.  
It includes metrics for NATS Core, JetStream, and the Prometheus exporter.

### Features Included
- NATS server health (connections, routes, subscriptions, slow consumers)
- JetStream storage metrics (streams, consumers, bytes, messages)
- Stream and consumer lag visualization
- Top connections and subscriptions
- Process metrics (CPU, memory, GC)
- Exporter metrics (scrape errors, promhttp stats)

### Use Case
This dashboard helps SRE and platform teams monitor the health and performance  
of the NATS messaging system deployed on Kubernetes.

### Additional Notes
- Designed to work with the NATS Prometheus Exporter on port `7777`
- Compatible with SigNoz PromQL
- Can be extended with alert rules (available on request)

Please review and merge.


NOTE: Once the dashboard is imported, open every panel, select Edit, and then Save Changes.
This action refreshes the queries and all panels will display data.
Its working for me