### PR TITLE
feat: add Kong Gateway monitoring dashboard

### DIFF
--- a/kong/README.md
+++ b/kong/README.md
@@ -1,0 +1,12 @@
+# Kong Gateway Dashboard
+
+Monitors Kong API Gateway metrics including requests, latency, errors, bandwidth, connections, and upstream health.
+
+## Prerequisites
+
+- Kong with the [Prometheus plugin](https://docs.konghq.com/hub/kong-inc/prometheus/) enabled
+- Prometheus scraping Kong metrics endpoint
+
+## Metrics Used
+
+Kong Prometheus plugin metrics: `kong_http_requests_total`, `kong_latency_ms_*`, `kong_bandwidth_bytes`, `kong_connections_*`, `kong_upstream_target_health`, `kong_memory_workers_lua_vms_bytes`, `kong_datastore_reachable`

--- a/kong/kong.json
+++ b/kong/kong.json
@@ -1,0 +1,841 @@
+{
+  "description": "Kong Gateway monitoring dashboard covering requests, latency, errors, bandwidth, connections, and resource usage.",
+  "id": "kong-gateway-dashboard-v1",
+  "layout": [
+    { "h": 2, "i": "w-001", "moved": false, "static": false, "w": 3, "x": 0, "y": 0 },
+    { "h": 2, "i": "w-002", "moved": false, "static": false, "w": 3, "x": 3, "y": 0 },
+    { "h": 2, "i": "w-003", "moved": false, "static": false, "w": 3, "x": 6, "y": 0 },
+    { "h": 2, "i": "w-004", "moved": false, "static": false, "w": 3, "x": 9, "y": 0 },
+    { "h": 4, "i": "w-005", "moved": false, "static": false, "w": 6, "x": 0, "y": 2 },
+    { "h": 4, "i": "w-006", "moved": false, "static": false, "w": 6, "x": 6, "y": 2 },
+    { "h": 4, "i": "w-007", "moved": false, "static": false, "w": 6, "x": 0, "y": 6 },
+    { "h": 4, "i": "w-008", "moved": false, "static": false, "w": 6, "x": 6, "y": 6 },
+    { "h": 4, "i": "w-009", "moved": false, "static": false, "w": 6, "x": 0, "y": 10 },
+    { "h": 4, "i": "w-010", "moved": false, "static": false, "w": 6, "x": 6, "y": 10 },
+    { "h": 4, "i": "w-011", "moved": false, "static": false, "w": 6, "x": 0, "y": 14 },
+    { "h": 4, "i": "w-012", "moved": false, "static": false, "w": 6, "x": 6, "y": 14 },
+    { "h": 4, "i": "w-013", "moved": false, "static": false, "w": 6, "x": 0, "y": 18 },
+    { "h": 4, "i": "w-014", "moved": false, "static": false, "w": 6, "x": 6, "y": 18 },
+    { "h": 4, "i": "w-015", "moved": false, "static": false, "w": 6, "x": 0, "y": 22 },
+    { "h": 4, "i": "w-016", "moved": false, "static": false, "w": 6, "x": 6, "y": 22 },
+    { "h": 4, "i": "w-017", "moved": false, "static": false, "w": 6, "x": 0, "y": 26 },
+    { "h": 4, "i": "w-018", "moved": false, "static": false, "w": 6, "x": 6, "y": 26 },
+    { "h": 4, "i": "w-019", "moved": false, "static": false, "w": 6, "x": 0, "y": 30 },
+    { "h": 4, "i": "w-020", "moved": false, "static": false, "w": 6, "x": 6, "y": 30 }
+  ],
+  "name": "Kong Gateway",
+  "tags": ["kong", "api-gateway", "proxy"],
+  "variables": {
+    "service": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Kong service name",
+      "multiSelect": true,
+      "name": "service",
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "TEXTBOX"
+    }
+  },
+  "version": "v4",
+  "widgets": [
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total number of HTTP requests processed by Kong.",
+      "fillSpans": false,
+      "id": "w-001",
+      "isLogScale": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [],
+        "id": "q-001",
+        "promql": [
+          {
+            "disabled": false,
+            "expression": "sum(kong_http_requests_total)",
+            "legend": "Total Requests",
+            "name": "A",
+            "query": "sum(kong_http_requests_total)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreference": "GLOBAL_TIME",
+      "title": "Total Requests",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of currently active connections managed by Kong.",
+      "fillSpans": false,
+      "id": "w-002",
+      "isLogScale": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [],
+        "id": "q-002",
+        "promql": [
+          {
+            "disabled": false,
+            "expression": "sum(kong_connections_active)",
+            "legend": "Active Connections",
+            "name": "A",
+            "query": "sum(kong_connections_active)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreference": "GLOBAL_TIME",
+      "title": "Active Connections",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Memory used by Kong Lua worker VMs.",
+      "fillSpans": false,
+      "id": "w-003",
+      "isLogScale": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [],
+        "id": "q-003",
+        "promql": [
+          {
+            "disabled": false,
+            "expression": "sum(kong_memory_workers_lua_vms_bytes)",
+            "legend": "Memory Usage",
+            "name": "A",
+            "query": "sum(kong_memory_workers_lua_vms_bytes)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreference": "GLOBAL_TIME",
+      "title": "Lua VM Memory Usage",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total number of nginx metric errors encountered by Kong.",
+      "fillSpans": false,
+      "id": "w-004",
+      "isLogScale": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [],
+        "id": "q-004",
+        "promql": [
+          {
+            "disabled": false,
+            "expression": "sum(kong_nginx_metric_errors_total)",
+            "legend": "Nginx Errors",
+            "name": "A",
+            "query": "sum(kong_nginx_metric_errors_total)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreference": "GLOBAL_TIME",
+      "title": "Total Nginx Errors",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of HTTP requests per second handled by Kong, broken down by service.",
+      "fillSpans": false,
+      "id": "w-005",
+      "isLogScale": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [],
+        "id": "q-005",
+        "promql": [
+          {
+            "disabled": false,
+            "expression": "sum(rate(kong_http_requests_total[5m])) by (service)",
+            "legend": "{{service}}",
+            "name": "A",
+            "query": "sum(rate(kong_http_requests_total[5m])) by (service)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreference": "GLOBAL_TIME",
+      "title": "Request Rate by Service (req/s)",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Distribution of HTTP response status codes (2xx, 4xx, 5xx) returned by Kong.",
+      "fillSpans": false,
+      "id": "w-006",
+      "isLogScale": false,
+      "isStacked": true,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [],
+        "id": "q-006",
+        "promql": [
+          {
+            "disabled": false,
+            "expression": "sum(rate(kong_http_requests_total[5m])) by (code)",
+            "legend": "HTTP {{code}}",
+            "name": "A",
+            "query": "sum(rate(kong_http_requests_total[5m])) by (code)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreference": "GLOBAL_TIME",
+      "title": "Response Status Codes",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Average end-to-end request latency (in milliseconds) measured by Kong.",
+      "fillSpans": false,
+      "id": "w-007",
+      "isLogScale": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [],
+        "id": "q-007",
+        "promql": [
+          {
+            "disabled": false,
+            "expression": "sum(rate(kong_latency_ms_sum{type=\"request\"}[5m])) by (service) / sum(rate(kong_latency_ms_count{type=\"request\"}[5m])) by (service)",
+            "legend": "{{service}}",
+            "name": "A",
+            "query": "sum(rate(kong_latency_ms_sum{type=\"request\"}[5m])) by (service) / sum(rate(kong_latency_ms_count{type=\"request\"}[5m])) by (service)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreference": "GLOBAL_TIME",
+      "title": "Average Request Latency (ms)",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "P50, P90, and P99 request latency percentiles to highlight performance variations.",
+      "fillSpans": false,
+      "id": "w-008",
+      "isLogScale": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [],
+        "id": "q-008",
+        "promql": [
+          {
+            "disabled": false,
+            "expression": "histogram_quantile(0.50, sum(rate(kong_latency_ms_bucket{type=\"request\"}[5m])) by (le))",
+            "legend": "p50",
+            "name": "A",
+            "query": "histogram_quantile(0.50, sum(rate(kong_latency_ms_bucket{type=\"request\"}[5m])) by (le))"
+          },
+          {
+            "disabled": false,
+            "expression": "histogram_quantile(0.90, sum(rate(kong_latency_ms_bucket{type=\"request\"}[5m])) by (le))",
+            "legend": "p90",
+            "name": "B",
+            "query": "histogram_quantile(0.90, sum(rate(kong_latency_ms_bucket{type=\"request\"}[5m])) by (le))"
+          },
+          {
+            "disabled": false,
+            "expression": "histogram_quantile(0.99, sum(rate(kong_latency_ms_bucket{type=\"request\"}[5m])) by (le))",
+            "legend": "p99",
+            "name": "C",
+            "query": "histogram_quantile(0.99, sum(rate(kong_latency_ms_bucket{type=\"request\"}[5m])) by (le))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreference": "GLOBAL_TIME",
+      "title": "Request Latency Percentiles (p50 / p90 / p99)",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Average latency introduced by upstream services that Kong proxies to.",
+      "fillSpans": false,
+      "id": "w-009",
+      "isLogScale": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [],
+        "id": "q-009",
+        "promql": [
+          {
+            "disabled": false,
+            "expression": "sum(rate(kong_latency_ms_sum{type=\"upstream\"}[5m])) by (service) / sum(rate(kong_latency_ms_count{type=\"upstream\"}[5m])) by (service)",
+            "legend": "{{service}}",
+            "name": "A",
+            "query": "sum(rate(kong_latency_ms_sum{type=\"upstream\"}[5m])) by (service) / sum(rate(kong_latency_ms_count{type=\"upstream\"}[5m])) by (service)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreference": "GLOBAL_TIME",
+      "title": "Upstream Latency by Service (ms)",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of 5xx error responses per second, indicating upstream or Kong failures.",
+      "fillSpans": false,
+      "id": "w-010",
+      "isLogScale": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [],
+        "id": "q-010",
+        "promql": [
+          {
+            "disabled": false,
+            "expression": "sum(rate(kong_http_requests_total{code=~\"5..\"}[5m])) by (service)",
+            "legend": "{{service}}",
+            "name": "A",
+            "query": "sum(rate(kong_http_requests_total{code=~\"5..\"}[5m])) by (service)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreference": "GLOBAL_TIME",
+      "title": "5xx Error Rate by Service (req/s)",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of 4xx client error responses per second.",
+      "fillSpans": false,
+      "id": "w-011",
+      "isLogScale": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [],
+        "id": "q-011",
+        "promql": [
+          {
+            "disabled": false,
+            "expression": "sum(rate(kong_http_requests_total{code=~\"4..\"}[5m])) by (service)",
+            "legend": "{{service}}",
+            "name": "A",
+            "query": "sum(rate(kong_http_requests_total{code=~\"4..\"}[5m])) by (service)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreference": "GLOBAL_TIME",
+      "title": "4xx Error Rate by Service (req/s)",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Incoming bandwidth (egress from client to Kong) in bytes per second.",
+      "fillSpans": false,
+      "id": "w-012",
+      "isLogScale": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [],
+        "id": "q-012",
+        "promql": [
+          {
+            "disabled": false,
+            "expression": "sum(rate(kong_bandwidth_bytes{direction=\"ingress\"}[5m])) by (service)",
+            "legend": "{{service}} ingress",
+            "name": "A",
+            "query": "sum(rate(kong_bandwidth_bytes{direction=\"ingress\"}[5m])) by (service)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreference": "GLOBAL_TIME",
+      "title": "Incoming Traffic Volume (bytes/s)",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Outgoing bandwidth (Kong to upstream/client) in bytes per second.",
+      "fillSpans": false,
+      "id": "w-013",
+      "isLogScale": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [],
+        "id": "q-013",
+        "promql": [
+          {
+            "disabled": false,
+            "expression": "sum(rate(kong_bandwidth_bytes{direction=\"egress\"}[5m])) by (service)",
+            "legend": "{{service}} egress",
+            "name": "A",
+            "query": "sum(rate(kong_bandwidth_bytes{direction=\"egress\"}[5m])) by (service)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreference": "GLOBAL_TIME",
+      "title": "Outgoing Traffic Volume (bytes/s)",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Current active, reading, writing, and waiting connection states in Kong's nginx.",
+      "fillSpans": false,
+      "id": "w-014",
+      "isLogScale": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [],
+        "id": "q-014",
+        "promql": [
+          {
+            "disabled": false,
+            "expression": "sum(kong_connections_active)",
+            "legend": "Active",
+            "name": "A",
+            "query": "sum(kong_connections_active)"
+          },
+          {
+            "disabled": false,
+            "expression": "sum(kong_connections_reading)",
+            "legend": "Reading",
+            "name": "B",
+            "query": "sum(kong_connections_reading)"
+          },
+          {
+            "disabled": false,
+            "expression": "sum(kong_connections_writing)",
+            "legend": "Writing",
+            "name": "C",
+            "query": "sum(kong_connections_writing)"
+          },
+          {
+            "disabled": false,
+            "expression": "sum(kong_connections_waiting)",
+            "legend": "Waiting",
+            "name": "D",
+            "query": "sum(kong_connections_waiting)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreference": "GLOBAL_TIME",
+      "title": "Connection States",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of new connections accepted by Kong's nginx per second.",
+      "fillSpans": false,
+      "id": "w-015",
+      "isLogScale": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [],
+        "id": "q-015",
+        "promql": [
+          {
+            "disabled": false,
+            "expression": "sum(rate(kong_connections_accepted_total[5m]))",
+            "legend": "Accepted",
+            "name": "A",
+            "query": "sum(rate(kong_connections_accepted_total[5m]))"
+          },
+          {
+            "disabled": false,
+            "expression": "sum(rate(kong_connections_handled_total[5m]))",
+            "legend": "Handled",
+            "name": "B",
+            "query": "sum(rate(kong_connections_handled_total[5m]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreference": "GLOBAL_TIME",
+      "title": "Connection Rate (accepted vs handled)",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Health status of Kong upstream targets. 1 = healthy, 0 = unhealthy.",
+      "fillSpans": false,
+      "id": "w-016",
+      "isLogScale": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [],
+        "id": "q-016",
+        "promql": [
+          {
+            "disabled": false,
+            "expression": "sum(kong_upstream_target_health{state=\"healthy\"}) by (upstream, target)",
+            "legend": "{{upstream}} / {{target}}",
+            "name": "A",
+            "query": "sum(kong_upstream_target_health{state=\"healthy\"}) by (upstream, target)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreference": "GLOBAL_TIME",
+      "title": "Upstream Target Health",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Kong overhead latency — time added by Kong itself excluding upstream wait time.",
+      "fillSpans": false,
+      "id": "w-017",
+      "isLogScale": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [],
+        "id": "q-017",
+        "promql": [
+          {
+            "disabled": false,
+            "expression": "sum(rate(kong_latency_ms_sum{type=\"kong\"}[5m])) by (service) / sum(rate(kong_latency_ms_count{type=\"kong\"}[5m])) by (service)",
+            "legend": "{{service}}",
+            "name": "A",
+            "query": "sum(rate(kong_latency_ms_sum{type=\"kong\"}[5m])) by (service) / sum(rate(kong_latency_ms_count{type=\"kong\"}[5m])) by (service)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreference": "GLOBAL_TIME",
+      "title": "Kong Overhead Latency by Service (ms)",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total requests broken down by service and HTTP status code family.",
+      "fillSpans": false,
+      "id": "w-018",
+      "isLogScale": false,
+      "isStacked": true,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [],
+        "id": "q-018",
+        "promql": [
+          {
+            "disabled": false,
+            "expression": "sum(rate(kong_http_requests_total{code=~\"2..\"}[5m])) by (service)",
+            "legend": "{{service}} 2xx",
+            "name": "A",
+            "query": "sum(rate(kong_http_requests_total{code=~\"2..\"}[5m])) by (service)"
+          },
+          {
+            "disabled": false,
+            "expression": "sum(rate(kong_http_requests_total{code=~\"4..\"}[5m])) by (service)",
+            "legend": "{{service}} 4xx",
+            "name": "B",
+            "query": "sum(rate(kong_http_requests_total{code=~\"4..\"}[5m])) by (service)"
+          },
+          {
+            "disabled": false,
+            "expression": "sum(rate(kong_http_requests_total{code=~\"5..\"}[5m])) by (service)",
+            "legend": "{{service}} 5xx",
+            "name": "C",
+            "query": "sum(rate(kong_http_requests_total{code=~\"5..\"}[5m])) by (service)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreference": "GLOBAL_TIME",
+      "title": "Requests by Service and Status Family",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Memory used by Kong Lua worker VMs over time.",
+      "fillSpans": false,
+      "id": "w-019",
+      "isLogScale": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [],
+        "id": "q-019",
+        "promql": [
+          {
+            "disabled": false,
+            "expression": "sum(kong_memory_workers_lua_vms_bytes) by (node_id)",
+            "legend": "{{node_id}}",
+            "name": "A",
+            "query": "sum(kong_memory_workers_lua_vms_bytes) by (node_id)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreference": "GLOBAL_TIME",
+      "title": "Lua VM Memory Usage Over Time",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Whether the Kong datastore (database) is reachable. 1 = reachable, 0 = unreachable.",
+      "fillSpans": false,
+      "id": "w-020",
+      "isLogScale": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [],
+        "id": "q-020",
+        "promql": [
+          {
+            "disabled": false,
+            "expression": "kong_datastore_reachable",
+            "legend": "Datastore Reachable",
+            "name": "A",
+            "query": "kong_datastore_reachable"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreference": "GLOBAL_TIME",
+      "title": "Datastore Reachability",
+      "yAxisUnit": "short"
+    }
+  ]
+}


### PR DESCRIPTION
Adds a Kong Gateway monitoring dashboard with 20 panels covering:
- Request rate and status code distribution
- Request latency (avg, p50, p90, p99)
- Upstream latency and Kong overhead latency
- 5xx and 4xx error rates
- Ingress and egress bandwidth
- Connection states and connection rate
- Upstream target health
- Lua VM memory usage
- Datastore reachability

Uses Kong's Prometheus plugin metrics.

Closes SigNoz/signoz#6028

/claim #6028