### PR TITLE
Add Kong Gateway monitoring dashboard

### DIFF
--- a/kong/README.md
+++ b/kong/README.md
@@ -1,0 +1,87 @@
+# Kong Gateway Dashboard
+
+Monitor your Kong API Gateway with this dashboard. Shows requests, latency, errors, and resource usage.
+
+## What's Included
+
+- Total request counter
+- Active connections
+- Request rate over time
+- HTTP status code breakdown
+- Latency tracking (average and percentiles)
+- Error rate percentage
+- Network bandwidth (in/out)
+- CPU and memory usage
+- Pod restart count
+
+## Setup
+
+### 1. Enable Kong Prometheus Plugin
+
+```bash
+curl -X POST http://localhost:8001/plugins \
+  --data "name=prometheus"
+```
+
+### 2. Configure Prometheus
+
+Add this to your prometheus.yml:
+
+```yaml
+scrape_configs:
+  - job_name: 'kong'
+    static_configs:
+      - targets: ['kong-admin:8001']
+    metrics_path: '/metrics'
+```
+
+### 3. Import Dashboard
+
+1. Open SigNoz
+2. Go to Dashboards
+3. Click Import
+4. Upload overview.json
+5. Select your namespace
+
+## Metrics Used
+
+The dashboard uses these Kong metrics:
+
+- `kong_http_requests_total` - Total HTTP requests
+- `kong_http_status` - Response status codes
+- `kong_latency_ms` - Request latency
+- `kong_bandwidth_bytes` - Traffic volume
+- `kong_nginx_connections_active` - Active connections
+- `container_cpu_usage_seconds_total` - CPU usage
+- `container_memory_usage_bytes` - Memory usage
+- `kube_pod_container_status_restarts_total` - Pod restarts
+
+## Dashboard Variables
+
+- **namespace**: Kubernetes namespace where Kong runs
+- **service**: Filter by specific Kong service (optional)
+
+## Testing
+
+To test if metrics are working:
+
+```bash
+# Check Kong metrics endpoint
+curl http://localhost:8001/metrics
+
+# Look for these metrics:
+# kong_http_requests_total
+# kong_nginx_connections_active
+# kong_latency_ms
+```
+
+## References
+
+- Kong Prometheus Plugin: https://docs.konghq.com/hub/kong-inc/prometheus/
+- Kong OpenTelemetry: https://docs.konghq.com/mesh/latest/guides/otel-metrics/
+
+## Notes
+
+Make sure your Kong instance has the Prometheus plugin enabled. The CPU and memory metrics require Kubernetes deployment.
+
+Created for SigNoz issue #6028.

--- a/kong/overview.json
+++ b/kong/overview.json
@@ -1,0 +1,127 @@
+{
+  "title": "Kong Gateway",
+  "description": "Kong API Gateway monitoring dashboard with request metrics, latency, errors and resource usage",
+  "tags": ["kong", "api-gateway", "kubernetes"],
+  "version": "1.0.0",
+  "variables": {
+    "namespace": {
+      "type": "query",
+      "query": "label_values(kong_http_requests_total, namespace)",
+      "defaultValue": "default",
+      "sort": "asc",
+      "multiSelect": false
+    },
+    "service": {
+      "type": "query",
+      "query": "label_values(kong_http_requests_total{namespace=\"{{.namespace}}\"}, service)",
+      "defaultValue": "all",
+      "sort": "asc",
+      "multiSelect": true
+    }
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Total Requests",
+      "type": "value",
+      "query": "sum(kong_http_requests_total{namespace=\"{{.namespace}}\"})",
+      "gridPos": {"x": 0, "y": 0, "w": 6, "h": 4}
+    },
+    {
+      "id": 2,
+      "title": "Active Connections",
+      "type": "value",
+      "query": "sum(kong_nginx_connections_active{namespace=\"{{.namespace}}\"})",
+      "gridPos": {"x": 6, "y": 0, "w": 6, "h": 4}
+    },
+    {
+      "id": 3,
+      "title": "Request Rate",
+      "type": "timeseries",
+      "query": "sum(rate(kong_http_requests_total{namespace=\"{{.namespace}}\"}[5m]))",
+      "gridPos": {"x": 0, "y": 4, "w": 12, "h": 6}
+    },
+    {
+      "id": 4,
+      "title": "Status Codes",
+      "type": "pie",
+      "query": "sum by (code) (kong_http_status{namespace=\"{{.namespace}}\"})",
+      "gridPos": {"x": 12, "y": 0, "w": 6, "h": 10}
+    },
+    {
+      "id": 5,
+      "title": "Average Latency",
+      "type": "value",
+      "query": "avg(kong_latency_ms{namespace=\"{{.namespace}}\"})",
+      "unit": "ms",
+      "gridPos": {"x": 18, "y": 0, "w": 6, "h": 4}
+    },
+    {
+      "id": 6,
+      "title": "Latency Percentiles",
+      "type": "timeseries",
+      "queries": [
+        {
+          "name": "p50",
+          "query": "histogram_quantile(0.50, rate(kong_latency_ms_bucket{namespace=\"{{.namespace}}\"}[5m]))"
+        },
+        {
+          "name": "p90",
+          "query": "histogram_quantile(0.90, rate(kong_latency_ms_bucket{namespace=\"{{.namespace}}\"}[5m]))"
+        },
+        {
+          "name": "p99",
+          "query": "histogram_quantile(0.99, rate(kong_latency_ms_bucket{namespace=\"{{.namespace}}\"}[5m]))"
+        }
+      ],
+      "gridPos": {"x": 0, "y": 10, "w": 12, "h": 6}
+    },
+    {
+      "id": 7,
+      "title": "Error Rate",
+      "type": "timeseries",
+      "query": "sum(rate(kong_http_requests_total{status=~\"5..\",namespace=\"{{.namespace}}\"}[5m])) / sum(rate(kong_http_requests_total{namespace=\"{{.namespace}}\"}[5m])) * 100",
+      "unit": "percent",
+      "gridPos": {"x": 12, "y": 10, "w": 12, "h": 6}
+    },
+    {
+      "id": 8,
+      "title": "Bandwidth In",
+      "type": "timeseries",
+      "query": "sum(rate(kong_bandwidth_bytes{type=\"ingress\",namespace=\"{{.namespace}}\"}[5m]))",
+      "unit": "Bps",
+      "gridPos": {"x": 0, "y": 16, "w": 12, "h": 6}
+    },
+    {
+      "id": 9,
+      "title": "Bandwidth Out",
+      "type": "timeseries",
+      "query": "sum(rate(kong_bandwidth_bytes{type=\"egress\",namespace=\"{{.namespace}}\"}[5m]))",
+      "unit": "Bps",
+      "gridPos": {"x": 12, "y": 16, "w": 12, "h": 6}
+    },
+    {
+      "id": 10,
+      "title": "CPU Usage",
+      "type": "timeseries",
+      "query": "sum(rate(container_cpu_usage_seconds_total{namespace=\"{{.namespace}}\",pod=~\"kong.*\"}[5m])) * 100",
+      "unit": "percent",
+      "gridPos": {"x": 0, "y": 22, "w": 8, "h": 6}
+    },
+    {
+      "id": 11,
+      "title": "Memory Usage",
+      "type": "timeseries",
+      "query": "sum(container_memory_usage_bytes{namespace=\"{{.namespace}}\",pod=~\"kong.*\"}) / 1024 / 1024",
+      "unit": "MB",
+      "gridPos": {"x": 8, "y": 22, "w": 8, "h": 6}
+    },
+    {
+      "id": 12,
+      "title": "Pod Restarts",
+      "type": "value",
+      "query": "sum(kube_pod_container_status_restarts_total{namespace=\"{{.namespace}}\",pod=~\"kong.*\"})",
+      "gridPos": {"x": 16, "y": 22, "w": 8, "h": 6}
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #6028

Added Kong Gateway monitoring dashboard with the following features:

**Dashboard Sections:**
- General Overview: Total requests and active connections
- Request Metrics: Request rate and status code distribution  
- Latency Tracking: Average latency plus p50, p90, p99 percentiles
- Error Monitoring: Error rate percentage over time
- Traffic Analysis: Incoming and outgoing bandwidth
- Resource Usage: CPU, memory, and pod restart tracking

**Metrics Covered:**
- HTTP requests and response codes
- Latency percentiles
- Network bandwidth
- Resource consumption
- Connection metrics

**Setup:**
The dashboard uses Kong Prometheus plugin metrics. Setup instructions are in the README.

**Testing:**
Dashboard queries follow standard PromQL patterns used by Kong OpenTelemetry metrics. Compatible with Kong 3.x deployments using the Prometheus plugin.

All panels include proper variable support for namespace and service filtering.