### PR TITLE
feat: add ASP.NET OTLP metrics dashboard

### DIFF
--- a/aspnet/README.md
+++ b/aspnet/README.md
@@ -1,0 +1,38 @@
+# ASP.NET Metrics Dashboard
+
+Monitor ASP.NET application performance using OpenTelemetry (OTLP) metrics.
+
+## Panels
+
+| Panel | Type | Description |
+|-------|------|-------------|
+| Request Rate | Graph | HTTP requests per second by route |
+| Average Response Time | Graph | Average request duration by route |
+| Active Requests | Value | Currently active HTTP requests |
+| Error Rate (5xx) | Graph | Rate of 5xx error responses |
+| GC Collections | Graph | .NET garbage collection rate by generation |
+| Thread Pool Size | Graph | Active thread pool thread count |
+| Memory Usage (GC Heap) | Graph | Managed heap size in bytes |
+| CPU Utilization | Graph | Process CPU utilization (0-100%) |
+
+## Variables
+
+- `namespace` — Kubernetes namespace
+- `deployment_environment` — Deployment environment
+- `service_name` — Application service name
+- `cluster` — Kubernetes cluster
+
+## Metrics Used
+
+All metrics follow [OpenTelemetry .NET semantic conventions](https://opentelemetry.io/docs/specs/semconv/dotnet/):
+
+- `http.server.request.duration` (Histogram) — HTTP request duration
+- `http.server.active_requests` (UpDownCounter) — Active request count
+- `process.runtime.dotnet.gc.collections.count` (Sum) — GC collections
+- `process.runtime.dotnet.thread_pool.threads.count` (Gauge) — Thread pool threads
+- `process.runtime.dotnet.gc.heap.size` (Gauge) — GC heap size
+- `process.cpu.utilization` (Gauge) — CPU utilization
+
+## Query Type
+
+Builder (OTLP metrics)

--- a/aspnet/aspnet-otlp-v1.json
+++ b/aspnet/aspnet-otlp-v1.json
@@ -75,7 +75,7 @@
       "y": 18
     }
   ],
-  "name": "",
+  "name": "aspnet-metrics",
   "panelMap": {},
   "tags": [
     "aspnet",

--- a/aspnet/aspnet-otlp-v1.json
+++ b/aspnet/aspnet-otlp-v1.json
@@ -76,32 +76,7 @@
     }
   ],
   "name": "",
-  "panelMap": {
-    "8dcbfda1-1e58-4fd2-af40-ff59ceee3e17": {
-      "collapsed": false
-    },
-    "658b067f-62d2-4500-bb67-7dda534022d2": {
-      "collapsed": false
-    },
-    "f97efdce-2f9e-47a9-acf2-c146548294da": {
-      "collapsed": false
-    },
-    "2b50cacc-25dc-4833-b47c-e68bc60d5f5f": {
-      "collapsed": false
-    },
-    "8c2ebc17-eb67-4a5b-92bb-0e5669a60d9f": {
-      "collapsed": false
-    },
-    "23c7cdd4-717e-4dec-8927-180051889320": {
-      "collapsed": false
-    },
-    "9f89ff70-f435-4b2f-8cb5-d3aab14cde21": {
-      "collapsed": false
-    },
-    "4b5eccd0-7d5b-443b-9901-e5da59d1927d": {
-      "collapsed": false
-    }
-  },
+  "panelMap": {},
   "tags": [
     "aspnet",
     "dotnet"
@@ -238,6 +213,21 @@
                     "value": [
                       "{{.service_name}}"
                     ]
+                  },
+                  {
+                    "id": "c1a2b3d4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "k8s_cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "k8s_cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cluster}}"
+                    ]
                   }
                 ],
                 "op": "AND"
@@ -361,6 +351,21 @@
                     "value": [
                       "{{.service_name}}"
                     ]
+                  },
+                  {
+                    "id": "c1a2b3d4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "k8s_cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "k8s_cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cluster}}"
+                    ]
                   }
                 ],
                 "op": "AND"
@@ -483,6 +488,21 @@
                     "op": "in",
                     "value": [
                       "{{.service_name}}"
+                    ]
+                  },
+                  {
+                    "id": "c1a2b3d4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "k8s_cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "k8s_cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cluster}}"
                     ]
                   }
                 ],
@@ -611,6 +631,21 @@
                     },
                     "op": ">=",
                     "value": "500"
+                  },
+                  {
+                    "id": "c1a2b3d4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "k8s_cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "k8s_cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cluster}}"
+                    ]
                   }
                 ],
                 "op": "AND"
@@ -724,6 +759,21 @@
                     "op": "in",
                     "value": [
                       "{{.service_name}}"
+                    ]
+                  },
+                  {
+                    "id": "c1a2b3d4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "k8s_cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "k8s_cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cluster}}"
                     ]
                   }
                 ],
@@ -848,6 +898,21 @@
                     "value": [
                       "{{.service_name}}"
                     ]
+                  },
+                  {
+                    "id": "c1a2b3d4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "k8s_cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "k8s_cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cluster}}"
+                    ]
                   }
                 ],
                 "op": "AND"
@@ -962,6 +1027,21 @@
                     "value": [
                       "{{.service_name}}"
                     ]
+                  },
+                  {
+                    "id": "c1a2b3d4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "k8s_cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "k8s_cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cluster}}"
+                    ]
                   }
                 ],
                 "op": "AND"
@@ -1075,6 +1155,21 @@
                     "op": "in",
                     "value": [
                       "{{.service_name}}"
+                    ]
+                  },
+                  {
+                    "id": "c1a2b3d4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "k8s_cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "k8s_cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cluster}}"
                     ]
                   }
                 ],

--- a/aspnet/aspnet-otlp-v1.json
+++ b/aspnet/aspnet-otlp-v1.json
@@ -1,0 +1,1124 @@
+{
+  "description": "Monitor ASP.NET application performance including request rates, response times, error rates, GC metrics, and resource usage.",
+  "id": "aspnet-otlp",
+  "layout": [
+    {
+      "h": 6,
+      "i": "8dcbfda1-1e58-4fd2-af40-ff59ceee3e17",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 6,
+      "i": "658b067f-62d2-4500-bb67-7dda534022d2",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 0
+    },
+    {
+      "h": 3,
+      "i": "f97efdce-2f9e-47a9-acf2-c146548294da",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 0,
+      "y": 6
+    },
+    {
+      "h": 6,
+      "i": "2b50cacc-25dc-4833-b47c-e68bc60d5f5f",
+      "moved": false,
+      "static": false,
+      "w": 9,
+      "x": 3,
+      "y": 6
+    },
+    {
+      "h": 6,
+      "i": "8c2ebc17-eb67-4a5b-92bb-0e5669a60d9f",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 12
+    },
+    {
+      "h": 6,
+      "i": "23c7cdd4-717e-4dec-8927-180051889320",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 12
+    },
+    {
+      "h": 6,
+      "i": "9f89ff70-f435-4b2f-8cb5-d3aab14cde21",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 18
+    },
+    {
+      "h": 6,
+      "i": "4b5eccd0-7d5b-443b-9901-e5da59d1927d",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 18
+    }
+  ],
+  "name": "",
+  "panelMap": {
+    "8dcbfda1-1e58-4fd2-af40-ff59ceee3e17": {
+      "collapsed": false
+    },
+    "658b067f-62d2-4500-bb67-7dda534022d2": {
+      "collapsed": false
+    },
+    "f97efdce-2f9e-47a9-acf2-c146548294da": {
+      "collapsed": false
+    },
+    "2b50cacc-25dc-4833-b47c-e68bc60d5f5f": {
+      "collapsed": false
+    },
+    "8c2ebc17-eb67-4a5b-92bb-0e5669a60d9f": {
+      "collapsed": false
+    },
+    "23c7cdd4-717e-4dec-8927-180051889320": {
+      "collapsed": false
+    },
+    "9f89ff70-f435-4b2f-8cb5-d3aab14cde21": {
+      "collapsed": false
+    },
+    "4b5eccd0-7d5b-443b-9901-e5da59d1927d": {
+      "collapsed": false
+    }
+  },
+  "tags": [
+    "aspnet",
+    "dotnet"
+  ],
+  "title": "ASP.NET Metrics",
+  "uploadedGrafana": false,
+  "variables": {
+    "0b343f7e-232c-424e-86b0-cb3c90e458cc": {
+      "customValue": "",
+      "description": "Kubernetes namespace",
+      "id": "0b343f7e-232c-424e-86b0-cb3c90e458cc",
+      "modificationUUID": "d7172772-f302-454e-9a06-2a2ebe21f72c",
+      "multiSelect": true,
+      "name": "namespace",
+      "order": 0,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'k8s_namespace_name')) FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'http_server_request_duration_seconds_count'",
+      "selectedValue": "",
+      "showALLOption": true,
+      "sort": "ASC",
+      "type": "QUERY"
+    },
+    "c552a5e1-4310-4e13-a735-6ff3a9fd96de": {
+      "customValue": "",
+      "description": "Deployment environment",
+      "id": "c552a5e1-4310-4e13-a735-6ff3a9fd96de",
+      "modificationUUID": "95357de8-ae59-48d8-b558-21061fd07ced",
+      "multiSelect": true,
+      "name": "deployment_environment",
+      "order": 1,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'deployment_environment')) FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'http_server_request_duration_seconds_count'",
+      "selectedValue": "",
+      "showALLOption": true,
+      "sort": "ASC",
+      "type": "QUERY"
+    },
+    "aa8f837a-b4eb-4a35-8417-b0616becfcb2": {
+      "customValue": "",
+      "description": "Service name",
+      "id": "aa8f837a-b4eb-4a35-8417-b0616becfcb2",
+      "modificationUUID": "7be9cd83-2553-42f5-8fef-80507d311704",
+      "multiSelect": true,
+      "name": "service_name",
+      "order": 2,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'service_name')) FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'http_server_request_duration_seconds_count'",
+      "selectedValue": "",
+      "showALLOption": true,
+      "sort": "ASC",
+      "type": "QUERY"
+    },
+    "ea77869e-1599-402f-af86-37b6ded97f01": {
+      "customValue": "",
+      "description": "Kubernetes cluster",
+      "id": "ea77869e-1599-402f-af86-37b6ded97f01",
+      "modificationUUID": "dbd12336-5e96-4ee2-838b-3f6adacbc832",
+      "multiSelect": true,
+      "name": "cluster",
+      "order": 3,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'k8s_cluster_name')) FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'http_server_request_duration_seconds_count'",
+      "selectedValue": "",
+      "showALLOption": true,
+      "sort": "ASC",
+      "type": "QUERY"
+    }
+  },
+  "version": "v4",
+  "widgets": [
+    {
+      "description": "Number of HTTP requests per second, grouped by route",
+      "fillSpans": false,
+      "id": "8dcbfda1-1e58-4fd2-af40-ff59ceee3e17",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http.server.request.duration--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http.server.request.duration",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "1001b70f",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "k8s_namespace_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.namespace}}"
+                    ]
+                  },
+                  {
+                    "id": "5a1f3bcf",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  },
+                  {
+                    "id": "2d7bda82",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.service_name}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "http_route--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "http_route",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "${http_route}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "5a143687-4faf-4b6d-bd9a-a9988d0283f3",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Rate",
+      "yAxisUnit": "ops"
+    },
+    {
+      "description": "Average HTTP request duration in seconds, grouped by route",
+      "fillSpans": false,
+      "id": "658b067f-62d2-4500-bb67-7dda534022d2",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http.server.request.duration--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http.server.request.duration",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "40b807da",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "k8s_namespace_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.namespace}}"
+                    ]
+                  },
+                  {
+                    "id": "2031855f",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  },
+                  {
+                    "id": "3ef61b8d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.service_name}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "http_route--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "http_route",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "${http_route}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "dc5390af-c015-4385-b8ab-a80094312979",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Average Response Time",
+      "yAxisUnit": "s"
+    },
+    {
+      "description": "Number of currently active HTTP requests",
+      "fillSpans": false,
+      "id": "f97efdce-2f9e-47a9-acf2-c146548294da",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http.server.active_requests--float64--UpDownCounter--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http.server.active_requests",
+                "type": "UpDownCounter"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f95d326d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "k8s_namespace_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.namespace}}"
+                    ]
+                  },
+                  {
+                    "id": "79bf43c4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  },
+                  {
+                    "id": "569e620a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.service_name}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "607a91c5-1e1f-40d9-9c5b-4e86e1734644",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Requests",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Rate of HTTP 5xx error responses per second",
+      "fillSpans": false,
+      "id": "2b50cacc-25dc-4833-b47c-e68bc60d5f5f",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http.server.request.duration--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http.server.request.duration",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "01589374",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "k8s_namespace_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.namespace}}"
+                    ]
+                  },
+                  {
+                    "id": "5aa5e4f3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  },
+                  {
+                    "id": "d0aa02e3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.service_name}}"
+                    ]
+                  },
+                  {
+                    "id": "ad132ce0",
+                    "key": {
+                      "dataType": "string",
+                      "id": "http_response_status_code--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "http_response_status_code",
+                      "type": "tag"
+                    },
+                    "op": ">=",
+                    "value": "500"
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "779465b9-597b-4dc3-84f1-1ca0bdfabfaf",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Error Rate (5xx)",
+      "yAxisUnit": "ops"
+    },
+    {
+      "description": "Rate of .NET garbage collection events per second by generation",
+      "fillSpans": false,
+      "id": "8c2ebc17-eb67-4a5b-92bb-0e5669a60d9f",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "process.runtime.dotnet.gc.collections.count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "process.runtime.dotnet.gc.collections.count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "bf29c31e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "k8s_namespace_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.namespace}}"
+                    ]
+                  },
+                  {
+                    "id": "ad54ebf7",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  },
+                  {
+                    "id": "32e6fecd",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.service_name}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "generation--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "generation",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Gen ${generation}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "27d41c7e-c6f3-48e0-bb43-a4e411827b36",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "GC Collections",
+      "yAxisUnit": "ops"
+    },
+    {
+      "description": "Average number of active .NET thread pool threads",
+      "fillSpans": false,
+      "id": "23c7cdd4-717e-4dec-8927-180051889320",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "process.runtime.dotnet.thread_pool.threads.count--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "process.runtime.dotnet.thread_pool.threads.count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "bca1f015",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "k8s_namespace_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.namespace}}"
+                    ]
+                  },
+                  {
+                    "id": "b79be134",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  },
+                  {
+                    "id": "2435a9bf",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.service_name}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c7eb6b0b-ce8a-418c-9fbd-37fe3887d9c2",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Thread Pool Size",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Average .NET GC managed heap size in bytes",
+      "fillSpans": false,
+      "id": "9f89ff70-f435-4b2f-8cb5-d3aab14cde21",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "process.runtime.dotnet.gc.heap.size--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "process.runtime.dotnet.gc.heap.size",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "dc31bf7a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "k8s_namespace_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.namespace}}"
+                    ]
+                  },
+                  {
+                    "id": "7da220d2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  },
+                  {
+                    "id": "f34dae8d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.service_name}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a4687e7f-609b-46ad-88ed-91e633033817",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memory Usage (GC Heap)",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "Average CPU utilization of the process (0-1 scale maps to 0-100%)",
+      "fillSpans": false,
+      "id": "4b5eccd0-7d5b-443b-9901-e5da59d1927d",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "process.cpu.utilization--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "process.cpu.utilization",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "6d07d430",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "k8s_namespace_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.namespace}}"
+                    ]
+                  },
+                  {
+                    "id": "b866c7f1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  },
+                  {
+                    "id": "c673988b",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.service_name}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "67534fb6-e676-4633-b443-f08611dacb08",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "CPU Utilization",
+      "yAxisUnit": "percentunit"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- 8-panel ASP.NET monitoring dashboard using OpenTelemetry builder queries
- Covers request rates, response times, error rates (5xx), GC collections, thread pool size, memory (GC heap), and CPU utilization
- 4 template variables: namespace, deployment_environment, service_name, cluster
- All metrics follow OpenTelemetry .NET semantic conventions

/claim #5996

?? Generated with [Claude Code](https://claude.com/claude-code)