### PR TITLE
Add Cert-Manager Prometheus Monitoring Dashboard

### DIFF
--- a/cert-manager/cert-manager-prometheus-v1.json
+++ b/cert-manager/cert-manager-prometheus-v1.json
@@ -1,0 +1,3655 @@
+{
+  "description": "Comprehensive monitoring dashboard for cert-manager, tracking certificate lifecycle, issuance, renewal, errors, resource usage, and API metrics.",
+  "image": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNOSAxLjVMMi4yNSA0LjVWOC4yNUMyLjI1IDEyLjQxIDUuMTA3NSAxNi4zMjM3IDkgMTcuMjVDMTIuODkyNSAxNi4zMjM3IDE1Ljc1IDEyLjQxIDE1Ljc1IDguMjVWNC41TDkgMS41WiIgZmlsbD0iIzMyNkNFNSIgc3Ryb2tlPSIjMjQ1N0IyIiBzdHJva2Utd2lkdGg9IjAuNSIvPjxwYXRoIGQ9Ik03IDkuNUw4LjUgMTFMMTEuNSA3IiBzdHJva2U9IndoaXRlIiBzdHJva2Utd2lkdGg9IjEuNSIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIiBmaWxsPSJub25lIi8+PC9zdmc+",
+  "layout": [
+    {
+      "h": 1,
+      "i": "80b051f3-a21d-4aa9-a26d-c9207629c5a8",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 0,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 3,
+      "i": "4d345958-570a-4fc9-82a8-e1d21fac8821",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 0,
+      "y": 1
+    },
+    {
+      "h": 3,
+      "i": "54127b77-9306-4b1d-b2b2-ce59d989993c",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 3,
+      "y": 1
+    },
+    {
+      "h": 3,
+      "i": "2e81582e-13fa-4c84-9067-646032184e38",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 6,
+      "y": 1
+    },
+    {
+      "h": 3,
+      "i": "857b1f1c-a08f-45c2-bd1b-b7406eb2a056",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 9,
+      "y": 1
+    },
+    {
+      "h": 1,
+      "i": "5d440dd8-3194-45ee-ad22-496fbaf06ff9",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 4,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 6,
+      "i": "4d4b06c3-f225-4675-81b8-402f02c5f09d",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 5
+    },
+    {
+      "h": 6,
+      "i": "9b697bef-9437-4ab6-80ce-167486c1daa4",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 5
+    },
+    {
+      "h": 3,
+      "i": "318b0c89-c38d-445e-9332-bb0e349892eb",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 11
+    },
+    {
+      "h": 1,
+      "i": "8aaadb41-8f0b-4c06-9114-7b4f44d2c8f2",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 14,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 3,
+      "i": "00c7cf33-1e4e-4348-bcd1-b278ffa1a9ab",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 15
+    },
+    {
+      "h": 3,
+      "i": "49c35f69-22e6-47a9-83d9-e7b73d2c6fe9",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 15
+    },
+    {
+      "h": 6,
+      "i": "884487e1-4dff-4915-9a21-fa5ced650c11",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 18
+    },
+    {
+      "h": 1,
+      "i": "055653f3-1311-4af5-884b-75e4874f619d",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 24,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 6,
+      "i": "21887f0c-dc48-4e16-9f14-52bd935da3bc",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 25
+    },
+    {
+      "h": 6,
+      "i": "ee75750c-8f84-4b54-8db4-fe8da96f657c",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 25
+    },
+    {
+      "h": 6,
+      "i": "5bde75bd-cc77-444c-aa2f-ec7816b5201d",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 25
+    },
+    {
+      "h": 1,
+      "i": "d72697cc-61ce-4385-85eb-28cda13c3f9f",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 31,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 6,
+      "i": "aee801ea-796d-430d-8876-dc2e6b03ccb2",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 32
+    },
+    {
+      "h": 6,
+      "i": "1f782451-a923-4e55-b36e-a78fc7477971",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 32
+    },
+    {
+      "h": 6,
+      "i": "e1db0e0e-70f4-4b92-94c3-bf67198620f6",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 32
+    },
+    {
+      "h": 1,
+      "i": "79c1f6f9-df67-4d9c-8fbd-9b1928c59d26",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 38,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 6,
+      "i": "8207bd5b-e37d-4c85-91e2-0b0ce4bf8400",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 39
+    },
+    {
+      "h": 6,
+      "i": "1c8f78bb-6ce7-4618-90ac-147a4d33f515",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 39
+    },
+    {
+      "h": 6,
+      "i": "3fee0556-644d-45ff-82d0-35c7d836c3ae",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 39
+    }
+  ],
+  "panelMap": {
+    "80b051f3-a21d-4aa9-a26d-c9207629c5a8": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 3,
+          "i": "4d345958-570a-4fc9-82a8-e1d21fac8821",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 0,
+          "y": 1
+        },
+        {
+          "h": 3,
+          "i": "54127b77-9306-4b1d-b2b2-ce59d989993c",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 3,
+          "y": 1
+        },
+        {
+          "h": 3,
+          "i": "2e81582e-13fa-4c84-9067-646032184e38",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 6,
+          "y": 1
+        },
+        {
+          "h": 3,
+          "i": "857b1f1c-a08f-45c2-bd1b-b7406eb2a056",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 9,
+          "y": 1
+        }
+      ]
+    },
+    "5d440dd8-3194-45ee-ad22-496fbaf06ff9": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "4d4b06c3-f225-4675-81b8-402f02c5f09d",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 5
+        },
+        {
+          "h": 6,
+          "i": "9b697bef-9437-4ab6-80ce-167486c1daa4",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 5
+        },
+        {
+          "h": 3,
+          "i": "318b0c89-c38d-445e-9332-bb0e349892eb",
+          "moved": false,
+          "static": false,
+          "w": 12,
+          "x": 0,
+          "y": 11
+        }
+      ]
+    },
+    "8aaadb41-8f0b-4c06-9114-7b4f44d2c8f2": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 3,
+          "i": "00c7cf33-1e4e-4348-bcd1-b278ffa1a9ab",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 15
+        },
+        {
+          "h": 3,
+          "i": "49c35f69-22e6-47a9-83d9-e7b73d2c6fe9",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 15
+        },
+        {
+          "h": 6,
+          "i": "884487e1-4dff-4915-9a21-fa5ced650c11",
+          "moved": false,
+          "static": false,
+          "w": 12,
+          "x": 0,
+          "y": 18
+        }
+      ]
+    },
+    "055653f3-1311-4af5-884b-75e4874f619d": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "21887f0c-dc48-4e16-9f14-52bd935da3bc",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 0,
+          "y": 25
+        },
+        {
+          "h": 6,
+          "i": "ee75750c-8f84-4b54-8db4-fe8da96f657c",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 4,
+          "y": 25
+        },
+        {
+          "h": 6,
+          "i": "5bde75bd-cc77-444c-aa2f-ec7816b5201d",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 8,
+          "y": 25
+        }
+      ]
+    },
+    "d72697cc-61ce-4385-85eb-28cda13c3f9f": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "aee801ea-796d-430d-8876-dc2e6b03ccb2",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 0,
+          "y": 32
+        },
+        {
+          "h": 6,
+          "i": "1f782451-a923-4e55-b36e-a78fc7477971",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 4,
+          "y": 32
+        },
+        {
+          "h": 6,
+          "i": "e1db0e0e-70f4-4b92-94c3-bf67198620f6",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 8,
+          "y": 32
+        }
+      ]
+    },
+    "79c1f6f9-df67-4d9c-8fbd-9b1928c59d26": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "8207bd5b-e37d-4c85-91e2-0b0ce4bf8400",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 0,
+          "y": 39
+        },
+        {
+          "h": 6,
+          "i": "1c8f78bb-6ce7-4618-90ac-147a4d33f515",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 4,
+          "y": 39
+        },
+        {
+          "h": 6,
+          "i": "3fee0556-644d-45ff-82d0-35c7d836c3ae",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 8,
+          "y": 39
+        }
+      ]
+    }
+  },
+  "tags": [
+    "cert-manager",
+    "kubernetes",
+    "tls",
+    "certificates",
+    "prometheus"
+  ],
+  "title": "Cert-Manager Dashboard",
+  "uploadedGrafana": false,
+  "variables": {
+    "adbb026b-861a-4dab-a850-b2fbdeef94d2": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "Kubernetes namespace where cert-manager is deployed",
+      "id": "adbb026b-861a-4dab-a850-b2fbdeef94d2",
+      "key": "adbb026b-861a-4dab-a850-b2fbdeef94d2",
+      "modificationUUID": "e3d9a943-b48b-412b-bed5-016474d96a1a",
+      "multiSelect": true,
+      "name": "namespace",
+      "order": 0,
+      "queryValue": "SELECT DISTINCT JSONExtractString(labels, 'namespace') FROM signoz_metrics.distributed_time_series_v4 WHERE metric_name = 'certmanager_certificate_ready_status'",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "cd4a5f93-7484-4309-a58f-c5a5f3b77a83": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "Certificate issuer name (e.g., letsencrypt, vault)",
+      "id": "cd4a5f93-7484-4309-a58f-c5a5f3b77a83",
+      "key": "cd4a5f93-7484-4309-a58f-c5a5f3b77a83",
+      "modificationUUID": "24fee436-a2b7-4486-9506-cb8ba26305bd",
+      "multiSelect": true,
+      "name": "issuer",
+      "order": 1,
+      "queryValue": "SELECT DISTINCT JSONExtractString(labels, 'issuer_name') FROM signoz_metrics.distributed_time_series_v4 WHERE metric_name = 'certmanager_certificate_ready_status'",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "875c94d3-53ea-40de-93bb-6934227545ce": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "Specific certificate name to filter metrics",
+      "id": "875c94d3-53ea-40de-93bb-6934227545ce",
+      "key": "875c94d3-53ea-40de-93bb-6934227545ce",
+      "modificationUUID": "22dbb8f3-5b4c-45eb-9d3a-c34f61c90692",
+      "multiSelect": true,
+      "name": "certificate_name",
+      "order": 2,
+      "queryValue": "SELECT DISTINCT JSONExtractString(labels, 'name') FROM signoz_metrics.distributed_time_series_v4 WHERE metric_name = 'certmanager_certificate_ready_status'",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "b7bc91cd-05a9-4cf4-af51-0bc308d5fb58": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "Kubernetes cluster name for multi-cluster setups",
+      "id": "b7bc91cd-05a9-4cf4-af51-0bc308d5fb58",
+      "key": "b7bc91cd-05a9-4cf4-af51-0bc308d5fb58",
+      "modificationUUID": "e4e5c412-f7eb-4415-b81c-650efc9bfdde",
+      "multiSelect": false,
+      "name": "cluster",
+      "order": 3,
+      "queryValue": "SELECT DISTINCT JSONExtractString(labels, 'k8s_cluster_name') FROM signoz_metrics.distributed_time_series_v4 WHERE metric_name LIKE 'certmanager%'",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "7aa49b1b-cace-458f-a67a-97e7d54b5195": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "Deployment environment (e.g., production, staging)",
+      "id": "7aa49b1b-cace-458f-a67a-97e7d54b5195",
+      "key": "7aa49b1b-cace-458f-a67a-97e7d54b5195",
+      "modificationUUID": "15648eff-634e-4af6-adb2-f4ceeb2657e8",
+      "multiSelect": false,
+      "name": "deployment_environment",
+      "order": 4,
+      "queryValue": "SELECT DISTINCT JSONExtractString(labels, 'deployment_environment') FROM signoz_metrics.distributed_time_series_v4 WHERE metric_name LIKE 'certmanager%'",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "version": "v4",
+  "widgets": [
+    {
+      "description": "High-level metrics providing an overview of cert-manager's health and performance",
+      "id": "80b051f3-a21d-4aa9-a26d-c9207629c5a8",
+      "panelTypes": "row",
+      "title": "General Overview"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total number of certificates managed by cert-manager across all states",
+      "fillSpans": false,
+      "id": "4d345958-570a-4fc9-82a8-e1d21fac8821",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "certmanager_certificate_ready_status--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "certmanager_certificate_ready_status",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b891ee5a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "count"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "fa38d603-4992-4920-be07-fe3674ae4ffe",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Certificates",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of certificates currently in Ready state",
+      "fillSpans": false,
+      "id": "54127b77-9306-4b1d-b2b2-ce59d989993c",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "certmanager_certificate_ready_status--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "certmanager_certificate_ready_status",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b891ee5a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  },
+                  {
+                    "id": "5a55a89e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "condition--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "condition",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "True"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8df88a57-0263-4022-825a-de0f76c09612",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [
+        {
+          "index": "76e559f3-a670-4156-841a-058d849014fc",
+          "isEditEnabled": false,
+          "keyIndex": 0,
+          "selectedGraph": "value",
+          "thresholdColor": "Green",
+          "thresholdFormat": "Text",
+          "thresholdLabel": "",
+          "thresholdOperator": ">",
+          "thresholdTableOptions": "A",
+          "thresholdUnit": "none",
+          "thresholdValue": 0
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Certificates",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total number of controller sync calls processed in the selected time range",
+      "fillSpans": false,
+      "id": "2e81582e-13fa-4c84-9067-646032184e38",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "certmanager_controller_sync_call_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "certmanager_controller_sync_call_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b891ee5a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d1fb1f99-0b5e-4a59-a856-d5a9726a2689",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Certificate Requests",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total uptime of cert-manager since the last restart",
+      "fillSpans": false,
+      "id": "857b1f1c-a08f-45c2-bd1b-b7406eb2a056",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "signoz_calls_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "signoz_calls_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a2fcc02f-8fba-4a54-9a49-00cdfbcbc43a",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Uptime",
+            "name": "A",
+            "query": "time() - max(process_start_time_seconds{namespace=~\"$namespace\"})"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Uptime",
+      "yAxisUnit": "s"
+    },
+    {
+      "description": "Metrics related to the issuance of certificates by cert-manager",
+      "id": "5d440dd8-3194-45ee-ad22-496fbaf06ff9",
+      "panelTypes": "row",
+      "title": "Certificate Issuance"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of certificates issued by each configured issuer",
+      "fillSpans": false,
+      "id": "4d4b06c3-f225-4675-81b8-402f02c5f09d",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "certmanager_certificate_ready_status--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "certmanager_certificate_ready_status",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b891ee5a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  },
+                  {
+                    "id": "e8d2643b",
+                    "key": {
+                      "dataType": "string",
+                      "id": "condition--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "condition",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "True"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "issuer_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "issuer_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{issuer_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "e9a8e757-861c-45cb-b9c8-df7e54eb1457",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Certificates Issued per Issuer",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate at which certificates are being issued over time",
+      "fillSpans": false,
+      "id": "9b697bef-9437-4ab6-80ce-167486c1daa4",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "certmanager_controller_sync_call_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "certmanager_controller_sync_call_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b891ee5a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  },
+                  {
+                    "id": "25608f52",
+                    "key": {
+                      "dataType": "string",
+                      "id": "controller--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "controller",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "certificates-issuing"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Issuance Rate",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "62562536-fd51-4264-86b0-ca0ba5f5d035",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Issuance Rate",
+      "yAxisUnit": "ops"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Percentage of successful certificate issuances versus failed attempts",
+      "fillSpans": false,
+      "id": "318b0c89-c38d-445e-9332-bb0e349892eb",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "certmanager_controller_sync_call_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "certmanager_controller_sync_call_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b891ee5a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  },
+                  {
+                    "id": "a5722bcf",
+                    "key": {
+                      "dataType": "string",
+                      "id": "controller--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "controller",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "certificates-issuing"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "certmanager_controller_sync_error_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "certmanager_controller_sync_error_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b891ee5a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  },
+                  {
+                    "id": "1a0258f9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "controller--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "controller",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "certificates-issuing"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "(A - B) / A * 100",
+              "queryName": "F1",
+              "legend": "Success Rate %"
+            }
+          ]
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ef8a34e2-4494-44b5-9d71-7373c1ec72d6",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Issuance Success Rate",
+      "yAxisUnit": "percent"
+    },
+    {
+      "description": "Metrics related to the renewal process of certificates managed by cert-manager",
+      "id": "8aaadb41-8f0b-4c06-9114-7b4f44d2c8f2",
+      "panelTypes": "row",
+      "title": "Certificate Renewal"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of certificates not in Ready state, potentially pending renewal or re-issuance",
+      "fillSpans": false,
+      "id": "00c7cf33-1e4e-4348-bcd1-b278ffa1a9ab",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "certmanager_certificate_ready_status--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "certmanager_certificate_ready_status",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b891ee5a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  },
+                  {
+                    "id": "804cbfbf",
+                    "key": {
+                      "dataType": "string",
+                      "id": "condition--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "condition",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "False"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ab4dda8c-612a-4bf7-bbf3-3ee917554e14",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [
+        {
+          "index": "a8645687-051d-4cc5-ac15-a6657ef20a18",
+          "isEditEnabled": false,
+          "keyIndex": 0,
+          "selectedGraph": "value",
+          "thresholdColor": "Red",
+          "thresholdFormat": "Text",
+          "thresholdLabel": "",
+          "thresholdOperator": ">",
+          "thresholdTableOptions": "A",
+          "thresholdUnit": "none",
+          "thresholdValue": 0
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Certificates Pending Renewal",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Percentage of successful renewals versus failed renewal attempts",
+      "fillSpans": false,
+      "id": "49c35f69-22e6-47a9-83d9-e7b73d2c6fe9",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "certmanager_controller_sync_call_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "certmanager_controller_sync_call_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b891ee5a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  },
+                  {
+                    "id": "824e5bc5",
+                    "key": {
+                      "dataType": "string",
+                      "id": "controller--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "controller",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "certificates-readiness"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "certmanager_controller_sync_error_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "certmanager_controller_sync_error_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b891ee5a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  },
+                  {
+                    "id": "4d67637b",
+                    "key": {
+                      "dataType": "string",
+                      "id": "controller--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "controller",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "certificates-readiness"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "(A - B) / A * 100",
+              "queryName": "F1",
+              "legend": "Renewal Success Rate %"
+            }
+          ]
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8d3ba28c-8e01-402c-9af1-69527dd7f2ef",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Renewal Success Rate",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Average time taken for ACME client requests, indicating certificate renewal duration",
+      "fillSpans": false,
+      "id": "884487e1-4dff-4915-9a21-fa5ced650c11",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "certmanager_http_acme_client_request_duration_seconds--float64--Summary--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "certmanager_http_acme_client_request_duration_seconds",
+                "type": "Summary"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b891ee5a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "host--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "host",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{host}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "218d1d75-dd8a-4be2-ba0b-92dd40fd2b73",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Renewal Duration",
+      "yAxisUnit": "s"
+    },
+    {
+      "description": "Metrics related to errors and failures within cert-manager operations",
+      "id": "055653f3-1311-4af5-884b-75e4874f619d",
+      "panelTypes": "row",
+      "title": "Error Metrics"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of errors encountered during the certificate issuance process",
+      "fillSpans": false,
+      "id": "21887f0c-dc48-4e16-9f14-52bd935da3bc",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "certmanager_controller_sync_error_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "certmanager_controller_sync_error_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b891ee5a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  },
+                  {
+                    "id": "f3872704",
+                    "key": {
+                      "dataType": "string",
+                      "id": "controller--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "controller",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "certificates-issuing"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "controller--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "controller",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{controller}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "33c338bd-7dd6-4bd4-95c7-782caaecaa89",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Certificate Issuance Errors",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of errors that occurred during the certificate renewal process",
+      "fillSpans": false,
+      "id": "ee75750c-8f84-4b54-8db4-fe8da96f657c",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "certmanager_controller_sync_error_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "certmanager_controller_sync_error_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b891ee5a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  },
+                  {
+                    "id": "e97da5ec",
+                    "key": {
+                      "dataType": "string",
+                      "id": "controller--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "controller",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "certificates-readiness"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "controller--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "controller",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{controller}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "099349c9-8be0-4a7a-9cfa-472638b4b625",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Renewal Errors",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of ACME API requests with error HTTP status codes (4xx/5xx)",
+      "fillSpans": false,
+      "id": "5bde75bd-cc77-444c-aa2f-ec7816b5201d",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "certmanager_http_acme_client_request_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "certmanager_http_acme_client_request_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b891ee5a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  },
+                  {
+                    "id": "5078414b",
+                    "key": {
+                      "dataType": "string",
+                      "id": "status--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "status",
+                      "type": "tag"
+                    },
+                    "op": ">=",
+                    "value": "400"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "status--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "status",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "method--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "method",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{method}} {{status}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "66662af2-dd4d-4fa7-a19b-ad1409540903",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "API Server Errors",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Metrics related to the resource consumption of cert-manager",
+      "id": "d72697cc-61ce-4385-85eb-28cda13c3f9f",
+      "panelTypes": "row",
+      "title": "Resource Usage"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "CPU usage by the cert-manager pods, indicating the processing load",
+      "fillSpans": false,
+      "id": "aee801ea-796d-430d-8876-dc2e6b03ccb2",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "process_cpu_seconds_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "process_cpu_seconds_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b891ee5a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "CPU Usage",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d2cb78a4-369b-49df-9810-aacc692d0c3d",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "CPU Usage",
+      "yAxisUnit": "percentunit"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Memory consumption of the cert-manager process",
+      "fillSpans": false,
+      "id": "1f782451-a923-4e55-b36e-a78fc7477971",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "process_resident_memory_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "process_resident_memory_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b891ee5a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Memory Usage",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f2d2d8a2-5018-4ba6-8e20-49bb5855ab9e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memory Usage",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Current depth of cert-manager work queues, spikes may indicate processing backlogs or stability issues",
+      "fillSpans": false,
+      "id": "e1db0e0e-70f4-4b92-94c3-bf67198620f6",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "workqueue_depth--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "workqueue_depth",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b891ee5a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "e39cb73f-1d8c-4b5a-a941-65678b50900a",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Workqueue Depth",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Metrics related to API requests and events handled by cert-manager",
+      "id": "79c1f6f9-df67-4d9c-8fbd-9b1928c59d26",
+      "panelTypes": "row",
+      "title": "API and Event Metrics"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of HTTP ACME API requests processed by cert-manager over time",
+      "fillSpans": false,
+      "id": "8207bd5b-e37d-4c85-91e2-0b0ce4bf8400",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "certmanager_http_acme_client_request_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "certmanager_http_acme_client_request_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b891ee5a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "method--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "method",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "status--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "status",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{method}} {{status}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "4a97215f-1158-443f-95db-1462e8554c22",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "API Request Rate",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of events being added to cert-manager work queues, indicating responsiveness to cluster changes",
+      "fillSpans": false,
+      "id": "1c8f78bb-6ce7-4618-90ac-147a4d33f515",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "workqueue_adds_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "workqueue_adds_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b891ee5a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "1006bfb4-94d3-41c4-a4be-16a289320762",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Event Processing Rate",
+      "yAxisUnit": "ops"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of failed ACME API requests, helping identify communication issues",
+      "fillSpans": false,
+      "id": "3fee0556-644d-45ff-82d0-35c7d836c3ae",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "certmanager_http_acme_client_request_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "certmanager_http_acme_client_request_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b891ee5a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  },
+                  {
+                    "id": "30c15a7e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "status--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "status",
+                      "type": "tag"
+                    },
+                    "op": ">=",
+                    "value": "400"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "status--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "status",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "host--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "host",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{host}} ({{status}})",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "51a35f51-a411-406a-bf43-a6bdb7e26adf",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Failed API Requests",
+      "yAxisUnit": "none"
+    }
+  ]
+}

--- a/cert-manager/readme.md
+++ b/cert-manager/readme.md
@@ -1,0 +1,191 @@
+# Cert-Manager Dashboard
+
+## Metrics Ingestion
+
+### Cert-Manager Metrics
+
+Cert-Manager exposes Prometheus metrics on port `9402` at the `/metrics` endpoint. These metrics provide insights into certificate lifecycle, controller operations, ACME client requests, and process health.
+
+Key metric categories:
+- **Certificate metrics**: `certmanager_certificate_ready_status`, `certmanager_certificate_expiration_timestamp_seconds`
+- **Controller metrics**: `certmanager_controller_sync_call_count`, `certmanager_controller_sync_error_count`
+- **ACME metrics**: `certmanager_http_acme_client_request_count`, `certmanager_http_acme_client_request_duration_seconds`
+- **Process metrics**: `process_cpu_seconds_total`, `process_resident_memory_bytes`, `process_start_time_seconds`
+- **Workqueue metrics**: `workqueue_adds_total`, `workqueue_depth`
+
+### Configure OpenTelemetry Collector
+
+1. Add a Prometheus receiver to the `receivers:` section of your OpenTelemetry Collector config:
+
+```yaml
+  prometheus:
+    config:
+      global:
+        scrape_interval: 60s
+      scrape_configs:
+        - job_name: cert-manager
+          metrics_path: /metrics
+          scheme: http
+          static_configs:
+            - targets:
+              - cert-manager.cert-manager.svc.cluster.local:9402
+```
+
+> **Note:** Adjust the target address based on your cert-manager deployment. The default Kubernetes service address is `cert-manager.cert-manager.svc.cluster.local:9402`. For local development, use `localhost:9402`.
+
+2. Complete Configuration Example
+
+Below is a complete `otel-config.yaml` example:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+  hostmetrics:
+    collection_interval: 60s
+    scrapers:
+      cpu: {}
+      disk: {}
+      load: {}
+      filesystem: {}
+      memory: {}
+      network: {}
+      paging: {}
+      process:
+        mute_process_name_error: true
+        mute_process_exe_error: true
+        mute_process_io_error: true
+      processes: {}
+  prometheus:
+    config:
+      global:
+        scrape_interval: 60s
+      scrape_configs:
+        - job_name: otel-collector-binary
+          static_configs:
+            - targets:
+              - localhost:8888
+        - job_name: cert-manager
+          metrics_path: /metrics
+          scheme: http
+          static_configs:
+            - targets:
+              - cert-manager.cert-manager.svc.cluster.local:9402
+
+processors:
+  batch:
+    send_batch_size: 1000
+    timeout: 10s
+  resourcedetection:
+    detectors: [env, system]
+    timeout: 2s
+    system:
+      hostname_sources: [os]
+  resource/env:
+    attributes:
+    - key: deployment.environment
+      value: production
+      action: upsert
+
+extensions:
+  health_check: {}
+  zpages: {}
+
+exporters:
+  otlp:
+    endpoint: "ingest.{region}.signoz.cloud:443"
+    tls:
+      insecure: false
+    headers:
+      "signoz-access-token": "your-ingestion-key"
+  logging:
+    verbosity: normal
+
+service:
+  telemetry:
+    metrics:
+      address: 0.0.0.0:8888
+  extensions: [health_check, zpages]
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [resource/env, batch]
+      exporters: [otlp]
+    metrics/internal:
+      receivers: [prometheus, hostmetrics]
+      processors: [resource/env, resourcedetection, batch]
+      exporters: [otlp]
+    traces:
+      receivers: [otlp]
+      processors: [resource/env, batch]
+      exporters: [otlp]
+    logs:
+      receivers: [otlp]
+      processors: [resource/env, batch]
+      exporters: [otlp]
+```
+
+## Variables
+
+- `{{namespace}}`: Kubernetes namespace where cert-manager is deployed
+- `{{issuer}}`: Certificate issuer name (e.g., letsencrypt-prod, vault)
+- `{{certificate_name}}`: Specific certificate name to filter metrics
+- `{{cluster}}`: Kubernetes cluster name for multi-cluster setups
+- `{{deployment_environment}}`: Deployment environment (e.g., production, staging)
+
+## Sections
+
+- General Overview
+  - Total Certificates -
+  `certmanager_certificate_ready_status`
+  - Active Certificates -
+  `certmanager_certificate_ready_status`
+  - Certificate Requests -
+  `certmanager_controller_sync_call_count`
+  - Uptime -
+  `process_start_time_seconds`
+  ![General Overview](assets/general-overview.png)
+- Certificate Issuance
+  - Certificates Issued per Issuer -
+  `certmanager_certificate_ready_status`
+  - Issuance Rate -
+  `certmanager_controller_sync_call_count`
+  - Issuance Success Rate -
+  `certmanager_controller_sync_call_count`, `certmanager_controller_sync_error_count`
+  ![Certificate Issuance](assets/certificate-issuance.png)
+- Certificate Renewal
+  - Certificates Pending Renewal -
+  `certmanager_certificate_ready_status`
+  - Renewal Success Rate -
+  `certmanager_controller_sync_call_count`, `certmanager_controller_sync_error_count`
+  - Renewal Duration -
+  `certmanager_http_acme_client_request_duration_seconds`
+  ![Certificate Renewal](assets/certificate-renewal.png)
+- Error Metrics
+  - Certificate Issuance Errors -
+  `certmanager_controller_sync_error_count`
+  - Renewal Errors -
+  `certmanager_controller_sync_error_count`
+  - API Server Errors -
+  `certmanager_http_acme_client_request_count`
+  ![Error Metrics](assets/error-metrics.png)
+- Resource Usage
+  - CPU Usage -
+  `process_cpu_seconds_total`
+  - Memory Usage -
+  `process_resident_memory_bytes`
+  - Workqueue Depth -
+  `workqueue_depth`
+  ![Resource Usage](assets/resource-usage.png)
+- API and Event Metrics
+  - API Request Rate -
+  `certmanager_http_acme_client_request_count`
+  - Event Processing Rate -
+  `workqueue_adds_total`
+  - Failed API Requests -
+  `certmanager_http_acme_client_request_count`
+  ![API and Event Metrics](assets/api-event-metrics.png)


### PR DESCRIPTION
## Summary

Adds a comprehensive **Cert-Manager Prometheus monitoring dashboard** with 6 sections and 19 panels, covering the full certificate lifecycle.

Closes https://github.com/SigNoz/signoz/issues/6023

## Dashboard Sections

### 1. General Overview (4 value panels)
- **Total Certificates** — Count of all managed certificates
- **Active Certificates** — Certificates in Ready state
- **Certificate Requests** — Controller sync calls processed
- **Uptime** — Time since last cert-manager restart

### 2. Certificate Issuance (2 graphs + 1 value)
- **Certificates Issued per Issuer** — Breakdown by issuer name
- **Issuance Rate** — Certificate issuance rate over time
- **Issuance Success Rate** — Success percentage via formula \(sync_calls - sync_errors) / sync_calls * 100\

### 3. Certificate Renewal (2 values + 1 graph)
- **Certificates Pending Renewal** — Not-ready certificates count
- **Renewal Success Rate** — Renewal success percentage
- **Renewal Duration** — ACME client request duration over time

### 4. Error Metrics (3 graphs)
- **Certificate Issuance Errors** — Error rate for issuance controller
- **Renewal Errors** — Error rate for readiness controller
- **API Server Errors** — ACME API requests with 4xx/5xx status codes

### 5. Resource Usage (3 graphs)
- **CPU Usage** — Process CPU consumption
- **Memory Usage** — Resident memory bytes
- **Workqueue Depth** — Work queue depth by queue name

### 6. API and Event Metrics (3 graphs)
- **API Request Rate** — ACME HTTP request rate by method/status
- **Event Processing Rate** — Workqueue additions rate
- **Failed API Requests** — Failed ACME requests by host/status

## Template Variables
| Variable | Description |
|----------|-------------|
| \
amespace\ | Kubernetes namespace where cert-manager is deployed |
| \issuer\ | Certificate issuer name (e.g., letsencrypt, vault) |
| \certificate_name\ | Specific certificate name filter |
| \cluster\ | Kubernetes cluster (multi-cluster setups) |
| \deployment_environment\ | Environment (production, staging) |

## Key Metrics Used
- \certmanager_certificate_ready_status\ — Certificate readiness state
- \certmanager_controller_sync_call_count\ / \certmanager_controller_sync_error_count\ — Controller operations
- \certmanager_http_acme_client_request_count\ / \certmanager_http_acme_client_request_duration_seconds\ — ACME client
- \process_cpu_seconds_total\ / \process_resident_memory_bytes\ — Resource usage
- \workqueue_adds_total\ / \workqueue_depth\ — Event processing

## Implementation Notes
- Uses **SigNoz Query Builder** format for 18/19 panels (PromQL used only for uptime calculation requiring \	ime()\ function)
- Dashboard schema version: **v4**
- Follows naming convention: \cert-manager-prometheus-v1.json\
- Includes OpenTelemetry Collector configuration in README for metrics ingestion via Prometheus receiver on port 9402
- References: [cert-manager Prometheus Metrics](https://cert-manager.io/docs/devops-tips/prometheus-metrics) and [Grafana Dashboard #11001](https://grafana.com/grafana/dashboards/11001)

## Files
- \cert-manager/cert-manager-prometheus-v1.json\ — Dashboard JSON (102KB, 19 panels)
- \cert-manager/readme.md\ — Documentation with OTel Collector config