### PR TITLE
Add AWS MSK dashboard - OTLP v1

### DIFF
--- a/aws-msk/README.md
+++ b/aws-msk/README.md
@@ -1,0 +1,42 @@
+# AWS MSK Dashboard - OTLP
+
+This dashboard covers Amazon MSK cluster health, broker connectivity, topic traffic, and storage pressure using CloudWatch-backed metrics ingested into SigNoz.
+
+## Metrics Ingestion
+
+Follow SigNoz's Amazon MSK integration guide:
+
+- https://signoz.io/docs/aws-monitoring/msk/
+
+AWS metric semantics and monitoring levels are documented here:
+
+- https://docs.aws.amazon.com/msk/latest/developerguide/metrics-details.html
+- https://docs.aws.amazon.com/msk/latest/developerguide/cloudwatch-metrics.html
+
+To populate all topic and broker level panels in this dashboard, enable enhanced monitoring at least at `PER_TOPIC_PER_BROKER`.
+
+## Variables
+
+- `{{cluster_name}}`: Amazon MSK cluster name
+- `{{broker_id}}`: Broker ID within the selected cluster
+- `{{topic}}`: Kafka topic within the selected cluster
+
+## Dashboard Panels
+
+- `ActiveControllerCount` - cluster controller health
+- `GlobalPartitionCount` - total partitions across the cluster
+- `OfflinePartitionsCount` - partitions currently offline
+- `UnderReplicatedPartitions` - replication health indicator
+- `ConnectionCount by Broker` - total active broker connections
+- `ClientConnectionCount by Broker` - authenticated client connections
+- `BytesInPerSec by Broker` - broker ingress throughput
+- `BytesOutPerSec by Broker` - broker egress throughput
+- `MessagesInPerSec by Topic` - topic ingest rate
+- `PartitionCount by Topic` - partition fanout by topic
+- `KafkaDataLogsDiskUsed by Broker` - broker log storage usage
+- `BurstBalance by Broker` - remaining EBS burst credits
+
+## Notes
+
+- This dashboard assumes CloudWatch metrics are ingested into SigNoz with metric names normalized under the `aws_kafka_*` prefix, consistent with SigNoz's existing AWS dashboard templates.
+- Some Amazon MSK metrics appear only after traffic becomes non-zero for the first time.

--- a/aws-msk/aws-msk-otlp-v1.json
+++ b/aws-msk/aws-msk-otlp-v1.json
@@ -1,0 +1,2060 @@
+{
+  "id": "aws_msk_otlp_v1",
+  "description": "AWS MSK dashboard built from CloudWatch-backed metrics ingested into SigNoz.",
+  "layout": [
+    {
+      "h": 5,
+      "i": "1706ba93-e20f-49f6-8637-f58e6affc8f0",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 5,
+      "i": "4fa4bb0c-70e1-45e9-a148-02c044428778",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 0
+    },
+    {
+      "h": 5,
+      "i": "c778b296-7a52-451e-aba6-7581a5d27b4e",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 5
+    },
+    {
+      "h": 5,
+      "i": "e16a5bab-4f85-4ae9-b5a9-771105fe0c5a",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 5
+    },
+    {
+      "h": 5,
+      "i": "5b914703-6849-4c7e-8f93-d07451d6ac66",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 10
+    },
+    {
+      "h": 5,
+      "i": "2885951c-a6ff-4dd5-9fc3-bfce9c3b1a29",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 10
+    },
+    {
+      "h": 5,
+      "i": "e378b44d-b948-4527-ab66-8c013dc01e11",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 15
+    },
+    {
+      "h": 5,
+      "i": "5a8e1eb0-e7d3-424c-a835-fbb72b91d150",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 15
+    },
+    {
+      "h": 5,
+      "i": "5d940283-38b4-4ef0-966f-fc71d255a12c",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 20
+    },
+    {
+      "h": 5,
+      "i": "3831c9ff-4096-484c-b1a4-8a307c9a578f",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 20
+    },
+    {
+      "h": 5,
+      "i": "fe6a64d8-632e-40e0-a63e-54f5be440b59",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 25
+    },
+    {
+      "h": 5,
+      "i": "fccbe753-9f4e-4d54-8b26-5244dba6566a",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 25
+    }
+  ],
+  "panelMap": {},
+  "tags": [
+    "aws",
+    "msk",
+    "kafka"
+  ],
+  "title": "AWS MSK - OTLP",
+  "uploadedGrafana": false,
+  "uuid": "9dc2faec-c4ba-41de-ac6c-4e4d9ceec5db",
+  "variables": {
+    "66cc2985-aa67-4635-a522-6d75347e984e": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "Select the MSK cluster",
+      "id": "66cc2985-aa67-4635-a522-6d75347e984e",
+      "modificationUUID": "87447709-03ae-499b-b7c9-5ee836a0c81b",
+      "multiSelect": false,
+      "name": "cluster_name",
+      "order": 0,
+      "queryValue": "SELECT JSONExtractString(labels, 'cluster_name') as cluster_name\nFROM signoz_metrics.distributed_time_series_v4_1day\nWHERE metric_name = 'aws_kafka_active_controller_count_average'\nGROUP BY cluster_name",
+      "selectedValue": "",
+      "showALLOption": false,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "d6b00a6c-154c-4d97-beea-b95162d09638": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "Select one or more brokers",
+      "id": "d6b00a6c-154c-4d97-beea-b95162d09638",
+      "modificationUUID": "a598ea10-6eab-4e6a-834c-22930aa91d9c",
+      "multiSelect": true,
+      "name": "broker_id",
+      "order": 1,
+      "queryValue": "SELECT JSONExtractString(labels, 'broker_id') as broker_id\nFROM signoz_metrics.distributed_time_series_v4_1day\nWHERE metric_name = 'aws_kafka_connection_count_average'\n  AND JSONExtractString(labels, 'cluster_name') = '{{.cluster_name}}'\nGROUP BY broker_id",
+      "selectedValue": [],
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "69166b65-c245-4484-9253-f9313f9b1e00": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "Select one or more topics",
+      "id": "69166b65-c245-4484-9253-f9313f9b1e00",
+      "modificationUUID": "616552b4-2c7b-4972-9e6f-8477e754e3d0",
+      "multiSelect": true,
+      "name": "topic",
+      "order": 2,
+      "queryValue": "SELECT JSONExtractString(labels, 'topic') as topic\nFROM signoz_metrics.distributed_time_series_v4_1day\nWHERE metric_name = 'aws_kafka_messages_in_per_sec_average'\n  AND JSONExtractString(labels, 'cluster_name') = '{{.cluster_name}}'\nGROUP BY topic",
+      "selectedValue": [],
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "version": "v4",
+  "widgets": [
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Only one controller per cluster should be active at any given time.",
+      "fillSpans": false,
+      "id": "1706ba93-e20f-49f6-8637-f58e6affc8f0",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_active_controller_count_average--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_active_controller_count_average",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "3a854365",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a04ec915-144a-4d12-ba62-340cba2d0817",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "ActiveControllerCount",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total partition count across the selected MSK cluster.",
+      "fillSpans": false,
+      "id": "4fa4bb0c-70e1-45e9-a148-02c044428778",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_global_partition_count_average--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_global_partition_count_average",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f0164f00",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "716fa4c8-4cca-4adb-aa13-aba2c9a468b4",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "GlobalPartitionCount",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Offline partitions should remain at zero under normal cluster health.",
+      "fillSpans": false,
+      "id": "c778b296-7a52-451e-aba6-7581a5d27b4e",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_offline_partitions_count_average--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_offline_partitions_count_average",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d45a77e1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "04a90fb9-e8bb-4539-87af-35cd21d1d59e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "OfflinePartitionsCount",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Under-replicated partitions indicate replication lag or broker stress.",
+      "fillSpans": false,
+      "id": "e16a5bab-4f85-4ae9-b5a9-771105fe0c5a",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_under_replicated_partitions_average--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_under_replicated_partitions_average",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "ea29aff8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "4a1683c3-4c62-4186-b21b-3ecd05eefd55",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "UnderReplicatedPartitions",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Active authenticated, unauthenticated, and inter-broker connections per broker.",
+      "fillSpans": false,
+      "id": "5b914703-6849-4c7e-8f93-d07451d6ac66",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_connection_count_average--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_connection_count_average",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "e73e2281",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "39d0e767",
+                    "key": {
+                      "dataType": "string",
+                      "id": "broker_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "broker_id",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.broker_id}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "broker_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "broker_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{broker_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9ccbcdd9-c244-4d38-b7fb-30da996743f0",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "ConnectionCount by Broker",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Active authenticated client connections grouped by broker.",
+      "fillSpans": false,
+      "id": "2885951c-a6ff-4dd5-9fc3-bfce9c3b1a29",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_client_connection_count_average--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_client_connection_count_average",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "68cb28a4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "db605241",
+                    "key": {
+                      "dataType": "string",
+                      "id": "broker_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "broker_id",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.broker_id}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "broker_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "broker_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{broker_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6146532d-ea5a-49aa-a621-0e8886123188",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "ClientConnectionCount by Broker",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Incoming bytes per second handled by each selected broker.",
+      "fillSpans": false,
+      "id": "e378b44d-b948-4527-ab66-8c013dc01e11",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_bytes_in_per_sec_average--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_bytes_in_per_sec_average",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "ebb8f3d9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "26c0fab5",
+                    "key": {
+                      "dataType": "string",
+                      "id": "broker_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "broker_id",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.broker_id}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "broker_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "broker_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{broker_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "3d8f42af-913d-4a24-a2b1-b4895ff245a2",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "BytesInPerSec by Broker",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Outgoing bytes per second served by each selected broker.",
+      "fillSpans": false,
+      "id": "5a8e1eb0-e7d3-424c-a835-fbb72b91d150",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_bytes_out_per_sec_average--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_bytes_out_per_sec_average",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "77c7b173",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "d70a8834",
+                    "key": {
+                      "dataType": "string",
+                      "id": "broker_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "broker_id",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.broker_id}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "broker_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "broker_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{broker_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6c8118c4-9026-417b-8599-d800d5c6ce12",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "BytesOutPerSec by Broker",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Incoming messages per second across selected topics in the cluster.",
+      "fillSpans": false,
+      "id": "5d940283-38b4-4ef0-966f-fc71d255a12c",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_messages_in_per_sec_average--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_messages_in_per_sec_average",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b088374d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "f4d0c388",
+                    "key": {
+                      "dataType": "string",
+                      "id": "topic--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "topic",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.topic}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "topic--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "topic",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{topic}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f66f3f03-f4db-480f-84e6-842213202cf9",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "MessagesInPerSec by Topic",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Per-topic partition count for the selected MSK cluster.",
+      "fillSpans": false,
+      "id": "3831c9ff-4096-484c-b1a4-8a307c9a578f",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_partition_count_average--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_partition_count_average",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "4bf2a82c",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "f48a8585",
+                    "key": {
+                      "dataType": "string",
+                      "id": "topic--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "topic",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.topic}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "topic--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "topic",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{topic}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a0368ff7-5959-4bc6-ae75-8ff2367e3333",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "PartitionCount by Topic",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Broker log disk usage helps catch storage pressure before a cluster degrades.",
+      "fillSpans": false,
+      "id": "fe6a64d8-632e-40e0-a63e-54f5be440b59",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_kafka_data_logs_disk_used_average--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_kafka_data_logs_disk_used_average",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "207ee14c",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "31fdf3d0",
+                    "key": {
+                      "dataType": "string",
+                      "id": "broker_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "broker_id",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.broker_id}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "broker_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "broker_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{broker_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a29ee602-6589-4740-bf78-b36e61cdd51d",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "KafkaDataLogsDiskUsed by Broker",
+      "yAxisUnit": "decbytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Remaining EBS burst balance for brokers. Low values often precede throughput issues.",
+      "fillSpans": false,
+      "id": "fccbe753-9f4e-4d54-8b26-5244dba6566a",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_burst_balance_average--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_burst_balance_average",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d2b18d05",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "0d4a03d6",
+                    "key": {
+                      "dataType": "string",
+                      "id": "broker_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "broker_id",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.broker_id}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "broker_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "broker_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{broker_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0847bd4c-6598-4fa0-be0a-5c061e6a1011",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "BurstBalance by Broker",
+      "yAxisUnit": "percent"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

  Adds a new AWS MSK dashboard template for SigNoz.

  This dashboard includes panels for:
  - ActiveControllerCount
  - GlobalPartitionCount
  - OfflinePartitionsCount
  - UnderReplicatedPartitions
  - ConnectionCount by Broker
  - ClientConnectionCount by Broker
  - BytesInPerSec by Broker
  - BytesOutPerSec by Broker
  - MessagesInPerSec by Topic
  - PartitionCount by Topic
  - KafkaDataLogsDiskUsed by Broker
  - BurstBalance by Broker

  ## Files added

  - `aws-msk/aws-msk-otlp-v1.json`
  - `aws-msk/README.md`

  ## Notes

  - Built around CloudWatch-backed Amazon MSK metrics ingested into SigNoz
  - Topic and broker-level panels assume enhanced monitoring is enabled at least at `PER_TOPIC_PER_BROKER`
  - README includes setup references for SigNoz and AWS MSK metrics documentation

  Closes https://github.com/SigNoz/signoz/issues/6036