### PR TITLE
Add Cert-Manager Monitoring Dashboard (Prometheus)

### DIFF
--- a/cert-manager/cert-manager-prometheus-v1.json
+++ b/cert-manager/cert-manager-prometheus-v1.json
@@ -1,0 +1,2182 @@
+{
+  "description": "Comprehensive monitoring dashboard for cert-manager, tracking certificate lifecycle, issuance, renewal, errors, resource usage, and API metrics.",
+  "image": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB4PSIzIiB5PSIxIiB3aWR0aD0iMTIiIGhlaWdodD0iMTYiIHJ4PSIxIiBmaWxsPSIjMzI5OGRjIi8+PHBhdGggZD0iTTYgNWg2TTYgOGg2TTYgMTFoNCIgc3Ryb2tlPSJ3aGl0ZSIgc3Ryb2tlLXdpZHRoPSIxLjUiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIvPjxjaXJjbGUgY3g9IjEyIiBjeT0iMTMiIHI9IjMuNSIgZmlsbD0iIzI3YWU2MCIgc3Ryb2tlPSJ3aGl0ZSIgc3Ryb2tlLXdpZHRoPSIxIi8+PHBhdGggZD0iTTEwLjUgMTNsMSAxIDItMiIgc3Ryb2tlPSJ3aGl0ZSIgc3Ryb2tlLXdpZHRoPSIxLjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIvPjwvc3ZnPg==",
+  "layout": [
+    {"h": 1, "i": "a1b2c3d4-0001-4000-8000-000000000001", "maxH": 1, "minH": 1, "minW": 12, "moved": false, "static": false, "w": 12, "x": 0, "y": 0},
+    {"h": 4, "i": "a1b2c3d4-0001-4000-8000-000000000002", "moved": false, "static": false, "w": 3, "x": 0, "y": 1},
+    {"h": 4, "i": "a1b2c3d4-0001-4000-8000-000000000003", "moved": false, "static": false, "w": 3, "x": 3, "y": 1},
+    {"h": 4, "i": "a1b2c3d4-0001-4000-8000-000000000004", "moved": false, "static": false, "w": 3, "x": 6, "y": 1},
+    {"h": 4, "i": "a1b2c3d4-0001-4000-8000-000000000005", "moved": false, "static": false, "w": 3, "x": 9, "y": 1},
+    {"h": 1, "i": "a1b2c3d4-0002-4000-8000-000000000001", "maxH": 1, "minH": 1, "minW": 12, "moved": false, "static": false, "w": 12, "x": 0, "y": 5},
+    {"h": 6, "i": "a1b2c3d4-0002-4000-8000-000000000002", "moved": false, "static": false, "w": 4, "x": 0, "y": 6},
+    {"h": 6, "i": "a1b2c3d4-0002-4000-8000-000000000003", "moved": false, "static": false, "w": 4, "x": 4, "y": 6},
+    {"h": 6, "i": "a1b2c3d4-0002-4000-8000-000000000004", "moved": false, "static": false, "w": 4, "x": 8, "y": 6},
+    {"h": 1, "i": "a1b2c3d4-0003-4000-8000-000000000001", "maxH": 1, "minH": 1, "minW": 12, "moved": false, "static": false, "w": 12, "x": 0, "y": 12},
+    {"h": 6, "i": "a1b2c3d4-0003-4000-8000-000000000002", "moved": false, "static": false, "w": 4, "x": 0, "y": 13},
+    {"h": 6, "i": "a1b2c3d4-0003-4000-8000-000000000003", "moved": false, "static": false, "w": 4, "x": 4, "y": 13},
+    {"h": 6, "i": "a1b2c3d4-0003-4000-8000-000000000004", "moved": false, "static": false, "w": 4, "x": 8, "y": 13},
+    {"h": 1, "i": "a1b2c3d4-0004-4000-8000-000000000001", "maxH": 1, "minH": 1, "minW": 12, "moved": false, "static": false, "w": 12, "x": 0, "y": 19},
+    {"h": 6, "i": "a1b2c3d4-0004-4000-8000-000000000002", "moved": false, "static": false, "w": 4, "x": 0, "y": 20},
+    {"h": 6, "i": "a1b2c3d4-0004-4000-8000-000000000003", "moved": false, "static": false, "w": 4, "x": 4, "y": 20},
+    {"h": 6, "i": "a1b2c3d4-0004-4000-8000-000000000004", "moved": false, "static": false, "w": 4, "x": 8, "y": 20},
+    {"h": 1, "i": "a1b2c3d4-0005-4000-8000-000000000001", "maxH": 1, "minH": 1, "minW": 12, "moved": false, "static": false, "w": 12, "x": 0, "y": 26},
+    {"h": 6, "i": "a1b2c3d4-0005-4000-8000-000000000002", "moved": false, "static": false, "w": 4, "x": 0, "y": 27},
+    {"h": 6, "i": "a1b2c3d4-0005-4000-8000-000000000003", "moved": false, "static": false, "w": 4, "x": 4, "y": 27},
+    {"h": 6, "i": "a1b2c3d4-0005-4000-8000-000000000004", "moved": false, "static": false, "w": 4, "x": 8, "y": 27},
+    {"h": 1, "i": "a1b2c3d4-0006-4000-8000-000000000001", "maxH": 1, "minH": 1, "minW": 12, "moved": false, "static": false, "w": 12, "x": 0, "y": 33},
+    {"h": 6, "i": "a1b2c3d4-0006-4000-8000-000000000002", "moved": false, "static": false, "w": 4, "x": 0, "y": 34},
+    {"h": 6, "i": "a1b2c3d4-0006-4000-8000-000000000003", "moved": false, "static": false, "w": 4, "x": 4, "y": 34},
+    {"h": 6, "i": "a1b2c3d4-0006-4000-8000-000000000004", "moved": false, "static": false, "w": 4, "x": 8, "y": 34}
+  ],
+  "panelMap": {
+    "a1b2c3d4-0001-4000-8000-000000000001": {
+      "collapsed": false,
+      "widgets": [
+        {"h": 4, "i": "a1b2c3d4-0001-4000-8000-000000000002", "moved": false, "static": false, "w": 3, "x": 0, "y": 1},
+        {"h": 4, "i": "a1b2c3d4-0001-4000-8000-000000000003", "moved": false, "static": false, "w": 3, "x": 3, "y": 1},
+        {"h": 4, "i": "a1b2c3d4-0001-4000-8000-000000000004", "moved": false, "static": false, "w": 3, "x": 6, "y": 1},
+        {"h": 4, "i": "a1b2c3d4-0001-4000-8000-000000000005", "moved": false, "static": false, "w": 3, "x": 9, "y": 1}
+      ]
+    },
+    "a1b2c3d4-0002-4000-8000-000000000001": {
+      "collapsed": false,
+      "widgets": [
+        {"h": 6, "i": "a1b2c3d4-0002-4000-8000-000000000002", "moved": false, "static": false, "w": 4, "x": 0, "y": 6},
+        {"h": 6, "i": "a1b2c3d4-0002-4000-8000-000000000003", "moved": false, "static": false, "w": 4, "x": 4, "y": 6},
+        {"h": 6, "i": "a1b2c3d4-0002-4000-8000-000000000004", "moved": false, "static": false, "w": 4, "x": 8, "y": 6}
+      ]
+    },
+    "a1b2c3d4-0003-4000-8000-000000000001": {
+      "collapsed": false,
+      "widgets": [
+        {"h": 6, "i": "a1b2c3d4-0003-4000-8000-000000000002", "moved": false, "static": false, "w": 4, "x": 0, "y": 13},
+        {"h": 6, "i": "a1b2c3d4-0003-4000-8000-000000000003", "moved": false, "static": false, "w": 4, "x": 4, "y": 13},
+        {"h": 6, "i": "a1b2c3d4-0003-4000-8000-000000000004", "moved": false, "static": false, "w": 4, "x": 8, "y": 13}
+      ]
+    },
+    "a1b2c3d4-0004-4000-8000-000000000001": {
+      "collapsed": false,
+      "widgets": [
+        {"h": 6, "i": "a1b2c3d4-0004-4000-8000-000000000002", "moved": false, "static": false, "w": 4, "x": 0, "y": 20},
+        {"h": 6, "i": "a1b2c3d4-0004-4000-8000-000000000003", "moved": false, "static": false, "w": 4, "x": 4, "y": 20},
+        {"h": 6, "i": "a1b2c3d4-0004-4000-8000-000000000004", "moved": false, "static": false, "w": 4, "x": 8, "y": 20}
+      ]
+    },
+    "a1b2c3d4-0005-4000-8000-000000000001": {
+      "collapsed": false,
+      "widgets": [
+        {"h": 6, "i": "a1b2c3d4-0005-4000-8000-000000000002", "moved": false, "static": false, "w": 4, "x": 0, "y": 27},
+        {"h": 6, "i": "a1b2c3d4-0005-4000-8000-000000000003", "moved": false, "static": false, "w": 4, "x": 4, "y": 27},
+        {"h": 6, "i": "a1b2c3d4-0005-4000-8000-000000000004", "moved": false, "static": false, "w": 4, "x": 8, "y": 27}
+      ]
+    },
+    "a1b2c3d4-0006-4000-8000-000000000001": {
+      "collapsed": false,
+      "widgets": [
+        {"h": 6, "i": "a1b2c3d4-0006-4000-8000-000000000002", "moved": false, "static": false, "w": 4, "x": 0, "y": 34},
+        {"h": 6, "i": "a1b2c3d4-0006-4000-8000-000000000003", "moved": false, "static": false, "w": 4, "x": 4, "y": 34},
+        {"h": 6, "i": "a1b2c3d4-0006-4000-8000-000000000004", "moved": false, "static": false, "w": 4, "x": 8, "y": 34}
+      ]
+    }
+  },
+  "tags": ["cert-manager", "certificates", "tls", "kubernetes"],
+  "title": "Cert-Manager Dashboard",
+  "uploadedGrafana": false,
+  "variables": {
+    "b7e1f2a3-0001-4000-9000-000000000001": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "Kubernetes namespace where cert-manager certificates are deployed",
+      "id": "b7e1f2a3-0001-4000-9000-000000000001",
+      "key": "b7e1f2a3-0001-4000-9000-000000000001",
+      "modificationUUID": "b7e1f2a3-0001-4000-9000-100000000001",
+      "multiSelect": false,
+      "name": "namespace",
+      "order": 0,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'namespace'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name like '%certmanager%'",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "b7e1f2a3-0002-4000-9000-000000000001": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "Certificate issuer name",
+      "id": "b7e1f2a3-0002-4000-9000-000000000001",
+      "key": "b7e1f2a3-0002-4000-9000-000000000001",
+      "modificationUUID": "b7e1f2a3-0002-4000-9000-100000000001",
+      "multiSelect": true,
+      "name": "issuer",
+      "order": 1,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'issuer'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name like '%certmanager%'",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "b7e1f2a3-0003-4000-9000-000000000001": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "Certificate name",
+      "id": "b7e1f2a3-0003-4000-9000-000000000001",
+      "key": "b7e1f2a3-0003-4000-9000-000000000001",
+      "modificationUUID": "b7e1f2a3-0003-4000-9000-100000000001",
+      "multiSelect": true,
+      "name": "certificate_name",
+      "order": 2,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'name'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name like '%certmanager_certificate%'",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "b7e1f2a3-0004-4000-9000-000000000001": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "Kubernetes cluster name for multi-cluster filtering",
+      "id": "b7e1f2a3-0004-4000-9000-000000000001",
+      "key": "b7e1f2a3-0004-4000-9000-000000000001",
+      "modificationUUID": "b7e1f2a3-0004-4000-9000-100000000001",
+      "multiSelect": false,
+      "name": "cluster",
+      "order": 3,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'k8s_cluster_name'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name like '%certmanager%'",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "b7e1f2a3-0005-4000-9000-000000000001": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "Deployment environment (e.g., staging, production)",
+      "id": "b7e1f2a3-0005-4000-9000-000000000001",
+      "key": "b7e1f2a3-0005-4000-9000-000000000001",
+      "modificationUUID": "b7e1f2a3-0005-4000-9000-100000000001",
+      "multiSelect": false,
+      "name": "deployment.environment",
+      "order": 4,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'deployment_environment'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name like '%certmanager%'",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "version": "v4",
+  "widgets": [
+    {
+      "description": "",
+      "id": "a1b2c3d4-0001-4000-8000-000000000001",
+      "panelTypes": "row",
+      "title": "General Overview"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total number of certificates tracked by cert-manager across all namespaces",
+      "fillSpans": false,
+      "id": "a1b2c3d4-0001-4000-8000-000000000002",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "certmanager_certificate_ready_status--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "certmanager_certificate_ready_status",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "count_distinct",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f1a00001",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q1b2c3d4-0001-4000-8000-000000000002",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": "count(certmanager_certificate_ready_status{namespace=~\"$namespace\"})"}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [
+        {
+          "index": "t1000001-0001-4000-8000-000000000001",
+          "isEditEnabled": false,
+          "keyIndex": 0,
+          "selectedGraph": "value",
+          "thresholdColor": "Green",
+          "thresholdFormat": "Text",
+          "thresholdLabel": "",
+          "thresholdOperator": ">",
+          "thresholdTableOptions": "A",
+          "thresholdUnit": "none",
+          "thresholdValue": 0
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Certificates",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of certificates currently in Ready state (condition=True)",
+      "fillSpans": false,
+      "id": "a1b2c3d4-0001-4000-8000-000000000003",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "certmanager_certificate_ready_status--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "certmanager_certificate_ready_status",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f1a00002",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  },
+                  {
+                    "id": "f1a00003",
+                    "key": {
+                      "dataType": "string",
+                      "id": "condition--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "condition",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "True"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q1b2c3d4-0001-4000-8000-000000000003",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": "sum(certmanager_certificate_ready_status{namespace=~\"$namespace\", condition=\"True\"})"}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [
+        {
+          "index": "t1000001-0001-4000-8000-000000000002",
+          "isEditEnabled": false,
+          "keyIndex": 0,
+          "selectedGraph": "value",
+          "thresholdColor": "Green",
+          "thresholdFormat": "Text",
+          "thresholdLabel": "",
+          "thresholdOperator": ">",
+          "thresholdTableOptions": "A",
+          "thresholdUnit": "none",
+          "thresholdValue": 0
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Certificates (Ready)",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total ACME HTTP client requests made by cert-manager for certificate operations",
+      "fillSpans": false,
+      "id": "a1b2c3d4-0001-4000-8000-000000000004",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "certmanager_http_acme_client_request_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "certmanager_http_acme_client_request_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f1a00004",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q1b2c3d4-0001-4000-8000-000000000004",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": "sum(certmanager_http_acme_client_request_count{namespace=~\"$namespace\"})"}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [
+        {
+          "index": "t1000001-0001-4000-8000-000000000003",
+          "isEditEnabled": false,
+          "keyIndex": 0,
+          "selectedGraph": "value",
+          "thresholdColor": "Blue",
+          "thresholdFormat": "Text",
+          "thresholdLabel": "",
+          "thresholdOperator": ">",
+          "thresholdTableOptions": "A",
+          "thresholdUnit": "none",
+          "thresholdValue": 0
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Certificate Requests",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Uptime of the cert-manager process calculated from process_start_time_seconds",
+      "fillSpans": false,
+      "id": "a1b2c3d4-0001-4000-8000-000000000005",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "process_start_time_seconds--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "process_start_time_seconds",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f1a00005",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "cert-manager"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "min",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q1b2c3d4-0001-4000-8000-000000000005",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": "time() - process_start_time_seconds{job=\"cert-manager\"}"}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [
+        {
+          "index": "t1000001-0001-4000-8000-000000000004",
+          "isEditEnabled": false,
+          "keyIndex": 0,
+          "selectedGraph": "value",
+          "thresholdColor": "Green",
+          "thresholdFormat": "Text",
+          "thresholdLabel": "",
+          "thresholdOperator": ">",
+          "thresholdTableOptions": "A",
+          "thresholdUnit": "s",
+          "thresholdValue": 0
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Uptime",
+      "yAxisUnit": "s"
+    },
+    {
+      "description": "",
+      "id": "a1b2c3d4-0002-4000-8000-000000000001",
+      "panelTypes": "row",
+      "title": "Certificate Issuance"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of ready certificates grouped by issuer to identify which issuers are most active",
+      "fillSpans": false,
+      "id": "a1b2c3d4-0002-4000-8000-000000000002",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "certmanager_certificate_ready_status--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "certmanager_certificate_ready_status",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f2a00001",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  },
+                  {
+                    "id": "f2a00002",
+                    "key": {
+                      "dataType": "string",
+                      "id": "condition--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "condition",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "True"
+                  },
+                  {
+                    "id": "f2a00003",
+                    "key": {
+                      "dataType": "string",
+                      "id": "issuer_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "issuer_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$issuer"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "issuer_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "issuer_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Issuer - {{issuer_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q1b2c3d4-0002-4000-8000-000000000002",
+        "promql": [{"disabled": false, "legend": "{{issuer_name}}", "name": "A", "query": "sum by (issuer_name) (certmanager_certificate_ready_status{namespace=~\"$namespace\", condition=\"True\"})"}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Certificates Issued per Issuer",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of certificate request duration completions, indicating how fast certificates are being issued over time",
+      "fillSpans": false,
+      "id": "a1b2c3d4-0002-4000-8000-000000000003",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "certmanager_http_acme_client_request_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "certmanager_http_acme_client_request_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f2a00004",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Issuance Rate",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q1b2c3d4-0002-4000-8000-000000000003",
+        "promql": [{"disabled": false, "legend": "Issuance Rate", "name": "A", "query": "sum(rate(certmanager_http_acme_client_request_count{namespace=~\"$namespace\"}[5m]))"}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Issuance Rate",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Percentage of certificate requests that completed successfully (Ready condition = True)",
+      "fillSpans": false,
+      "id": "a1b2c3d4-0002-4000-8000-000000000004",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "certmanager_certificate_ready_status--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "certmanager_certificate_ready_status",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f2a00005",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  },
+                  {
+                    "id": "f2a00006",
+                    "key": {
+                      "dataType": "string",
+                      "id": "condition--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "condition",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "True"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Ready",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "certmanager_certificate_ready_status--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "certmanager_certificate_ready_status",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "count_distinct",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f2a00007",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Total",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "A / B * 100",
+              "legend": "Success Rate %",
+              "queryName": "F1"
+            }
+          ]
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q1b2c3d4-0002-4000-8000-000000000004",
+        "promql": [{"disabled": false, "legend": "Success Rate %", "name": "A", "query": "sum(certmanager_certificate_ready_status{namespace=~\"$namespace\", condition=\"True\"}) / count(certmanager_certificate_ready_status{namespace=~\"$namespace\"}) * 100"}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 100,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [
+        {
+          "index": "t1000001-0002-4000-8000-000000000001",
+          "isEditEnabled": false,
+          "keyIndex": 0,
+          "selectedGraph": "value",
+          "thresholdColor": "Green",
+          "thresholdFormat": "Text",
+          "thresholdLabel": "",
+          "thresholdOperator": ">",
+          "thresholdTableOptions": "F1",
+          "thresholdUnit": "none",
+          "thresholdValue": 90
+        },
+        {
+          "index": "t1000001-0002-4000-8000-000000000002",
+          "isEditEnabled": false,
+          "keyIndex": 1,
+          "selectedGraph": "value",
+          "thresholdColor": "Red",
+          "thresholdFormat": "Text",
+          "thresholdLabel": "",
+          "thresholdOperator": "<",
+          "thresholdTableOptions": "F1",
+          "thresholdUnit": "none",
+          "thresholdValue": 50
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Issuance Success Rate",
+      "yAxisUnit": "percent"
+    },
+    {
+      "description": "",
+      "id": "a1b2c3d4-0003-4000-8000-000000000001",
+      "panelTypes": "row",
+      "title": "Certificate Renewal"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Certificates with expiration timestamps approaching, indicating they need renewal soon",
+      "fillSpans": false,
+      "id": "a1b2c3d4-0003-4000-8000-000000000002",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "certmanager_certificate_expiration_timestamp_seconds--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "certmanager_certificate_expiration_timestamp_seconds",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f3a00001",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "min",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q1b2c3d4-0003-4000-8000-000000000002",
+        "promql": [{"disabled": false, "legend": "{{name}}", "name": "A", "query": "(certmanager_certificate_expiration_timestamp_seconds{namespace=~\"$namespace\"} - time()) / 86400"}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Days Until Certificate Expiration",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Percentage of certificates that have been successfully renewed before expiration",
+      "fillSpans": false,
+      "id": "a1b2c3d4-0003-4000-8000-000000000003",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "certmanager_certificate_ready_status--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "certmanager_certificate_ready_status",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f3a00002",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  },
+                  {
+                    "id": "f3a00003",
+                    "key": {
+                      "dataType": "string",
+                      "id": "condition--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "condition",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "True"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Renewal Success Rate",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q1b2c3d4-0003-4000-8000-000000000003",
+        "promql": [{"disabled": false, "legend": "Renewal Success Rate", "name": "A", "query": "sum(certmanager_certificate_ready_status{namespace=~\"$namespace\", condition=\"True\"}) / count(certmanager_certificate_ready_status{namespace=~\"$namespace\"}) * 100"}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 100,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Renewal Success Rate",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Tracks the renewal timestamp of certificates to monitor when renewals are happening",
+      "fillSpans": false,
+      "id": "a1b2c3d4-0003-4000-8000-000000000004",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "certmanager_certificate_renewal_timestamp_seconds--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "certmanager_certificate_renewal_timestamp_seconds",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f3a00004",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "min",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q1b2c3d4-0003-4000-8000-000000000004",
+        "promql": [{"disabled": false, "legend": "{{name}}", "name": "A", "query": "(certmanager_certificate_renewal_timestamp_seconds{namespace=~\"$namespace\"} - time()) / 86400"}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Days Until Renewal",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "",
+      "id": "a1b2c3d4-0004-4000-8000-000000000001",
+      "panelTypes": "row",
+      "title": "Error Metrics"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Certificates with Ready condition set to False, indicating issuance failures",
+      "fillSpans": false,
+      "id": "a1b2c3d4-0004-4000-8000-000000000002",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "certmanager_certificate_ready_status--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "certmanager_certificate_ready_status",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f4a00001",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  },
+                  {
+                    "id": "f4a00002",
+                    "key": {
+                      "dataType": "string",
+                      "id": "condition--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "condition",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "False"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q1b2c3d4-0004-4000-8000-000000000002",
+        "promql": [{"disabled": false, "legend": "{{name}}", "name": "A", "query": "certmanager_certificate_ready_status{namespace=~\"$namespace\", condition=\"False\"}"}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Certificate Issuance Errors",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Certificates that have expired or failed to renew, detected by expiration timestamp being in the past",
+      "fillSpans": false,
+      "id": "a1b2c3d4-0004-4000-8000-000000000003",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "certmanager_certificate_ready_status--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "certmanager_certificate_ready_status",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f4a00003",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  },
+                  {
+                    "id": "f4a00004",
+                    "key": {
+                      "dataType": "string",
+                      "id": "condition--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "condition",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "False"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "issuer_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "issuer_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Issuer - {{issuer_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q1b2c3d4-0004-4000-8000-000000000003",
+        "promql": [{"disabled": false, "legend": "{{issuer_name}}", "name": "A", "query": "sum by (issuer_name) (certmanager_certificate_ready_status{namespace=~\"$namespace\", condition=\"False\"})"}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Renewal Errors by Issuer",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "ACME HTTP client requests with 4xx/5xx status codes indicating API-level errors",
+      "fillSpans": false,
+      "id": "a1b2c3d4-0004-4000-8000-000000000004",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "certmanager_http_acme_client_request_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "certmanager_http_acme_client_request_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f4a00005",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  },
+                  {
+                    "id": "f4a00006",
+                    "key": {
+                      "dataType": "string",
+                      "id": "status--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "status",
+                      "type": "tag"
+                    },
+                    "op": ">=",
+                    "value": "400"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "status--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "status",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Status {{status}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q1b2c3d4-0004-4000-8000-000000000004",
+        "promql": [{"disabled": false, "legend": "{{status}}", "name": "A", "query": "sum by (status) (rate(certmanager_http_acme_client_request_count{namespace=~\"$namespace\", status=~\"4..|5..\"}[5m]))"}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "API Server Errors",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "a1b2c3d4-0005-4000-8000-000000000001",
+      "panelTypes": "row",
+      "title": "Resource Usage"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "CPU time consumed by the cert-manager process in seconds",
+      "fillSpans": false,
+      "id": "a1b2c3d4-0005-4000-8000-000000000002",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "process_cpu_seconds_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "process_cpu_seconds_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f5a00001",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "cert-manager"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "CPU Usage",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q1b2c3d4-0005-4000-8000-000000000002",
+        "promql": [{"disabled": false, "legend": "CPU Usage", "name": "A", "query": "rate(process_cpu_seconds_total{job=\"cert-manager\"}[5m])"}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "CPU Usage",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Resident memory (RSS) used by the cert-manager process",
+      "fillSpans": false,
+      "id": "a1b2c3d4-0005-4000-8000-000000000003",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "process_resident_memory_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "process_resident_memory_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f5a00002",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "cert-manager"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Memory Usage",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q1b2c3d4-0005-4000-8000-000000000003",
+        "promql": [{"disabled": false, "legend": "Memory Usage", "name": "A", "query": "process_resident_memory_bytes{job=\"cert-manager\"}"}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memory Usage",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of container restarts for cert-manager pods, indicating stability issues",
+      "fillSpans": false,
+      "id": "a1b2c3d4-0005-4000-8000-000000000004",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "kube_pod_container_status_restarts_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "kube_pod_container_status_restarts_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f5a00003",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  },
+                  {
+                    "id": "f5a00004",
+                    "key": {
+                      "dataType": "string",
+                      "id": "container--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "container",
+                      "type": "tag"
+                    },
+                    "op": "contains",
+                    "value": "cert-manager"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "pod--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "pod",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{pod}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q1b2c3d4-0005-4000-8000-000000000004",
+        "promql": [{"disabled": false, "legend": "{{pod}}", "name": "A", "query": "kube_pod_container_status_restarts_total{namespace=~\"$namespace\", container=~\".*cert-manager.*\"}"}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Pod Restarts",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "",
+      "id": "a1b2c3d4-0006-4000-8000-000000000001",
+      "panelTypes": "row",
+      "title": "API and Event Metrics"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of ACME HTTP client requests made by cert-manager, grouped by HTTP method and path",
+      "fillSpans": false,
+      "id": "a1b2c3d4-0006-4000-8000-000000000002",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "certmanager_http_acme_client_request_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "certmanager_http_acme_client_request_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f6a00001",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "method--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "method",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{method}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q1b2c3d4-0006-4000-8000-000000000002",
+        "promql": [{"disabled": false, "legend": "{{method}}", "name": "A", "query": "sum by (method) (rate(certmanager_http_acme_client_request_count{namespace=~\"$namespace\"}[5m]))"}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "API Request Rate",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of controller sync calls showing how frequently cert-manager processes events and reconciles resources",
+      "fillSpans": false,
+      "id": "a1b2c3d4-0006-4000-8000-000000000003",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "certmanager_controller_sync_call_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "certmanager_controller_sync_call_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f6a00002",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "controller--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "controller",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{controller}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q1b2c3d4-0006-4000-8000-000000000003",
+        "promql": [{"disabled": false, "legend": "{{controller}}", "name": "A", "query": "sum by (controller) (rate(certmanager_controller_sync_call_count{namespace=~\"$namespace\"}[5m]))"}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Event Processing Rate",
+      "yAxisUnit": "ops"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of failed ACME API requests (HTTP 4xx and 5xx responses) grouped by status code",
+      "fillSpans": false,
+      "id": "a1b2c3d4-0006-4000-8000-000000000004",
+      "isStacked": true,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "certmanager_http_acme_client_request_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "certmanager_http_acme_client_request_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f6a00003",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  },
+                  {
+                    "id": "f6a00004",
+                    "key": {
+                      "dataType": "string",
+                      "id": "status--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "status",
+                      "type": "tag"
+                    },
+                    "op": ">=",
+                    "value": "400"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "status--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "status",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "method--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "method",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{method}} - {{status}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q1b2c3d4-0006-4000-8000-000000000004",
+        "promql": [{"disabled": false, "legend": "{{method}} - {{status}}", "name": "A", "query": "sum by (method, status) (rate(certmanager_http_acme_client_request_count{namespace=~\"$namespace\", status=~\"4..|5..\"}[5m]))"}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Failed API Requests",
+      "yAxisUnit": "reqps"
+    }
+  ]
+}

--- a/cert-manager/readme.md
+++ b/cert-manager/readme.md
@@ -1,0 +1,206 @@
+# Cert-Manager Dashboard - Prometheus
+
+## Metrics Ingestion
+
+### Cert-Manager Metrics
+Cert-Manager exposes Prometheus metrics natively on port `9402` at the `/metrics` endpoint. These metrics cover certificate lifecycle, issuance, renewal, ACME client activity, and controller performance.
+
+Key metric families:
+- `certmanager_certificate_ready_status` - Certificate readiness state
+- `certmanager_certificate_expiration_timestamp_seconds` - Certificate expiration timestamps
+- `certmanager_certificate_renewal_timestamp_seconds` - Certificate renewal timestamps
+- `certmanager_http_acme_client_request_count` - ACME HTTP client request counts
+- `certmanager_controller_sync_call_count` - Controller sync/reconciliation counts
+- `process_cpu_seconds_total` / `process_resident_memory_bytes` - Process resource metrics
+
+Reference: [cert-manager Prometheus Metrics Documentation](https://cert-manager.io/docs/devops-tips/prometheus-metrics/)
+
+### Configure OpenTelemetry Collector
+
+1. Add prometheus receiver to the `receivers:` section:
+
+```yaml
+  prometheus:
+    config:
+      global:
+        scrape_interval: 60s
+      scrape_configs:
+        - job_name: cert-manager
+          metrics_path: /metrics
+          scheme: http
+          static_configs:
+            - targets:
+              - cert-manager.cert-manager.svc.cluster.local:9402
+```
+
+2. Complete Configuration Example
+
+Below is a complete `otel-config.yaml` example:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+  hostmetrics:
+    collection_interval: 60s
+    scrapers:
+      cpu: {}
+      disk: {}
+      load: {}
+      filesystem: {}
+      memory: {}
+      network: {}
+      paging: {}
+      process:
+        mute_process_name_error: true
+        mute_process_exe_error: true
+        mute_process_io_error: true
+      processes: {}
+  prometheus:
+    config:
+      global:
+        scrape_interval: 60s
+      scrape_configs:
+        - job_name: otel-collector-binary
+          static_configs:
+            - targets:
+              - localhost:8888
+        - job_name: cert-manager
+          metrics_path: /metrics
+          scheme: http
+          static_configs:
+            - targets:
+              - cert-manager.cert-manager.svc.cluster.local:9402
+
+processors:
+  batch:
+    send_batch_size: 1000
+    timeout: 10s
+  resourcedetection:
+    detectors: [env, system]
+    timeout: 2s
+    system:
+      hostname_sources: [os]
+  resource/env:
+    attributes:
+    - key: deployment.environment
+      value: production
+      action: upsert
+
+extensions:
+  health_check: {}
+  zpages: {}
+
+exporters:
+  otlp:
+    endpoint: "ingest.{region}.signoz.cloud:443"
+    tls:
+      insecure: false
+    headers:
+      "signoz-access-token": "your-ingestion-key"
+  logging:
+    verbosity: normal
+
+service:
+  telemetry:
+    metrics:
+      address: 0.0.0.0:8888
+  extensions: [health_check, zpages]
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [resource/env, batch]
+      exporters: [otlp]
+    metrics/internal:
+      receivers: [prometheus, hostmetrics]
+      processors: [resource/env, resourcedetection, batch]
+      exporters: [otlp]
+    traces:
+      receivers: [otlp]
+      processors: [resource/env, batch]
+      exporters: [otlp]
+    logs:
+      receivers: [otlp]
+      processors: [resource/env, batch]
+      exporters: [otlp]
+```
+
+> **Note**: If cert-manager is deployed in a different namespace or with a different service name, update the target address accordingly. For Kubernetes ServiceMonitor-based setups, ensure the OpenTelemetry Collector can reach cert-manager's metrics endpoint.
+
+## Variables
+
+- `{{namespace}}` - Kubernetes namespace where certificates are deployed
+- `{{issuer}}` - Certificate issuer name for filtering by issuer
+- `{{certificate_name}}` - Certificate name for filtering specific certificates
+- `{{cluster}}` - Kubernetes cluster name for multi-cluster environments
+- `{{deployment.environment}}` - Deployment environment (e.g., staging, production)
+
+## Dashboard Panels
+
+### General Overview
+- **Total Certificates** - Total number of certificates tracked by cert-manager
+  `certmanager_certificate_ready_status`
+- **Active Certificates (Ready)** - Certificates currently in Ready state
+  `certmanager_certificate_ready_status` (condition=True)
+- **Certificate Requests** - Total ACME HTTP client requests
+  `certmanager_http_acme_client_request_count`
+- **Uptime** - Cert-manager process uptime
+  `process_start_time_seconds`
+
+![General Overview](assets/general-overview.png)
+
+### Certificate Issuance
+- **Certificates Issued per Issuer** - Ready certificates grouped by issuer
+  `certmanager_certificate_ready_status` grouped by `issuer_name`
+- **Issuance Rate** - Rate of ACME client requests over time
+  `certmanager_http_acme_client_request_count` (rate)
+- **Issuance Success Rate** - Percentage of certificates in Ready state
+  `certmanager_certificate_ready_status` (formula: Ready / Total * 100)
+
+![Certificate Issuance](assets/certificate-issuance.png)
+
+### Certificate Renewal
+- **Days Until Certificate Expiration** - Time remaining before certificate expiry
+  `certmanager_certificate_expiration_timestamp_seconds`
+- **Renewal Success Rate** - Percentage of successfully renewed certificates
+  `certmanager_certificate_ready_status`
+- **Days Until Renewal** - Time remaining before scheduled renewal
+  `certmanager_certificate_renewal_timestamp_seconds`
+
+![Certificate Renewal](assets/certificate-renewal.png)
+
+### Error Metrics
+- **Certificate Issuance Errors** - Certificates with Ready condition = False
+  `certmanager_certificate_ready_status` (condition=False)
+- **Renewal Errors by Issuer** - Failed certificates grouped by issuer
+  `certmanager_certificate_ready_status` (condition=False, grouped by issuer_name)
+- **API Server Errors** - ACME requests with 4xx/5xx status codes
+  `certmanager_http_acme_client_request_count` (status >= 400)
+
+![Error Metrics](assets/error-metrics.png)
+
+### Resource Usage
+- **CPU Usage** - CPU time consumed by cert-manager process
+  `process_cpu_seconds_total`
+- **Memory Usage** - Resident memory used by cert-manager
+  `process_resident_memory_bytes`
+- **Pod Restarts** - Container restart count for cert-manager pods
+  `kube_pod_container_status_restarts_total`
+
+![Resource Usage](assets/resource-usage.png)
+
+### API and Event Metrics
+- **API Request Rate** - Rate of ACME HTTP requests by method
+  `certmanager_http_acme_client_request_count` (rate, grouped by method)
+- **Event Processing Rate** - Controller sync call rate by controller
+  `certmanager_controller_sync_call_count` (rate, grouped by controller)
+- **Failed API Requests** - Rate of failed ACME requests by method and status
+  `certmanager_http_acme_client_request_count` (rate, status=4xx/5xx)
+
+![API and Event Metrics](assets/api-event-metrics.png)
+
+> **Note**: Screenshots will be added after importing the dashboard into SigNoz. Placeholder image references are included above for the expected screenshot locations in the `assets/` directory.


### PR DESCRIPTION
## Summary
- Adds a comprehensive **Cert-Manager Monitoring Dashboard** with **19 panels across 6 sections**, covering the full certificate lifecycle
- Sections: General Overview, Certificate Issuance, Certificate Renewal, Error Metrics, Resource Usage, API & Event Metrics
- Includes **5 dashboard variables** (namespace, issuer, certificate_name, cluster, deployment.environment) for flexible filtering
- Uses SigNoz Query Builder format (v4 schema) with PromQL fallbacks
- Includes complete README with OpenTelemetry Collector configuration for scraping cert-manager's `/metrics` endpoint on port 9402

## Panels (19 total)

| Section | Panels | Key Metrics |
|---------|--------|-------------|
| General Overview | Total Certificates, Active Certificates, Certificate Requests, Uptime | `certmanager_certificate_ready_status`, `certmanager_http_acme_client_request_count`, `process_start_time_seconds` |
| Certificate Issuance | Certs per Issuer, Issuance Rate, Success Rate | `certmanager_certificate_ready_status`, `certmanager_http_acme_client_request_count` |
| Certificate Renewal | Days Until Expiration, Renewal Success Rate, Days Until Renewal | `certmanager_certificate_expiration_timestamp_seconds`, `certmanager_certificate_renewal_timestamp_seconds` |
| Error Metrics | Issuance Errors, Renewal Errors by Issuer, API Server Errors | `certmanager_certificate_ready_status` (condition=False), `certmanager_http_acme_client_request_count` (4xx/5xx) |
| Resource Usage | CPU Usage, Memory Usage, Pod Restarts | `process_cpu_seconds_total`, `process_resident_memory_bytes`, `kube_pod_container_status_restarts_total` |
| API & Event Metrics | API Request Rate, Event Processing Rate, Failed API Requests | `certmanager_http_acme_client_request_count`, `certmanager_controller_sync_call_count` |

## Files Added
- `cert-manager/cert-manager-prometheus-v1.json` — Dashboard JSON (v4 schema)
- `cert-manager/readme.md` — Setup guide with OTel Collector config
- `cert-manager/assets/.gitkeep` — Placeholder for screenshots

## Test plan
- [ ] Import `cert-manager-prometheus-v1.json` into SigNoz via Dashboard Import
- [ ] Verify all 6 sections and 19 panels render correctly
- [ ] Verify dashboard variables populate and filter correctly
- [ ] Confirm metrics display when cert-manager Prometheus metrics are being scraped

/claim SigNoz/signoz#6023

🤖 Generated with [Claude Code](https://claude.com/claude-code)