### PR TITLE
feat: add Istio service mesh Prometheus dashboard

### DIFF
--- a/istio/README.md
+++ b/istio/README.md
@@ -1,0 +1,39 @@
+# Istio Service Mesh Dashboard
+
+Monitor Istio service mesh performance using Prometheus metrics.
+
+## Panels
+
+| Panel | Type | Description |
+|-------|------|-------------|
+| Request Volume | Graph | Incoming request rate per service |
+| Success Rate | Value | Percentage of non-5xx requests |
+| Request Duration P50 | Graph | 50th percentile latency by service |
+| Request Duration P99 | Graph | 99th percentile latency by service |
+| TCP Connections Opened | Graph | TCP connection open rate per service |
+| TCP Connections Closed | Graph | TCP connection close rate per service |
+| Pilot xDS Pushes | Graph | Istiod config push rate by type |
+| Pilot Proxy Convergence Time P99 | Graph | P99 config convergence latency |
+| Envoy Proxy CPU Usage | Graph | CPU usage per istio-proxy sidecar |
+| Envoy Proxy Memory Usage | Graph | Memory usage per istio-proxy sidecar |
+
+## Variables
+
+- `namespace` — Istio destination service namespace
+- `deployment_environment` — Deployment environment
+- `cluster` — Kubernetes cluster name
+
+## Metrics Used
+
+- `istio_requests_total` — Request counter
+- `istio_request_duration_milliseconds_bucket` — Request latency histogram
+- `istio_tcp_connections_opened_total` — TCP connections opened
+- `istio_tcp_connections_closed_total` — TCP connections closed
+- `pilot_xds_pushes` — Pilot xDS push counter
+- `pilot_proxy_convergence_time_bucket` — Proxy convergence histogram
+- `container_cpu_usage_seconds_total` — Container CPU (istio-proxy)
+- `container_memory_working_set_bytes` — Container memory (istio-proxy)
+
+## Query Type
+
+PromQL

--- a/istio/istio-prometheus-v1.json
+++ b/istio/istio-prometheus-v1.json
@@ -1,0 +1,815 @@
+{
+  "id": "istio-prometheus",
+  "title": "Istio Service Mesh",
+  "description": "Monitor Istio service mesh performance including request volume, success rates, latencies, TCP connections, and control plane metrics.",
+  "name": "",
+  "version": "v4",
+  "tags": [
+    "istio",
+    "service-mesh",
+    "prometheus"
+  ],
+  "uploadedGrafana": false,
+  "layout": [
+    {
+      "i": "1a464c49-1776-4eda-abac-2acfadb93862",
+      "x": 0,
+      "y": 0,
+      "w": 6,
+      "h": 6
+    },
+    {
+      "i": "2dc5dee8-301c-4fd4-9cf0-46cbcb8db876",
+      "x": 6,
+      "y": 0,
+      "w": 6,
+      "h": 3
+    },
+    {
+      "i": "272d3d0a-1ad0-44dc-b393-f60c57a539ff",
+      "x": 0,
+      "y": 6,
+      "w": 6,
+      "h": 6
+    },
+    {
+      "i": "c463818b-f703-4909-ab65-15dc87ebde58",
+      "x": 6,
+      "y": 6,
+      "w": 6,
+      "h": 6
+    },
+    {
+      "i": "79f9f116-6a3f-4b2c-bc46-ac5237866ca5",
+      "x": 0,
+      "y": 12,
+      "w": 6,
+      "h": 6
+    },
+    {
+      "i": "3dd5ef24-2f1d-425f-9215-5bc921d454bb",
+      "x": 6,
+      "y": 12,
+      "w": 6,
+      "h": 6
+    },
+    {
+      "i": "d6c06213-b95d-4808-b8e9-bb023c2cc7b2",
+      "x": 0,
+      "y": 18,
+      "w": 6,
+      "h": 6
+    },
+    {
+      "i": "f58dda6a-6cee-40e0-9066-84ac8842bb5c",
+      "x": 6,
+      "y": 18,
+      "w": 6,
+      "h": 6
+    },
+    {
+      "i": "882c4d43-abf1-4cd6-b7d9-0f91a058a311",
+      "x": 0,
+      "y": 24,
+      "w": 6,
+      "h": 6
+    },
+    {
+      "i": "e658de00-6712-4368-ab89-2ff23afd3218",
+      "x": 6,
+      "y": 24,
+      "w": 6,
+      "h": 6
+    }
+  ],
+  "variables": {
+    "6b8eeb5c-fa89-4a2b-b5bc-64678e125eb7": {
+      "id": "6b8eeb5c-fa89-4a2b-b5bc-64678e125eb7",
+      "name": "namespace",
+      "description": "Istio destination service namespace",
+      "type": "QUERY",
+      "multiSelect": true,
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "selectedValue": ".*",
+      "allSelected": true,
+      "customValue": "",
+      "queryValue": "SELECT DISTINCT JSONExtractString(labels, 'destination_service_namespace') FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'istio_requests_total'",
+      "modificationUUID": "14578bad-58a8-4bd0-aca6-698e70ff1c1a"
+    },
+    "de113011-d367-4770-92c4-4e14c9e973c8": {
+      "id": "de113011-d367-4770-92c4-4e14c9e973c8",
+      "name": "deployment_environment",
+      "description": "Deployment environment label",
+      "type": "QUERY",
+      "multiSelect": true,
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "selectedValue": ".*",
+      "allSelected": true,
+      "customValue": "",
+      "queryValue": "SELECT DISTINCT JSONExtractString(labels, 'deployment_environment') FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'istio_requests_total'",
+      "modificationUUID": "2472ee53-3789-4b00-8f8a-f3d46812ef68"
+    },
+    "d7c5095a-209f-4700-8357-ddf7c262e350": {
+      "id": "d7c5095a-209f-4700-8357-ddf7c262e350",
+      "name": "cluster",
+      "description": "Kubernetes cluster name",
+      "type": "QUERY",
+      "multiSelect": true,
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "selectedValue": ".*",
+      "allSelected": true,
+      "customValue": "",
+      "queryValue": "SELECT DISTINCT JSONExtractString(labels, 'k8s_cluster_name') FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'istio_requests_total'",
+      "modificationUUID": "0af59478-0df0-4d41-a2d9-7f2685534cf3"
+    }
+  },
+  "widgets": [
+    {
+      "id": "1a464c49-1776-4eda-abac-2acfadb93862",
+      "title": "Request Volume",
+      "description": "Total incoming request volume per service over 5-minute windows.",
+      "panelTypes": "graph",
+      "isStacked": false,
+      "fillSpans": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "ops",
+      "query": {
+        "queryType": "promql",
+        "id": "aceb1901-17b8-40c0-8735-96bb4eaa54d5",
+        "builder": {
+          "queryData": [
+            {
+              "queryName": "A",
+              "expression": "A",
+              "dataSource": "metrics",
+              "disabled": false,
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false
+              },
+              "aggregateOperator": "count",
+              "spaceAggregation": "sum",
+              "timeAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "orderBy": [],
+              "legend": "",
+              "limit": null,
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{destination_service_name}}",
+            "name": "A",
+            "query": "sum(rate(istio_requests_total{destination_service_namespace=~\"{{.namespace}}\"}[5m])) by (destination_service_name)"
+          }
+        ],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ]
+      }
+    },
+    {
+      "id": "2dc5dee8-301c-4fd4-9cf0-46cbcb8db876",
+      "title": "Success Rate",
+      "description": "Percentage of non-5xx requests across all services in the selected namespace.",
+      "panelTypes": "value",
+      "isStacked": false,
+      "fillSpans": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "short",
+      "query": {
+        "queryType": "promql",
+        "id": "68be0d4b-15ed-4165-8bb9-c87c25e372e2",
+        "builder": {
+          "queryData": [
+            {
+              "queryName": "A",
+              "expression": "A",
+              "dataSource": "metrics",
+              "disabled": false,
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false
+              },
+              "aggregateOperator": "count",
+              "spaceAggregation": "sum",
+              "timeAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "orderBy": [],
+              "legend": "",
+              "limit": null,
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Success Rate %",
+            "name": "A",
+            "query": "sum(rate(istio_requests_total{destination_service_namespace=~\"{{.namespace}}\",response_code!~\"5.*\"}[5m])) / sum(rate(istio_requests_total{destination_service_namespace=~\"{{.namespace}}\"}[5m])) * 100"
+          }
+        ],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ]
+      }
+    },
+    {
+      "id": "272d3d0a-1ad0-44dc-b393-f60c57a539ff",
+      "title": "Request Duration P50",
+      "description": "50th percentile request duration in milliseconds by destination service.",
+      "panelTypes": "graph",
+      "isStacked": false,
+      "fillSpans": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "ms",
+      "query": {
+        "queryType": "promql",
+        "id": "cb6e5352-a2f8-42aa-bbfd-555d474724a3",
+        "builder": {
+          "queryData": [
+            {
+              "queryName": "A",
+              "expression": "A",
+              "dataSource": "metrics",
+              "disabled": false,
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false
+              },
+              "aggregateOperator": "count",
+              "spaceAggregation": "sum",
+              "timeAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "orderBy": [],
+              "legend": "",
+              "limit": null,
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{destination_service_name}}",
+            "name": "A",
+            "query": "histogram_quantile(0.5, sum(rate(istio_request_duration_milliseconds_bucket{destination_service_namespace=~\"{{.namespace}}\"}[5m])) by (le, destination_service_name))"
+          }
+        ],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ]
+      }
+    },
+    {
+      "id": "c463818b-f703-4909-ab65-15dc87ebde58",
+      "title": "Request Duration P99",
+      "description": "99th percentile request duration in milliseconds by destination service.",
+      "panelTypes": "graph",
+      "isStacked": false,
+      "fillSpans": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "ms",
+      "query": {
+        "queryType": "promql",
+        "id": "e7c4ee87-5b39-49fc-9394-4bd5e01e3f66",
+        "builder": {
+          "queryData": [
+            {
+              "queryName": "A",
+              "expression": "A",
+              "dataSource": "metrics",
+              "disabled": false,
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false
+              },
+              "aggregateOperator": "count",
+              "spaceAggregation": "sum",
+              "timeAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "orderBy": [],
+              "legend": "",
+              "limit": null,
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{destination_service_name}}",
+            "name": "A",
+            "query": "histogram_quantile(0.99, sum(rate(istio_request_duration_milliseconds_bucket{destination_service_namespace=~\"{{.namespace}}\"}[5m])) by (le, destination_service_name))"
+          }
+        ],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ]
+      }
+    },
+    {
+      "id": "79f9f116-6a3f-4b2c-bc46-ac5237866ca5",
+      "title": "TCP Connections Opened",
+      "description": "Rate of TCP connections opened per destination service.",
+      "panelTypes": "graph",
+      "isStacked": false,
+      "fillSpans": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "cps",
+      "query": {
+        "queryType": "promql",
+        "id": "e68b1c80-a5f0-4063-b95c-1879a591d25f",
+        "builder": {
+          "queryData": [
+            {
+              "queryName": "A",
+              "expression": "A",
+              "dataSource": "metrics",
+              "disabled": false,
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false
+              },
+              "aggregateOperator": "count",
+              "spaceAggregation": "sum",
+              "timeAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "orderBy": [],
+              "legend": "",
+              "limit": null,
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{destination_service_name}}",
+            "name": "A",
+            "query": "sum(rate(istio_tcp_connections_opened_total{destination_service_namespace=~\"{{.namespace}}\"}[5m])) by (destination_service_name)"
+          }
+        ],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ]
+      }
+    },
+    {
+      "id": "3dd5ef24-2f1d-425f-9215-5bc921d454bb",
+      "title": "TCP Connections Closed",
+      "description": "Rate of TCP connections closed per destination service.",
+      "panelTypes": "graph",
+      "isStacked": false,
+      "fillSpans": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "cps",
+      "query": {
+        "queryType": "promql",
+        "id": "48eebad4-4d73-41c2-8f87-5511bfd1674b",
+        "builder": {
+          "queryData": [
+            {
+              "queryName": "A",
+              "expression": "A",
+              "dataSource": "metrics",
+              "disabled": false,
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false
+              },
+              "aggregateOperator": "count",
+              "spaceAggregation": "sum",
+              "timeAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "orderBy": [],
+              "legend": "",
+              "limit": null,
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{destination_service_name}}",
+            "name": "A",
+            "query": "sum(rate(istio_tcp_connections_closed_total{destination_service_namespace=~\"{{.namespace}}\"}[5m])) by (destination_service_name)"
+          }
+        ],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ]
+      }
+    },
+    {
+      "id": "d6c06213-b95d-4808-b8e9-bb023c2cc7b2",
+      "title": "Pilot xDS Pushes",
+      "description": "Rate of Istio pilot xDS configuration pushes to Envoy proxies, grouped by push type.",
+      "panelTypes": "graph",
+      "isStacked": false,
+      "fillSpans": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "ops",
+      "query": {
+        "queryType": "promql",
+        "id": "72c48adb-f559-4c9f-bbc9-7e15180a4182",
+        "builder": {
+          "queryData": [
+            {
+              "queryName": "A",
+              "expression": "A",
+              "dataSource": "metrics",
+              "disabled": false,
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false
+              },
+              "aggregateOperator": "count",
+              "spaceAggregation": "sum",
+              "timeAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "orderBy": [],
+              "legend": "",
+              "limit": null,
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{type}}",
+            "name": "A",
+            "query": "sum(rate(pilot_xds_pushes[5m])) by (type)"
+          }
+        ],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ]
+      }
+    },
+    {
+      "id": "f58dda6a-6cee-40e0-9066-84ac8842bb5c",
+      "title": "Pilot Proxy Convergence Time P99",
+      "description": "99th percentile time for pilot to push config changes to all proxies (convergence latency).",
+      "panelTypes": "graph",
+      "isStacked": false,
+      "fillSpans": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "s",
+      "query": {
+        "queryType": "promql",
+        "id": "5166a859-9f8a-4eb9-b0a8-fa865f68b6f6",
+        "builder": {
+          "queryData": [
+            {
+              "queryName": "A",
+              "expression": "A",
+              "dataSource": "metrics",
+              "disabled": false,
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false
+              },
+              "aggregateOperator": "count",
+              "spaceAggregation": "sum",
+              "timeAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "orderBy": [],
+              "legend": "",
+              "limit": null,
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "P99 Convergence",
+            "name": "A",
+            "query": "histogram_quantile(0.99, sum(rate(pilot_proxy_convergence_time_bucket[5m])) by (le))"
+          }
+        ],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ]
+      }
+    },
+    {
+      "id": "882c4d43-abf1-4cd6-b7d9-0f91a058a311",
+      "title": "Envoy Proxy CPU Usage",
+      "description": "CPU usage rate for istio-proxy sidecar containers, grouped by pod.",
+      "panelTypes": "graph",
+      "isStacked": false,
+      "fillSpans": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "short",
+      "query": {
+        "queryType": "promql",
+        "id": "d907208b-4b61-4dc5-ab51-05920a9811a6",
+        "builder": {
+          "queryData": [
+            {
+              "queryName": "A",
+              "expression": "A",
+              "dataSource": "metrics",
+              "disabled": false,
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false
+              },
+              "aggregateOperator": "count",
+              "spaceAggregation": "sum",
+              "timeAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "orderBy": [],
+              "legend": "",
+              "limit": null,
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "sum(rate(container_cpu_usage_seconds_total{container=\"istio-proxy\", namespace=~\"{{.namespace}}\"}[5m])) by (pod)"
+          }
+        ],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ]
+      }
+    },
+    {
+      "id": "e658de00-6712-4368-ab89-2ff23afd3218",
+      "title": "Envoy Proxy Memory Usage",
+      "description": "Working set memory usage for istio-proxy sidecar containers, grouped by pod.",
+      "panelTypes": "graph",
+      "isStacked": false,
+      "fillSpans": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "bytes",
+      "query": {
+        "queryType": "promql",
+        "id": "036d35b3-d6bd-4c72-8211-90d265991805",
+        "builder": {
+          "queryData": [
+            {
+              "queryName": "A",
+              "expression": "A",
+              "dataSource": "metrics",
+              "disabled": false,
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false
+              },
+              "aggregateOperator": "count",
+              "spaceAggregation": "sum",
+              "timeAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "orderBy": [],
+              "legend": "",
+              "limit": null,
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "sum(container_memory_working_set_bytes{container=\"istio-proxy\", namespace=~\"{{.namespace}}\"}) by (pod)"
+          }
+        ],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ]
+      }
+    }
+  ],
+  "panelMap": {}
+}

--- a/istio/istio-prometheus-v1.json
+++ b/istio/istio-prometheus-v1.json
@@ -90,13 +90,14 @@
       "type": "QUERY",
       "multiSelect": true,
       "showALLOption": true,
-      "sort": "DISABLED",
+      "sort": "ASC",
       "textboxValue": "",
-      "selectedValue": ".*",
+      "selectedValue": "ALL",
       "allSelected": true,
       "customValue": "",
       "queryValue": "SELECT DISTINCT JSONExtractString(labels, 'destination_service_namespace') FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'istio_requests_total'",
-      "modificationUUID": "14578bad-58a8-4bd0-aca6-698e70ff1c1a"
+      "modificationUUID": "14578bad-58a8-4bd0-aca6-698e70ff1c1a",
+      "order": 0
     },
     "de113011-d367-4770-92c4-4e14c9e973c8": {
       "id": "de113011-d367-4770-92c4-4e14c9e973c8",
@@ -105,13 +106,14 @@
       "type": "QUERY",
       "multiSelect": true,
       "showALLOption": true,
-      "sort": "DISABLED",
+      "sort": "ASC",
       "textboxValue": "",
-      "selectedValue": ".*",
+      "selectedValue": "ALL",
       "allSelected": true,
       "customValue": "",
       "queryValue": "SELECT DISTINCT JSONExtractString(labels, 'deployment_environment') FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'istio_requests_total'",
-      "modificationUUID": "2472ee53-3789-4b00-8f8a-f3d46812ef68"
+      "modificationUUID": "2472ee53-3789-4b00-8f8a-f3d46812ef68",
+      "order": 1
     },
     "d7c5095a-209f-4700-8357-ddf7c262e350": {
       "id": "d7c5095a-209f-4700-8357-ddf7c262e350",
@@ -120,13 +122,14 @@
       "type": "QUERY",
       "multiSelect": true,
       "showALLOption": true,
-      "sort": "DISABLED",
+      "sort": "ASC",
       "textboxValue": "",
-      "selectedValue": ".*",
+      "selectedValue": "ALL",
       "allSelected": true,
       "customValue": "",
       "queryValue": "SELECT DISTINCT JSONExtractString(labels, 'k8s_cluster_name') FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'istio_requests_total'",
-      "modificationUUID": "0af59478-0df0-4d41-a2d9-7f2685534cf3"
+      "modificationUUID": "0af59478-0df0-4d41-a2d9-7f2685534cf3",
+      "order": 2
     }
   },
   "widgets": [
@@ -185,7 +188,7 @@
             "disabled": false,
             "legend": "{{destination_service_name}}",
             "name": "A",
-            "query": "sum(rate(istio_requests_total{destination_service_namespace=~\"{{.namespace}}\"}[5m])) by (destination_service_name)"
+            "query": "sum(rate(istio_requests_total{destination_service_namespace=~\"{{.namespace}}\", deployment_environment=~\"{{.deployment_environment}}\", k8s_cluster_name=~\"{{.cluster}}\"}[5m])) by (destination_service_name)"
           }
         ],
         "clickhouse_sql": [
@@ -253,7 +256,7 @@
             "disabled": false,
             "legend": "Success Rate %",
             "name": "A",
-            "query": "sum(rate(istio_requests_total{destination_service_namespace=~\"{{.namespace}}\",response_code!~\"5.*\"}[5m])) / sum(rate(istio_requests_total{destination_service_namespace=~\"{{.namespace}}\"}[5m])) * 100"
+            "query": "sum(rate(istio_requests_total{destination_service_namespace=~\"{{.namespace}}\", deployment_environment=~\"{{.deployment_environment}}\", k8s_cluster_name=~\"{{.cluster}}\",response_code!~\"5.*\"}[5m])) / sum(rate(istio_requests_total{destination_service_namespace=~\"{{.namespace}}\", deployment_environment=~\"{{.deployment_environment}}\", k8s_cluster_name=~\"{{.cluster}}\"}[5m])) * 100"
           }
         ],
         "clickhouse_sql": [
@@ -321,7 +324,7 @@
             "disabled": false,
             "legend": "{{destination_service_name}}",
             "name": "A",
-            "query": "histogram_quantile(0.5, sum(rate(istio_request_duration_milliseconds_bucket{destination_service_namespace=~\"{{.namespace}}\"}[5m])) by (le, destination_service_name))"
+            "query": "histogram_quantile(0.5, sum(rate(istio_request_duration_milliseconds_bucket{destination_service_namespace=~\"{{.namespace}}\", deployment_environment=~\"{{.deployment_environment}}\", k8s_cluster_name=~\"{{.cluster}}\"}[5m])) by (le, destination_service_name))"
           }
         ],
         "clickhouse_sql": [
@@ -389,7 +392,7 @@
             "disabled": false,
             "legend": "{{destination_service_name}}",
             "name": "A",
-            "query": "histogram_quantile(0.99, sum(rate(istio_request_duration_milliseconds_bucket{destination_service_namespace=~\"{{.namespace}}\"}[5m])) by (le, destination_service_name))"
+            "query": "histogram_quantile(0.99, sum(rate(istio_request_duration_milliseconds_bucket{destination_service_namespace=~\"{{.namespace}}\", deployment_environment=~\"{{.deployment_environment}}\", k8s_cluster_name=~\"{{.cluster}}\"}[5m])) by (le, destination_service_name))"
           }
         ],
         "clickhouse_sql": [
@@ -457,7 +460,7 @@
             "disabled": false,
             "legend": "{{destination_service_name}}",
             "name": "A",
-            "query": "sum(rate(istio_tcp_connections_opened_total{destination_service_namespace=~\"{{.namespace}}\"}[5m])) by (destination_service_name)"
+            "query": "sum(rate(istio_tcp_connections_opened_total{destination_service_namespace=~\"{{.namespace}}\", deployment_environment=~\"{{.deployment_environment}}\", k8s_cluster_name=~\"{{.cluster}}\"}[5m])) by (destination_service_name)"
           }
         ],
         "clickhouse_sql": [
@@ -525,7 +528,7 @@
             "disabled": false,
             "legend": "{{destination_service_name}}",
             "name": "A",
-            "query": "sum(rate(istio_tcp_connections_closed_total{destination_service_namespace=~\"{{.namespace}}\"}[5m])) by (destination_service_name)"
+            "query": "sum(rate(istio_tcp_connections_closed_total{destination_service_namespace=~\"{{.namespace}}\", deployment_environment=~\"{{.deployment_environment}}\", k8s_cluster_name=~\"{{.cluster}}\"}[5m])) by (destination_service_name)"
           }
         ],
         "clickhouse_sql": [
@@ -593,7 +596,7 @@
             "disabled": false,
             "legend": "{{type}}",
             "name": "A",
-            "query": "sum(rate(pilot_xds_pushes[5m])) by (type)"
+            "query": "sum(rate(pilot_xds_pushes{namespace=~\"{{.namespace}}\", deployment_environment=~\"{{.deployment_environment}}\", k8s_cluster_name=~\"{{.cluster}}\"}[5m])) by (type)"
           }
         ],
         "clickhouse_sql": [
@@ -661,7 +664,7 @@
             "disabled": false,
             "legend": "P99 Convergence",
             "name": "A",
-            "query": "histogram_quantile(0.99, sum(rate(pilot_proxy_convergence_time_bucket[5m])) by (le))"
+            "query": "histogram_quantile(0.99, sum(rate(pilot_proxy_convergence_time_bucket{namespace=~\"{{.namespace}}\", deployment_environment=~\"{{.deployment_environment}}\", k8s_cluster_name=~\"{{.cluster}}\"}[5m])) by (le))"
           }
         ],
         "clickhouse_sql": [
@@ -729,7 +732,7 @@
             "disabled": false,
             "legend": "{{pod}}",
             "name": "A",
-            "query": "sum(rate(container_cpu_usage_seconds_total{container=\"istio-proxy\", namespace=~\"{{.namespace}}\"}[5m])) by (pod)"
+            "query": "sum(rate(container_cpu_usage_seconds_total{container=\"istio-proxy\", namespace=~\"{{.namespace}}\", deployment_environment=~\"{{.deployment_environment}}\", k8s_cluster_name=~\"{{.cluster}}\"}[5m])) by (pod)"
           }
         ],
         "clickhouse_sql": [
@@ -797,7 +800,7 @@
             "disabled": false,
             "legend": "{{pod}}",
             "name": "A",
-            "query": "sum(container_memory_working_set_bytes{container=\"istio-proxy\", namespace=~\"{{.namespace}}\"}) by (pod)"
+            "query": "sum(container_memory_working_set_bytes{container=\"istio-proxy\", namespace=~\"{{.namespace}}\", deployment_environment=~\"{{.deployment_environment}}\", k8s_cluster_name=~\"{{.cluster}}\"}) by (pod)"
           }
         ],
         "clickhouse_sql": [

--- a/istio/istio-prometheus-v1.json
+++ b/istio/istio-prometheus-v1.json
@@ -2,7 +2,7 @@
   "id": "istio-prometheus",
   "title": "Istio Service Mesh",
   "description": "Monitor Istio service mesh performance including request volume, success rates, latencies, TCP connections, and control plane metrics.",
-  "name": "",
+  "name": "istio-service-mesh",
   "version": "v4",
   "tags": [
     "istio",
@@ -23,7 +23,7 @@
       "x": 6,
       "y": 0,
       "w": 6,
-      "h": 3
+      "h": 6
     },
     {
       "i": "272d3d0a-1ad0-44dc-b393-f60c57a539ff",


### PR DESCRIPTION
## Summary
- 10-panel Istio service mesh monitoring dashboard using PromQL queries
- Request volume, success rate, P50/P99 latency, TCP connections opened/closed
- Control plane metrics: pilot xDS pushes, proxy convergence time P99
- Envoy proxy resource usage: CPU and memory per sidecar pod
- 3 template variables: namespace, deployment_environment, cluster

/claim #6025

Generated with [Claude Code](https://claude.com/claude-code)