### PR TITLE
feat: add Istio monitoring dashboard

### DIFF
--- a/istio/istio-prometheus-v1.json
+++ b/istio/istio-prometheus-v1.json
@@ -1,0 +1,6048 @@
+{
+  "description": "Comprehensive monitoring dashboard for Istio service mesh, tracking traffic, performance, errors, resource usage, control plane, data plane, and security metrics.",
+  "image": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNOSAxTDIgNVYxM0w5IDE3TDE2IDEzVjVMOSAxWiIgZmlsbD0iIzQ2NkJCMCIgc3Ryb2tlPSIjMzQ1NTk1IiBzdHJva2Utd2lkdGg9IjAuNSIvPjxwYXRoIGQ9Ik05IDNWMTVNNS41IDVMOSAxM00xMi41IDVMOSAxMyIgc3Ryb2tlPSJ3aGl0ZSIgc3Ryb2tlLXdpZHRoPSIxLjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgZmlsbD0ibm9uZSIvPjwvc3ZnPg==",
+  "layout": [
+    {
+      "h": 1,
+      "i": "9325cb4a-7b4e-497d-b559-22cecc1f8079",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 0,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 3,
+      "i": "07d00d3d-82a0-490e-9e7e-ff4d747bce7e",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 0,
+      "y": 1
+    },
+    {
+      "h": 3,
+      "i": "15082fce-78e4-4253-8c8c-34bacc7358b4",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 3,
+      "y": 1
+    },
+    {
+      "h": 3,
+      "i": "605c4d86-0acf-450b-87de-aa8441b5ec31",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 6,
+      "y": 1
+    },
+    {
+      "h": 3,
+      "i": "532ab43f-b6e4-4668-853f-5de3890af409",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 9,
+      "y": 1
+    },
+    {
+      "h": 1,
+      "i": "5ee8595a-4fc1-488a-a4c1-3cb4b72477f8",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 4,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 6,
+      "i": "4ba298b4-3a05-4e33-961c-699d0e0a52cb",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 5
+    },
+    {
+      "h": 6,
+      "i": "124c9644-8cba-45ab-9ea5-7dfb10eb49a9",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 5
+    },
+    {
+      "h": 6,
+      "i": "db7a00fa-8474-4223-b06d-b221a9394e0e",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 11
+    },
+    {
+      "h": 6,
+      "i": "5a5b7e10-27eb-4e9e-8456-6b5e0a01ae79",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 11
+    },
+    {
+      "h": 1,
+      "i": "56cb440f-a195-4476-93ca-63862eeebc2e",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 17,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 6,
+      "i": "eeb07e34-a6a1-4400-8e77-3fe5a5ee5777",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 18
+    },
+    {
+      "h": 6,
+      "i": "47414554-ff0b-44d0-a065-becafcc8f690",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 18
+    },
+    {
+      "h": 6,
+      "i": "fa4b7e9c-0ab3-47cb-902e-59bdd8c6ab39",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 24
+    },
+    {
+      "h": 6,
+      "i": "dfb05c15-375f-48cc-b5a0-50f5835854c2",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 24
+    },
+    {
+      "h": 1,
+      "i": "73614b39-bd65-485d-ab01-c615403eea91",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 30,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 6,
+      "i": "dd0a15a4-2427-42cd-8253-422902bbf73e",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 31
+    },
+    {
+      "h": 6,
+      "i": "9c67999d-7276-4b96-8d6b-f52846cad069",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 31
+    },
+    {
+      "h": 6,
+      "i": "680decf1-56cf-4931-bac1-bc5b13318354",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 37
+    },
+    {
+      "h": 6,
+      "i": "55cba844-873d-4009-b1e7-fa7f67f46510",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 37
+    },
+    {
+      "h": 1,
+      "i": "567d68fe-91d5-43d0-b726-7cbdcdf1949e",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 43,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 6,
+      "i": "723f16d8-a870-48da-a26d-6ae858e050b7",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 44
+    },
+    {
+      "h": 6,
+      "i": "5369ede9-f9e2-4823-81d6-a23f10865afb",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 44
+    },
+    {
+      "h": 6,
+      "i": "d01f26b4-1aec-4057-bd1c-94acbebb17a8",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 44
+    },
+    {
+      "h": 1,
+      "i": "c50bcb41-146b-4427-8994-f0ae9e211c83",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 50,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 6,
+      "i": "0e53dd5e-2ee7-4922-a50b-3a6a1871e69c",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 51
+    },
+    {
+      "h": 6,
+      "i": "7a54e4df-5466-42c2-a2f3-f454304dd3e8",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 51
+    },
+    {
+      "h": 6,
+      "i": "28706862-ed89-45d4-8894-fd1c4b291576",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 57
+    },
+    {
+      "h": 6,
+      "i": "56a5639e-d1a0-4f4c-85f9-054e4b9b4646",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 57
+    },
+    {
+      "h": 1,
+      "i": "2f4b1328-77e8-440a-8a64-23e859c7649b",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 63,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 6,
+      "i": "2a7fccab-49b0-4692-b187-05bb670b79cb",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 64
+    },
+    {
+      "h": 6,
+      "i": "163ada43-5811-40c2-b010-a82776dc2bb8",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 64
+    },
+    {
+      "h": 6,
+      "i": "e70ff548-5faa-4565-8a91-132dd384dd4a",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 70
+    },
+    {
+      "h": 6,
+      "i": "9444371f-18d1-4395-8643-a40a969c7ca2",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 70
+    },
+    {
+      "h": 1,
+      "i": "130d0293-2520-4c8b-b6c4-8c805cefa22f",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 76,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 6,
+      "i": "bf8f1939-4ebb-4c65-bd6a-7d417e2f4d3d",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 77
+    },
+    {
+      "h": 6,
+      "i": "44f56e6b-6034-4e9e-8b9f-2f1c32c6dc18",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 77
+    },
+    {
+      "h": 6,
+      "i": "8f8edb94-cdfb-4f72-a7c2-9ce547c5c9c3",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 83
+    },
+    {
+      "h": 6,
+      "i": "4a5ec04c-3db8-4c42-98aa-f57fdf8fe03f",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 83
+    }
+  ],
+  "panelMap": {
+    "9325cb4a-7b4e-497d-b559-22cecc1f8079": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 3,
+          "i": "07d00d3d-82a0-490e-9e7e-ff4d747bce7e",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 0,
+          "y": 1
+        },
+        {
+          "h": 3,
+          "i": "15082fce-78e4-4253-8c8c-34bacc7358b4",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 3,
+          "y": 1
+        },
+        {
+          "h": 3,
+          "i": "605c4d86-0acf-450b-87de-aa8441b5ec31",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 6,
+          "y": 1
+        },
+        {
+          "h": 3,
+          "i": "532ab43f-b6e4-4668-853f-5de3890af409",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 9,
+          "y": 1
+        }
+      ]
+    },
+    "5ee8595a-4fc1-488a-a4c1-3cb4b72477f8": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "4ba298b4-3a05-4e33-961c-699d0e0a52cb",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 5
+        },
+        {
+          "h": 6,
+          "i": "124c9644-8cba-45ab-9ea5-7dfb10eb49a9",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 5
+        },
+        {
+          "h": 6,
+          "i": "db7a00fa-8474-4223-b06d-b221a9394e0e",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 11
+        },
+        {
+          "h": 6,
+          "i": "5a5b7e10-27eb-4e9e-8456-6b5e0a01ae79",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 11
+        }
+      ]
+    },
+    "56cb440f-a195-4476-93ca-63862eeebc2e": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "eeb07e34-a6a1-4400-8e77-3fe5a5ee5777",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 18
+        },
+        {
+          "h": 6,
+          "i": "47414554-ff0b-44d0-a065-becafcc8f690",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 18
+        },
+        {
+          "h": 6,
+          "i": "fa4b7e9c-0ab3-47cb-902e-59bdd8c6ab39",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 24
+        },
+        {
+          "h": 6,
+          "i": "dfb05c15-375f-48cc-b5a0-50f5835854c2",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 24
+        }
+      ]
+    },
+    "73614b39-bd65-485d-ab01-c615403eea91": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "dd0a15a4-2427-42cd-8253-422902bbf73e",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 31
+        },
+        {
+          "h": 6,
+          "i": "9c67999d-7276-4b96-8d6b-f52846cad069",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 31
+        },
+        {
+          "h": 6,
+          "i": "680decf1-56cf-4931-bac1-bc5b13318354",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 37
+        },
+        {
+          "h": 6,
+          "i": "55cba844-873d-4009-b1e7-fa7f67f46510",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 37
+        }
+      ]
+    },
+    "567d68fe-91d5-43d0-b726-7cbdcdf1949e": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "723f16d8-a870-48da-a26d-6ae858e050b7",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 0,
+          "y": 44
+        },
+        {
+          "h": 6,
+          "i": "5369ede9-f9e2-4823-81d6-a23f10865afb",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 4,
+          "y": 44
+        },
+        {
+          "h": 6,
+          "i": "d01f26b4-1aec-4057-bd1c-94acbebb17a8",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 8,
+          "y": 44
+        }
+      ]
+    },
+    "c50bcb41-146b-4427-8994-f0ae9e211c83": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "0e53dd5e-2ee7-4922-a50b-3a6a1871e69c",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 51
+        },
+        {
+          "h": 6,
+          "i": "7a54e4df-5466-42c2-a2f3-f454304dd3e8",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 51
+        },
+        {
+          "h": 6,
+          "i": "28706862-ed89-45d4-8894-fd1c4b291576",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 57
+        },
+        {
+          "h": 6,
+          "i": "56a5639e-d1a0-4f4c-85f9-054e4b9b4646",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 57
+        }
+      ]
+    },
+    "2f4b1328-77e8-440a-8a64-23e859c7649b": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "2a7fccab-49b0-4692-b187-05bb670b79cb",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 64
+        },
+        {
+          "h": 6,
+          "i": "163ada43-5811-40c2-b010-a82776dc2bb8",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 64
+        },
+        {
+          "h": 6,
+          "i": "e70ff548-5faa-4565-8a91-132dd384dd4a",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 70
+        },
+        {
+          "h": 6,
+          "i": "9444371f-18d1-4395-8643-a40a969c7ca2",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 70
+        }
+      ]
+    },
+    "130d0293-2520-4c8b-b6c4-8c805cefa22f": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "bf8f1939-4ebb-4c65-bd6a-7d417e2f4d3d",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 77
+        },
+        {
+          "h": 6,
+          "i": "44f56e6b-6034-4e9e-8b9f-2f1c32c6dc18",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 77
+        },
+        {
+          "h": 6,
+          "i": "8f8edb94-cdfb-4f72-a7c2-9ce547c5c9c3",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 83
+        },
+        {
+          "h": 6,
+          "i": "4a5ec04c-3db8-4c42-98aa-f57fdf8fe03f",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 83
+        }
+      ]
+    }
+  },
+  "tags": [
+    "istio",
+    "service-mesh",
+    "kubernetes",
+    "envoy",
+    "prometheus"
+  ],
+  "title": "Istio Monitoring Dashboard",
+  "uploadedGrafana": false,
+  "variables": {
+    "2b8aba66-89a4-4786-ab62-b38db96f6b2e": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "Kubernetes namespace where Istio is deployed",
+      "id": "2b8aba66-89a4-4786-ab62-b38db96f6b2e",
+      "key": "2b8aba66-89a4-4786-ab62-b38db96f6b2e",
+      "modificationUUID": "6dd4e1eb-1bce-4e06-9c89-aeb59b4ebcdf",
+      "multiSelect": true,
+      "name": "namespace",
+      "order": 0,
+      "queryValue": "SELECT DISTINCT JSONExtractString(labels, 'namespace') FROM signoz_metrics.distributed_time_series_v4 WHERE metric_name = 'istio_requests_total'",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "48be5c1f-ca1e-47c7-8e3f-51d528ab3a95": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "Deployment environment",
+      "id": "48be5c1f-ca1e-47c7-8e3f-51d528ab3a95",
+      "key": "48be5c1f-ca1e-47c7-8e3f-51d528ab3a95",
+      "modificationUUID": "88890a59-6e40-4e33-8b47-7d90f7eceb3b",
+      "multiSelect": false,
+      "name": "deployment_environment",
+      "order": 1,
+      "queryValue": "SELECT DISTINCT JSONExtractString(labels, 'deployment_environment') FROM signoz_metrics.distributed_time_series_v4 WHERE metric_name LIKE 'istio%'",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "a53e5c32-a7ac-4235-bdab-e8647f876c84": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "Destination service name within the mesh",
+      "id": "a53e5c32-a7ac-4235-bdab-e8647f876c84",
+      "key": "a53e5c32-a7ac-4235-bdab-e8647f876c84",
+      "modificationUUID": "da500b40-7887-4ff2-88cc-7a717564d167",
+      "multiSelect": true,
+      "name": "service_name",
+      "order": 2,
+      "queryValue": "SELECT DISTINCT JSONExtractString(labels, 'destination_service_name') FROM signoz_metrics.distributed_time_series_v4 WHERE metric_name = 'istio_requests_total'",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "c6bd45ef-c32c-4934-bcf1-eb2691345dad": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "Kubernetes cluster for multi-cluster setups",
+      "id": "c6bd45ef-c32c-4934-bcf1-eb2691345dad",
+      "key": "c6bd45ef-c32c-4934-bcf1-eb2691345dad",
+      "modificationUUID": "95a8fe47-f6fa-4d09-ac4b-dcb23cb388ab",
+      "multiSelect": false,
+      "name": "cluster",
+      "order": 3,
+      "queryValue": "SELECT DISTINCT JSONExtractString(labels, 'k8s_cluster_name') FROM signoz_metrics.distributed_time_series_v4 WHERE metric_name LIKE 'istio%'",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "version": "v4",
+  "widgets": [
+    {
+      "description": "High-level metrics providing an overview of Istio's health and performance",
+      "id": "9325cb4a-7b4e-497d-b559-22cecc1f8079",
+      "panelTypes": "row",
+      "title": "General Overview"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total number of requests processed by the service mesh",
+      "fillSpans": false,
+      "id": "07d00d3d-82a0-490e-9e7e-ff4d747bce7e",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0b2145bf-7372-4468-88d9-ee67a8426684",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Requests",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of incoming and outgoing requests per second",
+      "fillSpans": false,
+      "id": "15082fce-78e4-4253-8c8c-34bacc7358b4",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Request Rate",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "61234e3f-7280-4805-b6c7-f95f0b9df541",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Rate",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Average latency of requests within the mesh",
+      "fillSpans": false,
+      "id": "605c4d86-0acf-450b-87de-aa8441b5ec31",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_request_duration_milliseconds_sum--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_request_duration_milliseconds_sum",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_request_duration_milliseconds_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_request_duration_milliseconds_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "A / B",
+              "queryName": "F1",
+              "legend": "Avg Latency"
+            }
+          ]
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "fa66a859-66ee-4ca8-b04b-f44ebdfe1b5c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Average Latency",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Percentage of failed requests (5xx) compared to total requests",
+      "fillSpans": false,
+      "id": "532ab43f-b6e4-4668-853f-5de3890af409",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  },
+                  {
+                    "id": "f4537ad2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "response_code--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "response_code",
+                      "type": "tag"
+                    },
+                    "op": "=~",
+                    "value": "5.*"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "A / B * 100",
+              "queryName": "F1",
+              "legend": "Error Rate %"
+            }
+          ]
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "5f3a1285-1af9-4dc9-8fb2-8f58646e9347",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Error Rate",
+      "yAxisUnit": "percent"
+    },
+    {
+      "description": "Metrics related to traffic routing, load balancing, and service discovery within Istio",
+      "id": "5ee8595a-4fc1-488a-a4c1-3cb4b72477f8",
+      "panelTypes": "row",
+      "title": "Traffic Management"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Distribution of requests across different destination services",
+      "fillSpans": false,
+      "id": "4ba298b4-3a05-4e33-961c-699d0e0a52cb",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "destination_service_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "destination_service_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{destination_service_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "634d8ca6-52f6-446a-ac69-87444dc003ae",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Distribution",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Request distribution across destination workloads",
+      "fillSpans": false,
+      "id": "124c9644-8cba-45ab-9ea5-7dfb10eb49a9",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "destination_workload--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "destination_workload",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{destination_workload}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9de5362e-95c2-4b16-bcce-c3c129e6a0c2",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Load Balancing Efficiency",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of circuit breaker events triggered",
+      "fillSpans": false,
+      "id": "db7a00fa-8474-4223-b06d-b221a9394e0e",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "envoy_cluster_circuit_breakers_default_cx_open--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "envoy_cluster_circuit_breakers_default_cx_open",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "cluster_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "cluster_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{cluster_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d6a26c23-e359-45a8-9d26-c22b9a25d80b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Circuit Breaker Events",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Retry attempts and timeout occurrences in request handling",
+      "fillSpans": false,
+      "id": "5a5b7e10-27eb-4e9e-8456-6b5e0a01ae79",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "envoy_cluster_upstream_rq_retry--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "envoy_cluster_upstream_rq_retry",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Retries",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "envoy_cluster_upstream_rq_timeout--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "envoy_cluster_upstream_rq_timeout",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Timeouts",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "5f4f5547-6cf1-4a38-8d1b-462ced76ce81",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Retries and Timeouts",
+      "yAxisUnit": "ops"
+    },
+    {
+      "description": "Metrics related to the performance and responsiveness of services within Istio",
+      "id": "56cb440f-a195-4476-93ca-63862eeebc2e",
+      "panelTypes": "row",
+      "title": "Performance Metrics"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "50th percentile request latency",
+      "fillSpans": false,
+      "id": "eeb07e34-a6a1-4400-8e77-3fe5a5ee5777",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_request_duration_milliseconds_bucket--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_request_duration_milliseconds_bucket",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p50",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "destination_service_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "destination_service_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "p50 {{destination_service_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "p50"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "cc592924-806f-4f4c-b8b6-eaefb035e971",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Latency P50",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "95th and 99th percentile request latency",
+      "fillSpans": false,
+      "id": "47414554-ff0b-44d0-a065-becafcc8f690",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_request_duration_milliseconds_bucket--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_request_duration_milliseconds_bucket",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p95",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "destination_service_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "destination_service_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "p95 {{destination_service_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "p95"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_request_duration_milliseconds_bucket--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_request_duration_milliseconds_bucket",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p99",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "destination_service_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "destination_service_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "p99 {{destination_service_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "p99"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "1eccec8e-7314-4a18-80ac-064d22ff77a4",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Latency P95 / P99",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Requests processed per second by service",
+      "fillSpans": false,
+      "id": "fa4b7e9c-0ab3-47cb-902e-59bdd8c6ab39",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "destination_service_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "destination_service_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{destination_service_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f91f7824-2a0d-4a14-a2ed-1d1b530bbc6b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Throughput",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Response times of individual services",
+      "fillSpans": false,
+      "id": "dfb05c15-375f-48cc-b5a0-50f5835854c2",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_request_duration_milliseconds_sum--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_request_duration_milliseconds_sum",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "destination_service_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "destination_service_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{destination_service_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6dfd0ea8-adf6-4137-b159-e4975a0a28b5",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Service Response Times",
+      "yAxisUnit": "ms"
+    },
+    {
+      "description": "Metrics related to errors and failures within the Istio service mesh",
+      "id": "73614b39-bd65-485d-ab01-c615403eea91",
+      "panelTypes": "row",
+      "title": "Error Metrics"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of HTTP errors (4xx, 5xx) across services",
+      "fillSpans": false,
+      "id": "dd0a15a4-2427-42cd-8253-422902bbf73e",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  },
+                  {
+                    "id": "c4e7de14",
+                    "key": {
+                      "dataType": "string",
+                      "id": "response_code--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "response_code",
+                      "type": "tag"
+                    },
+                    "op": "=~",
+                    "value": "4.*"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "response_code--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "response_code",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "4xx {{response_code}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  },
+                  {
+                    "id": "3252d26e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "response_code--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "response_code",
+                      "type": "tag"
+                    },
+                    "op": "=~",
+                    "value": "5.*"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "response_code--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "response_code",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "5xx {{response_code}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "fae1bcd7-e060-4556-9521-f253879d9b89",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "HTTP Error Rates",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of gRPC errors in service communications",
+      "fillSpans": false,
+      "id": "9c67999d-7276-4b96-8d6b-f52846cad069",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  },
+                  {
+                    "id": "bf876716",
+                    "key": {
+                      "dataType": "string",
+                      "id": "request_protocol--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "request_protocol",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "grpc"
+                  },
+                  {
+                    "id": "d59a0000",
+                    "key": {
+                      "dataType": "string",
+                      "id": "grpc_response_status--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "grpc_response_status",
+                      "type": "tag"
+                    },
+                    "op": "!=",
+                    "value": "0"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "grpc_response_status--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "grpc_response_status",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "destination_service_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "destination_service_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{destination_service_name}} ({{grpc_response_status}})",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "7f7cfe37-30a5-48db-a178-187e22f338dd",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "gRPC Error Rates",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of failed requests (5xx) attributed to each service",
+      "fillSpans": false,
+      "id": "680decf1-56cf-4931-bac1-bc5b13318354",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  },
+                  {
+                    "id": "f92295f9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "response_code--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "response_code",
+                      "type": "tag"
+                    },
+                    "op": "=~",
+                    "value": "5.*"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "destination_service_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "destination_service_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{destination_service_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "609a03ae-2d04-4e7a-85ab-615e8e487abf",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Failed Requests by Service",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of TLS handshake failures",
+      "fillSpans": false,
+      "id": "55cba844-873d-4009-b1e7-fa7f67f46510",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "envoy_cluster_ssl_handshake--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "envoy_cluster_ssl_handshake",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "cluster_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "cluster_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{cluster_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "82f7b16e-ebec-4676-9b5c-a3baebb1cdac",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "TLS Handshake Failures",
+      "yAxisUnit": "ops"
+    },
+    {
+      "description": "Metrics related to the resource consumption of Istio components",
+      "id": "567d68fe-91d5-43d0-b726-7cbdcdf1949e",
+      "panelTypes": "row",
+      "title": "Resource Usage"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "CPU usage for Istio control plane and data plane components",
+      "fillSpans": false,
+      "id": "723f16d8-a870-48da-a26d-6ae858e050b7",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "process_cpu_seconds_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "process_cpu_seconds_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "job--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "job",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{job}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c1c7e4ad-03f5-44d8-8bb1-439fb95913e5",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "CPU Usage",
+      "yAxisUnit": "percentunit"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Memory consumption of Istio components",
+      "fillSpans": false,
+      "id": "5369ede9-f9e2-4823-81d6-a23f10865afb",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "process_resident_memory_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "process_resident_memory_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "job--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "job",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{job}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f2a552e3-7f22-4e36-9a57-3442f74c4ebf",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memory Usage",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Active TCP connections across the mesh",
+      "fillSpans": false,
+      "id": "d01f26b4-1aec-4057-bd1c-94acbebb17a8",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_tcp_connections_opened_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_tcp_connections_opened_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Opened",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_tcp_connections_closed_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_tcp_connections_closed_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Closed",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b138e5ea-2a98-4a68-8bd8-6572cc95eac7",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "TCP Connections",
+      "yAxisUnit": "ops"
+    },
+    {
+      "description": "Metrics related to the Istio control plane operations",
+      "id": "c50bcb41-146b-4427-8994-f0ae9e211c83",
+      "panelTypes": "row",
+      "title": "Control Plane Metrics"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Configuration synchronizations performed by Pilot (istiod)",
+      "fillSpans": false,
+      "id": "0e53dd5e-2ee7-4922-a50b-3a6a1871e69c",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "pilot_xds_pushes--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "pilot_xds_pushes",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "type--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "type",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{type}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b81fdeb2-f72f-49d9-8e57-69da9d9348fa",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Pilot xDS Pushes",
+      "yAxisUnit": "ops"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Time taken for proxy configuration to converge",
+      "fillSpans": false,
+      "id": "7a54e4df-5466-42c2-a2f3-f454304dd3e8",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "pilot_proxy_convergence_time_bucket--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "pilot_proxy_convergence_time_bucket",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p95",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p95 Convergence Time",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "p95"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "3e54a3aa-febd-49a8-a8aa-27c1e39ec4a8",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Pilot Proxy Convergence Time",
+      "yAxisUnit": "s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of connected xDS endpoints",
+      "fillSpans": false,
+      "id": "28706862-ed89-45d4-8894-fd1c4b291576",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "pilot_xds--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "pilot_xds",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "type--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "type",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{type}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b5c2149e-943e-4d45-8658-0e34c2e6c89b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Pilot Connected Endpoints",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Certificates issued by Citadel/istiod for mTLS",
+      "fillSpans": false,
+      "id": "56a5639e-d1a0-4f4c-85f9-054e4b9b4646",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "citadel_server_csr_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "citadel_server_csr_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "CSR Count",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "673b9c15-ecfb-42a1-800f-5c6dab689f03",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Citadel Certificate Issuance",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Metrics related to the Istio data plane (Envoy sidecar proxies)",
+      "id": "2f4b1328-77e8-440a-8a64-23e859c7649b",
+      "panelTypes": "row",
+      "title": "Data Plane Metrics"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Active upstream connections in Envoy proxies",
+      "fillSpans": false,
+      "id": "2a7fccab-49b0-4692-b187-05bb670b79cb",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "envoy_cluster_upstream_cx_active--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "envoy_cluster_upstream_cx_active",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "cluster_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "cluster_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{cluster_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "cad3ab82-6d67-452c-8dda-22583229e96a",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Connections",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Volume of inbound and outbound traffic through proxies",
+      "fillSpans": false,
+      "id": "163ada43-5811-40c2-b010-a82776dc2bb8",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_request_bytes_sum--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_request_bytes_sum",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  },
+                  {
+                    "id": "f75fa029",
+                    "key": {
+                      "dataType": "string",
+                      "id": "reporter--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "reporter",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "destination"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Inbound",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_request_bytes_sum--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_request_bytes_sum",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  },
+                  {
+                    "id": "aa366caf",
+                    "key": {
+                      "dataType": "string",
+                      "id": "reporter--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "reporter",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "source"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Outbound",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "1e506353-51b3-4f99-8d53-fc94b217df1c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Inbound vs Outbound Traffic",
+      "yAxisUnit": "binBps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Response bytes through Envoy proxies by service",
+      "fillSpans": false,
+      "id": "e70ff548-5faa-4565-8a91-132dd384dd4a",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_response_bytes_sum--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_response_bytes_sum",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "destination_service_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "destination_service_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{destination_service_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "44ff4ccf-82fb-4d7d-91c3-d6e14fcc69b4",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Proxy Response Size",
+      "yAxisUnit": "binBps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Connection errors encountered by data plane proxies",
+      "fillSpans": false,
+      "id": "9444371f-18d1-4395-8643-a40a969c7ca2",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "envoy_cluster_upstream_cx_connect_fail--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "envoy_cluster_upstream_cx_connect_fail",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "cluster_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "cluster_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{cluster_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0bf30dd2-5a71-4d18-9d4b-e6fda48a0358",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Connection Errors",
+      "yAxisUnit": "ops"
+    },
+    {
+      "description": "Metrics related to security features and policies enforced by Istio",
+      "id": "130d0293-2520-4c8b-b6c4-8c805cefa22f",
+      "panelTypes": "row",
+      "title": "Security Metrics"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Connections secured with mutual TLS vs plaintext",
+      "fillSpans": false,
+      "id": "bf8f1939-4ebb-4c65-bd6a-7d417e2f4d3d",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  },
+                  {
+                    "id": "ceb0d65f",
+                    "key": {
+                      "dataType": "string",
+                      "id": "connection_security_policy--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "connection_security_policy",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "mutual_tls"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "mTLS",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  },
+                  {
+                    "id": "ddfc727e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "connection_security_policy--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "connection_security_policy",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "none"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Plaintext",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d81972fc-d1fe-4530-869b-a705fdc56461",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Mutual TLS Usage",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Allowed and denied requests by authorization policy",
+      "fillSpans": false,
+      "id": "44f56e6b-6034-4e9e-8b9f-2f1c32c6dc18",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  },
+                  {
+                    "id": "d97a7b23",
+                    "key": {
+                      "dataType": "string",
+                      "id": "response_code--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "response_code",
+                      "type": "tag"
+                    },
+                    "op": "=~",
+                    "value": "2.*|3.*"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Allowed",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  },
+                  {
+                    "id": "83350be3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "response_code--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "response_code",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "403"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Denied (403)",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "cbed1713-1ed7-4e24-8013-725a358bf2fe",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Authorization Policy Enforcement",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "CSR requests and certificate issuance counts",
+      "fillSpans": false,
+      "id": "8f8edb94-cdfb-4f72-a7c2-9ce547c5c9c3",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "citadel_server_csr_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "citadel_server_csr_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "CSR Requests",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "citadel_server_success_cert_issuance_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "citadel_server_success_cert_issuance_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Successful Issuances",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "2cd18079-1e4c-42e4-a28c-79f1cd64c02b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Certificate Expirations",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Requests denied due to security policies (4xx/403)",
+      "fillSpans": false,
+      "id": "4a5ec04c-3db8-4c42-98aa-f57fdf8fe03f",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "11d5d61e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$namespace"
+                  },
+                  {
+                    "id": "e3203b45",
+                    "key": {
+                      "dataType": "string",
+                      "id": "response_code--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "response_code",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "403"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "destination_service_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "destination_service_name",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "source_workload--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "source_workload",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{source_workload}} -> {{destination_service_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6f852440-0e1e-4dba-85d3-1c886344e548",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Security Policy Violations",
+      "yAxisUnit": "reqps"
+    }
+  ]
+}

--- a/istio/readme.md
+++ b/istio/readme.md
@@ -1,0 +1,212 @@
+# Istio Monitoring Dashboard
+
+## Metrics Ingestion
+
+### Istio Metrics
+Istio exports Prometheus metrics from both the control plane (istiod) and data plane (Envoy sidecar proxies). Key metric endpoints:
+
+1. **Envoy sidecar proxies** expose metrics at port `15090` on `/stats/prometheus` — includes `istio_requests_total`, `istio_request_duration_milliseconds`, `istio_request_bytes`, `istio_response_bytes`, and `envoy_*` metrics.
+2. **Istiod (Pilot)** exposes metrics at port `15014` on `/metrics` — includes `pilot_*`, `citadel_*`, and `process_*` metrics.
+
+### Configure OpenTelemetry Collector
+
+1. Add prometheus receiver to the `receivers:` section:
+
+```yaml
+  prometheus:
+    config:
+      global:
+        scrape_interval: 60s
+      scrape_configs:
+        - job_name: istio-envoy
+          metrics_path: /stats/prometheus
+          kubernetes_sd_configs:
+            - role: pod
+          relabel_configs:
+            - source_labels: [__meta_kubernetes_pod_container_port_number]
+              regex: "15090"
+              action: keep
+            - source_labels: [__meta_kubernetes_pod_name]
+              target_label: pod
+            - source_labels: [__meta_kubernetes_namespace]
+              target_label: namespace
+        - job_name: istiod
+          metrics_path: /metrics
+          kubernetes_sd_configs:
+            - role: endpoints
+              namespaces:
+                names:
+                  - istio-system
+          relabel_configs:
+            - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+              regex: istiod;http-monitoring
+              action: keep
+```
+
+2. Complete Configuration Example
+
+Below is a complete `otel-config.yaml` example:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+  hostmetrics:
+    collection_interval: 60s
+    scrapers:
+      cpu: {}
+      disk: {}
+      load: {}
+      filesystem: {}
+      memory: {}
+      network: {}
+      paging: {}
+      process:
+        mute_process_name_error: true
+        mute_process_exe_error: true
+        mute_process_io_error: true
+      processes: {}
+  prometheus:
+    config:
+      global:
+        scrape_interval: 60s
+      scrape_configs:
+        - job_name: otel-collector-binary
+          static_configs:
+            - targets:
+              - localhost:8888
+        - job_name: istio-envoy
+          metrics_path: /stats/prometheus
+          kubernetes_sd_configs:
+            - role: pod
+          relabel_configs:
+            - source_labels: [__meta_kubernetes_pod_container_port_number]
+              regex: "15090"
+              action: keep
+            - source_labels: [__meta_kubernetes_pod_name]
+              target_label: pod
+            - source_labels: [__meta_kubernetes_namespace]
+              target_label: namespace
+        - job_name: istiod
+          metrics_path: /metrics
+          kubernetes_sd_configs:
+            - role: endpoints
+              namespaces:
+                names:
+                  - istio-system
+          relabel_configs:
+            - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+              regex: istiod;http-monitoring
+              action: keep
+
+processors:
+  batch:
+    send_batch_size: 1000
+    timeout: 10s
+  resourcedetection:
+    detectors: [env, system]
+    timeout: 2s
+    system:
+      hostname_sources: [os]
+  resource/env:
+    attributes:
+    - key: deployment.environment
+      value: staging
+      action: upsert
+
+extensions:
+  health_check: {}
+  zpages: {}
+
+exporters:
+  otlp:
+    endpoint: "ingest.{region}.signoz.cloud:443"
+    tls:
+      insecure: false
+    headers:
+      "signoz-access-token": "your-ingestion-key"
+  logging:
+    verbosity: normal
+
+service:
+  telemetry:
+    metrics:
+      address: 0.0.0.0:8888
+  extensions: [health_check, zpages]
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [resource/env, batch]
+      exporters: [otlp]
+    metrics/internal:
+      receivers: [prometheus, hostmetrics]
+      processors: [resource/env, resourcedetection, batch]
+      exporters: [otlp]
+    traces:
+      receivers: [otlp]
+      processors: [resource/env, batch]
+      exporters: [otlp]
+    logs:
+      receivers: [otlp]
+      processors: [resource/env, batch]
+      exporters: [otlp]
+```
+
+## Variables
+
+- `{{namespace}}`: Kubernetes namespace where Istio is deployed
+- `{{deployment_environment}}`: Deployment environment (e.g., production, staging)
+- `{{service_name}}`: Destination service name within the mesh
+- `{{cluster}}`: Kubernetes cluster for multi-cluster setups
+
+## Sections
+
+- General Overview
+  - Total Requests — `istio_requests_total`
+  - Request Rate — `istio_requests_total`
+  - Average Latency — `istio_request_duration_milliseconds_sum` / `istio_request_duration_milliseconds_count`
+  - Error Rate — `istio_requests_total` (5xx / total)
+- Traffic Management
+  - Request Distribution — `istio_requests_total` by `destination_service_name`
+  - Load Balancing Efficiency — `istio_requests_total` by `destination_workload`
+  - Circuit Breaker Events — `envoy_cluster_circuit_breakers_default_cx_open`
+  - Retries and Timeouts — `envoy_cluster_upstream_rq_retry`, `envoy_cluster_upstream_rq_timeout`
+- Performance Metrics
+  - Request Latency P50 — `istio_request_duration_milliseconds_bucket` (p50)
+  - Request Latency P95 / P99 — `istio_request_duration_milliseconds_bucket` (p95, p99)
+  - Throughput — `istio_requests_total` by `destination_service_name`
+  - Service Response Times — `istio_request_duration_milliseconds_sum`
+- Error Metrics
+  - HTTP Error Rates — `istio_requests_total` (4xx, 5xx)
+  - gRPC Error Rates — `istio_requests_total` (grpc errors)
+  - Failed Requests by Service — `istio_requests_total` (5xx by service)
+  - TLS Handshake Failures — `envoy_cluster_ssl_handshake`
+- Resource Usage
+  - CPU Usage — `process_cpu_seconds_total`
+  - Memory Usage — `process_resident_memory_bytes`
+  - TCP Connections — `istio_tcp_connections_opened_total`, `istio_tcp_connections_closed_total`
+- Control Plane Metrics
+  - Pilot xDS Pushes — `pilot_xds_pushes`
+  - Pilot Proxy Convergence Time — `pilot_proxy_convergence_time_bucket`
+  - Pilot Connected Endpoints — `pilot_xds`
+  - Citadel Certificate Issuance — `citadel_server_csr_count`
+- Data Plane Metrics
+  - Active Connections — `envoy_cluster_upstream_cx_active`
+  - Inbound vs Outbound Traffic — `istio_request_bytes_sum`
+  - Proxy Response Size — `istio_response_bytes_sum`
+  - Connection Errors — `envoy_cluster_upstream_cx_connect_fail`
+- Security Metrics
+  - Mutual TLS Usage — `istio_requests_total` by `connection_security_policy`
+  - Authorization Policy Enforcement — `istio_requests_total` (allowed vs denied)
+  - Certificate Expirations — `citadel_server_csr_count`, `citadel_server_success_cert_issuance_count`
+  - Security Policy Violations — `istio_requests_total` (403 by source/destination)
+
+## References
+
+- [Istio Standard Metrics](https://istio.io/latest/docs/reference/config/metrics/)
+- [Istio Observability](https://istio.io/latest/docs/tasks/observability/metrics/)
+- [Grafana Dashboard #7645](https://grafana.com/grafana/dashboards/7645)


### PR DESCRIPTION
## Istio Monitoring Dashboard

Adds a comprehensive Istio service mesh monitoring dashboard for SigNoz.

### Dashboard Structure

| Section | Panels | Key Metrics |
|---------|--------|-------------|
| General Overview | Total Requests, Request Rate, Avg Latency, Error Rate | `istio_requests_total`, `istio_request_duration_milliseconds` |
| Traffic Management | Request Distribution, Load Balancing, Circuit Breakers, Retries/Timeouts | `istio_requests_total`, `envoy_cluster_upstream_rq_retry` |
| Performance Metrics | Latency P50/P95/P99, Throughput, Response Times | `istio_request_duration_milliseconds_bucket` |
| Error Metrics | HTTP Errors, gRPC Errors, Failed Requests, TLS Failures | `istio_requests_total`, `envoy_cluster_ssl_handshake` |
| Resource Usage | CPU, Memory, TCP Connections | `process_cpu_seconds_total`, `process_resident_memory_bytes` |
| Control Plane | Pilot Pushes, Convergence Time, Connected Endpoints, Cert Issuance | `pilot_xds_pushes`, `citadel_server_csr_count` |
| Data Plane | Active Connections, Traffic Volume, Response Size, Connection Errors | `envoy_cluster_upstream_cx_active`, `istio_request_bytes_sum` |
| Security | mTLS Usage, Auth Policy, Cert Expirations, Policy Violations | `istio_requests_total` (connection_security_policy) |

### Variables
- `namespace` — Kubernetes namespace
- `deployment_environment` — Deployment environment
- `service_name` — Destination service name
- `cluster` — Kubernetes cluster (multi-cluster)

### Files
- `istio/istio-prometheus-v1.json` — Dashboard JSON (169KB, 31 panels, 8 sections)
- `istio/readme.md` — Setup instructions with OTel Collector config

### References
- [Istio Standard Metrics](https://istio.io/latest/docs/reference/config/metrics/)
- [Istio Observability](https://istio.io/latest/docs/tasks/observability/metrics/)
- Grafana Dashboard #7645

Closes SigNoz/signoz#6025