### PR TITLE
feat: add cert-manager Prometheus monitoring dashboard

### DIFF
--- a/cert-manager/README.md
+++ b/cert-manager/README.md
@@ -1,0 +1,50 @@
+# cert-manager Monitoring Dashboard
+
+Monitor cert-manager certificate lifecycle using Prometheus metrics.
+
+## Panels
+
+| Panel | Type | Description |
+|-------|------|-------------|
+| Total Certificates Issued | Value | Total certificates tracked |
+| Active Certificates | Value | Certificates in Ready=True state |
+| Controller Sync Count | Value | Controller sync calls processed |
+| Certificates Issued per Issuer | Graph | Breakdown by issuer name/kind |
+| Certificate State Changes | Graph | Ready status changes per namespace |
+| ACME Client Request Count | Graph | ACME HTTP request rate by status |
+| Certificates Expiring Soon | Value | Certificates expiring within 7 days |
+| Certificate Expiration Timeline | Graph | Days until each certificate expires |
+| Time Until Next Renewal | Graph | Seconds until next scheduled renewal |
+| Controller Sync Errors | Graph | Sync error rate per controller |
+| ACME Request Errors | Graph | ACME 4xx/5xx error rate |
+| CPU Usage | Graph | CPU usage per cert-manager pod |
+| Memory Usage | Graph | Memory per cert-manager pod |
+| Pod Restarts | Graph | Container restart count per pod |
+| API Request Rate | Graph | K8s API request rate by method/code |
+| Workqueue Depth | Graph | Controller workqueue depth |
+
+## Variables
+
+- `namespace` — Kubernetes namespace
+- `issuer` — Certificate issuer name
+- `certificate_name` — Certificate name
+- `cluster` — Kubernetes cluster
+- `deployment_environment` — Deployment environment
+
+## Metrics Used
+
+- `certmanager_certificate_ready_status` — Certificate ready state
+- `certmanager_certificate_expiration_timestamp_seconds` — Expiration timestamp
+- `certmanager_certificate_renewal_timestamp_seconds` — Next renewal timestamp
+- `certmanager_controller_sync_call_count` — Controller sync calls
+- `certmanager_controller_sync_error_count` — Controller sync errors
+- `certmanager_http_acme_client_request_count` — ACME HTTP requests
+- `container_cpu_usage_seconds_total` — Container CPU
+- `container_memory_working_set_bytes` — Container memory
+- `kube_pod_container_status_restarts_total` — Pod restarts
+- `rest_client_requests_total` — K8s API client requests
+- `workqueue_depth` — Controller workqueue depth
+
+## Query Type
+
+PromQL

--- a/cert-manager/cert-manager-prometheus-v1.json
+++ b/cert-manager/cert-manager-prometheus-v1.json
@@ -264,7 +264,7 @@
             "disabled": false,
             "legend": "Total Certificates",
             "name": "A",
-            "query": "sum(certmanager_certificate_ready_status{namespace=~\"{{.namespace}}\"})"
+            "query": "sum(certmanager_certificate_ready_status{namespace=~\"{{.namespace}}\", deployment_environment=~\"{{.deployment_environment}}\", k8s_cluster_name=~\"{{.cluster}}\", issuer_name=~\"{{.issuer}}\"})"
           }
         ],
         "clickhouse_sql": [
@@ -332,7 +332,7 @@
             "disabled": false,
             "legend": "Active Certificates",
             "name": "A",
-            "query": "count(certmanager_certificate_ready_status{condition=\"True\", namespace=~\"{{.namespace}}\"})"
+            "query": "count(certmanager_certificate_ready_status{condition=\"True\", namespace=~\"{{.namespace}}\", deployment_environment=~\"{{.deployment_environment}}\", k8s_cluster_name=~\"{{.cluster}}\", issuer_name=~\"{{.issuer}}\"})"
           }
         ],
         "clickhouse_sql": [
@@ -400,7 +400,7 @@
             "disabled": false,
             "legend": "Certificate Requests",
             "name": "A",
-            "query": "sum(certmanager_controller_sync_call_count{namespace=~\"{{.namespace}}\"})"
+            "query": "sum(certmanager_controller_sync_call_count{namespace=~\"{{.namespace}}\", deployment_environment=~\"{{.deployment_environment}}\", k8s_cluster_name=~\"{{.cluster}}\"})"
           }
         ],
         "clickhouse_sql": [
@@ -468,7 +468,7 @@
             "disabled": false,
             "legend": "{{issuer_name}} ({{issuer_kind}})",
             "name": "A",
-            "query": "sum(certmanager_certificate_ready_status{namespace=~\"{{.namespace}}\"}) by (issuer_name, issuer_kind)"
+            "query": "sum(certmanager_certificate_ready_status{namespace=~\"{{.namespace}}\", deployment_environment=~\"{{.deployment_environment}}\", k8s_cluster_name=~\"{{.cluster}}\"}) by (issuer_name, issuer_kind)"
           }
         ],
         "clickhouse_sql": [
@@ -604,7 +604,7 @@
             "disabled": false,
             "legend": "{{status}}",
             "name": "A",
-            "query": "sum(rate(certmanager_http_acme_client_request_count{namespace=~\"{{.namespace}}\"}[5m])) by (status)"
+            "query": "sum(rate(certmanager_http_acme_client_request_count{namespace=~\"{{.namespace}}\", deployment_environment=~\"{{.deployment_environment}}\", k8s_cluster_name=~\"{{.cluster}}\"}[5m])) by (status)"
           }
         ],
         "clickhouse_sql": [
@@ -678,7 +678,7 @@
             "disabled": false,
             "legend": "Expiring Within 7 Days",
             "name": "A",
-            "query": "count(certmanager_certificate_expiration_timestamp_seconds{namespace=~\"{{.namespace}}\"} - time() < 7*24*3600)"
+            "query": "count(certmanager_certificate_expiration_timestamp_seconds{namespace=~\"{{.namespace}}\", deployment_environment=~\"{{.deployment_environment}}\", k8s_cluster_name=~\"{{.cluster}}\", issuer_name=~\"{{.issuer}}\"} - time() < 7*24*3600)"
           }
         ],
         "clickhouse_sql": [
@@ -746,7 +746,7 @@
             "disabled": false,
             "legend": "{{name}}",
             "name": "A",
-            "query": "(certmanager_certificate_expiration_timestamp_seconds{namespace=~\"{{.namespace}}\"} - time()) / 3600 / 24"
+            "query": "(certmanager_certificate_expiration_timestamp_seconds{namespace=~\"{{.namespace}}\", deployment_environment=~\"{{.deployment_environment}}\", k8s_cluster_name=~\"{{.cluster}}\", issuer_name=~\"{{.issuer}}\"} - time()) / 3600 / 24"
           }
         ],
         "clickhouse_sql": [
@@ -814,7 +814,7 @@
             "disabled": false,
             "legend": "p99 Renewal Duration",
             "name": "A",
-            "query": "certmanager_certificate_renewal_timestamp_seconds{namespace=~\"{{.namespace}}\"} - time()"
+            "query": "certmanager_certificate_renewal_timestamp_seconds{namespace=~\"{{.namespace}}\", deployment_environment=~\"{{.deployment_environment}}\", k8s_cluster_name=~\"{{.cluster}}\", issuer_name=~\"{{.issuer}}\"} - time()"
           }
         ],
         "clickhouse_sql": [
@@ -882,7 +882,7 @@
             "disabled": false,
             "legend": "{{controller}}",
             "name": "A",
-            "query": "sum(rate(certmanager_controller_sync_error_count{namespace=~\"{{.namespace}}\"}[5m])) by (controller)"
+            "query": "sum(rate(certmanager_controller_sync_error_count{namespace=~\"{{.namespace}}\", deployment_environment=~\"{{.deployment_environment}}\", k8s_cluster_name=~\"{{.cluster}}\"}[5m])) by (controller)"
           }
         ],
         "clickhouse_sql": [
@@ -950,7 +950,7 @@
             "disabled": false,
             "legend": "ACME Errors",
             "name": "A",
-            "query": "sum(rate(certmanager_http_acme_client_request_count{status=~\"4..|5..\"}[5m]))"
+            "query": "sum(rate(certmanager_http_acme_client_request_count{namespace=~\"{{.namespace}}\", deployment_environment=~\"{{.deployment_environment}}\", k8s_cluster_name=~\"{{.cluster}}\", status=~\"4..|5..\"}[5m]))"
           }
         ],
         "clickhouse_sql": [
@@ -1018,7 +1018,7 @@
             "disabled": false,
             "legend": "{{pod}}",
             "name": "A",
-            "query": "sum(rate(container_cpu_usage_seconds_total{container=\"cert-manager\", namespace=~\"{{.namespace}}\"}[5m])) by (pod)"
+            "query": "sum(rate(container_cpu_usage_seconds_total{container=\"cert-manager\", namespace=~\"{{.namespace}}\", deployment_environment=~\"{{.deployment_environment}}\", k8s_cluster_name=~\"{{.cluster}}\"}[5m])) by (pod)"
           }
         ],
         "clickhouse_sql": [
@@ -1086,7 +1086,7 @@
             "disabled": false,
             "legend": "{{pod}}",
             "name": "A",
-            "query": "sum(container_memory_working_set_bytes{container=\"cert-manager\", namespace=~\"{{.namespace}}\"}) by (pod)"
+            "query": "sum(container_memory_working_set_bytes{container=\"cert-manager\", namespace=~\"{{.namespace}}\", deployment_environment=~\"{{.deployment_environment}}\", k8s_cluster_name=~\"{{.cluster}}\"}) by (pod)"
           }
         ],
         "clickhouse_sql": [
@@ -1154,7 +1154,7 @@
             "disabled": false,
             "legend": "{{pod}}",
             "name": "A",
-            "query": "sum(kube_pod_container_status_restarts_total{container=\"cert-manager\", namespace=~\"{{.namespace}}\"}) by (pod)"
+            "query": "sum(kube_pod_container_status_restarts_total{container=\"cert-manager\", namespace=~\"{{.namespace}}\", deployment_environment=~\"{{.deployment_environment}}\", k8s_cluster_name=~\"{{.cluster}}\"}) by (pod)"
           }
         ],
         "clickhouse_sql": [
@@ -1222,7 +1222,7 @@
             "disabled": false,
             "legend": "{{method}} {{code}}",
             "name": "A",
-            "query": "sum(rate(rest_client_requests_total{namespace=~\"{{.namespace}}\"}[5m])) by (method, code)"
+            "query": "sum(rate(rest_client_requests_total{namespace=~\"{{.namespace}}\", deployment_environment=~\"{{.deployment_environment}}\", k8s_cluster_name=~\"{{.cluster}}\"}[5m])) by (method, code)"
           }
         ],
         "clickhouse_sql": [
@@ -1290,7 +1290,7 @@
             "disabled": false,
             "legend": "{{name}}",
             "name": "A",
-            "query": "sum(workqueue_depth{namespace=~\"{{.namespace}}\"}) by (name)"
+            "query": "sum(workqueue_depth{namespace=~\"{{.namespace}}\", deployment_environment=~\"{{.deployment_environment}}\", k8s_cluster_name=~\"{{.cluster}}\"}) by (name)"
           }
         ],
         "clickhouse_sql": [

--- a/cert-manager/cert-manager-prometheus-v1.json
+++ b/cert-manager/cert-manager-prometheus-v1.json
@@ -2,7 +2,7 @@
   "id": "cert-manager-prometheus",
   "title": "cert-manager Monitoring",
   "description": "Monitor cert-manager certificate lifecycle including issuance, renewal, errors, and resource usage.",
-  "name": "",
+  "name": "cert-manager-monitoring",
   "version": "v4",
   "tags": [
     "cert-manager",
@@ -91,7 +91,7 @@
       "customValue": "",
       "allSelected": true,
       "modifyQuery": true,
-      "key": "deployment.environment"
+      "key": "deployment_environment"
     }
   },
   "layout": [

--- a/cert-manager/cert-manager-prometheus-v1.json
+++ b/cert-manager/cert-manager-prometheus-v1.json
@@ -1,0 +1,1307 @@
+{
+  "id": "cert-manager-prometheus",
+  "title": "cert-manager Monitoring",
+  "description": "Monitor cert-manager certificate lifecycle including issuance, renewal, errors, and resource usage.",
+  "name": "",
+  "version": "v4",
+  "tags": [
+    "cert-manager",
+    "certificates",
+    "tls",
+    "prometheus"
+  ],
+  "uploadedGrafana": false,
+  "panelMap": {},
+  "variables": {
+    "bbc01ad1-1f9e-4d65-a127-c0ea87ba71d3": {
+      "id": "bbc01ad1-1f9e-4d65-a127-c0ea87ba71d3",
+      "name": "namespace",
+      "description": "Kubernetes namespace",
+      "type": "QUERY",
+      "order": 0,
+      "multiSelect": true,
+      "showALLOption": true,
+      "selectedValue": "ALL",
+      "queryValue": "SELECT DISTINCT JSONExtractString(labels, 'namespace') FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'certmanager_certificate_ready_status'",
+      "textboxValue": "",
+      "customValue": "",
+      "allSelected": true,
+      "modifyQuery": true,
+      "key": "namespace"
+    },
+    "3074e4f7-3881-4e5c-9386-c72f754b60ba": {
+      "id": "3074e4f7-3881-4e5c-9386-c72f754b60ba",
+      "name": "issuer",
+      "description": "Certificate issuer name",
+      "type": "QUERY",
+      "order": 1,
+      "multiSelect": true,
+      "showALLOption": true,
+      "selectedValue": "ALL",
+      "queryValue": "SELECT DISTINCT JSONExtractString(labels, 'issuer_name') FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'certmanager_certificate_ready_status'",
+      "textboxValue": "",
+      "customValue": "",
+      "allSelected": true,
+      "modifyQuery": true,
+      "key": "issuer_name"
+    },
+    "0c436016-3ad6-4157-9f07-dacdc2c12169": {
+      "id": "0c436016-3ad6-4157-9f07-dacdc2c12169",
+      "name": "certificate_name",
+      "description": "Certificate name",
+      "type": "QUERY",
+      "order": 2,
+      "multiSelect": true,
+      "showALLOption": true,
+      "selectedValue": "ALL",
+      "queryValue": "SELECT DISTINCT JSONExtractString(labels, 'name') FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'certmanager_certificate_ready_status'",
+      "textboxValue": "",
+      "customValue": "",
+      "allSelected": true,
+      "modifyQuery": true,
+      "key": "name"
+    },
+    "0665ba51-44bf-4e54-a3c5-b3b921b8359d": {
+      "id": "0665ba51-44bf-4e54-a3c5-b3b921b8359d",
+      "name": "cluster",
+      "description": "Kubernetes cluster name",
+      "type": "QUERY",
+      "order": 3,
+      "multiSelect": true,
+      "showALLOption": true,
+      "selectedValue": "ALL",
+      "queryValue": "SELECT DISTINCT JSONExtractString(labels, 'k8s_cluster_name') FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'certmanager_certificate_ready_status'",
+      "textboxValue": "",
+      "customValue": "",
+      "allSelected": true,
+      "modifyQuery": true,
+      "key": "k8s_cluster_name"
+    },
+    "d5b8256d-4605-4d88-be2b-a90cac400111": {
+      "id": "d5b8256d-4605-4d88-be2b-a90cac400111",
+      "name": "deployment_environment",
+      "description": "Deployment environment",
+      "type": "QUERY",
+      "order": 4,
+      "multiSelect": true,
+      "showALLOption": true,
+      "selectedValue": "ALL",
+      "queryValue": "SELECT DISTINCT JSONExtractString(labels, 'deployment_environment') FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'certmanager_certificate_ready_status'",
+      "textboxValue": "",
+      "customValue": "",
+      "allSelected": true,
+      "modifyQuery": true,
+      "key": "deployment.environment"
+    }
+  },
+  "layout": [
+    {
+      "i": "c4a7be14-ea16-4ef0-ae8e-81949a759772",
+      "x": 0,
+      "y": 0,
+      "w": 4,
+      "h": 3
+    },
+    {
+      "i": "aac93bbb-e2b9-4a7a-8b3d-9019d3ad23cc",
+      "x": 4,
+      "y": 0,
+      "w": 4,
+      "h": 3
+    },
+    {
+      "i": "68966995-8c32-414e-8aac-1bebffc6aec0",
+      "x": 8,
+      "y": 0,
+      "w": 4,
+      "h": 3
+    },
+    {
+      "i": "4e4e6e70-26ff-415d-8fed-f7f92291bbb5",
+      "x": 0,
+      "y": 3,
+      "w": 6,
+      "h": 6
+    },
+    {
+      "i": "24c7b329-36cd-4a0c-9305-c7338510c303",
+      "x": 6,
+      "y": 3,
+      "w": 6,
+      "h": 6
+    },
+    {
+      "i": "f940d22e-1f77-427c-888d-ddedd853ff31",
+      "x": 0,
+      "y": 9,
+      "w": 6,
+      "h": 6
+    },
+    {
+      "i": "6c354910-9477-45a8-ac67-5e28c78835eb",
+      "x": 0,
+      "y": 15,
+      "w": 4,
+      "h": 3
+    },
+    {
+      "i": "a006358b-2627-4715-ad8c-2e5d6fbd94dc",
+      "x": 4,
+      "y": 15,
+      "w": 8,
+      "h": 6
+    },
+    {
+      "i": "7590bd7f-d33a-4069-bcde-7e8511400a3a",
+      "x": 0,
+      "y": 21,
+      "w": 6,
+      "h": 6
+    },
+    {
+      "i": "228698f7-53f6-41c9-adcd-beb38d3b0ed2",
+      "x": 6,
+      "y": 21,
+      "w": 6,
+      "h": 6
+    },
+    {
+      "i": "de8f605a-3979-4d4a-bdb3-04c8e0c1a88a",
+      "x": 0,
+      "y": 27,
+      "w": 6,
+      "h": 6
+    },
+    {
+      "i": "e15781fd-542f-485a-ba0e-5bc59d0545b4",
+      "x": 6,
+      "y": 27,
+      "w": 6,
+      "h": 6
+    },
+    {
+      "i": "545d0fb4-68e5-4c6a-b0ea-8801ea340cd7",
+      "x": 0,
+      "y": 33,
+      "w": 6,
+      "h": 6
+    },
+    {
+      "i": "85d46824-bf0b-4a88-8689-69d542efefde",
+      "x": 6,
+      "y": 33,
+      "w": 6,
+      "h": 6
+    },
+    {
+      "i": "7b36612e-b755-42c7-ae30-b356b60b8562",
+      "x": 0,
+      "y": 39,
+      "w": 6,
+      "h": 6
+    },
+    {
+      "i": "57794e60-36b3-499e-8386-df778f16f7a6",
+      "x": 6,
+      "y": 39,
+      "w": 6,
+      "h": 6
+    }
+  ],
+  "widgets": [
+    {
+      "id": "c4a7be14-ea16-4ef0-ae8e-81949a759772",
+      "title": "Total Certificates Issued",
+      "description": "Total count of all certificates tracked by cert-manager across selected namespaces.",
+      "panelTypes": "value",
+      "isStacked": false,
+      "fillSpans": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "none",
+      "query": {
+        "queryType": "promql",
+        "id": "97abd24f-6768-4cc8-8041-503ba719534f",
+        "builder": {
+          "queryData": [
+            {
+              "queryName": "A",
+              "expression": "A",
+              "dataSource": "metrics",
+              "disabled": false,
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false
+              },
+              "aggregateOperator": "count",
+              "spaceAggregation": "sum",
+              "timeAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "orderBy": [],
+              "legend": "",
+              "limit": null,
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Total Certificates",
+            "name": "A",
+            "query": "sum(certmanager_certificate_ready_status{namespace=~\"{{.namespace}}\"})"
+          }
+        ],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ]
+      }
+    },
+    {
+      "id": "aac93bbb-e2b9-4a7a-8b3d-9019d3ad23cc",
+      "title": "Active Certificates",
+      "description": "Count of certificates currently in Ready=True state.",
+      "panelTypes": "value",
+      "isStacked": false,
+      "fillSpans": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "none",
+      "query": {
+        "queryType": "promql",
+        "id": "e20be6ba-41b5-4306-b6b4-11406d1fefdb",
+        "builder": {
+          "queryData": [
+            {
+              "queryName": "A",
+              "expression": "A",
+              "dataSource": "metrics",
+              "disabled": false,
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false
+              },
+              "aggregateOperator": "count",
+              "spaceAggregation": "sum",
+              "timeAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "orderBy": [],
+              "legend": "",
+              "limit": null,
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Active Certificates",
+            "name": "A",
+            "query": "count(certmanager_certificate_ready_status{condition=\"True\", namespace=~\"{{.namespace}}\"})"
+          }
+        ],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ]
+      }
+    },
+    {
+      "id": "68966995-8c32-414e-8aac-1bebffc6aec0",
+      "title": "Controller Sync Count",
+      "description": "Total controller synchronization calls processed by cert-manager.",
+      "panelTypes": "value",
+      "isStacked": false,
+      "fillSpans": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "none",
+      "query": {
+        "queryType": "promql",
+        "id": "b6b5a652-a819-48a3-b06b-e3a64b578408",
+        "builder": {
+          "queryData": [
+            {
+              "queryName": "A",
+              "expression": "A",
+              "dataSource": "metrics",
+              "disabled": false,
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false
+              },
+              "aggregateOperator": "count",
+              "spaceAggregation": "sum",
+              "timeAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "orderBy": [],
+              "legend": "",
+              "limit": null,
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Certificate Requests",
+            "name": "A",
+            "query": "sum(certmanager_controller_sync_call_count{namespace=~\"{{.namespace}}\"})"
+          }
+        ],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ]
+      }
+    },
+    {
+      "id": "4e4e6e70-26ff-415d-8fed-f7f92291bbb5",
+      "title": "Certificates Issued per Issuer",
+      "description": "Breakdown of certificates by issuer name and kind.",
+      "panelTypes": "graph",
+      "isStacked": false,
+      "fillSpans": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "none",
+      "query": {
+        "queryType": "promql",
+        "id": "794d9f59-51d2-4afd-bdac-eb4d331e30e4",
+        "builder": {
+          "queryData": [
+            {
+              "queryName": "A",
+              "expression": "A",
+              "dataSource": "metrics",
+              "disabled": false,
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false
+              },
+              "aggregateOperator": "count",
+              "spaceAggregation": "sum",
+              "timeAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "orderBy": [],
+              "legend": "",
+              "limit": null,
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{issuer_name}} ({{issuer_kind}})",
+            "name": "A",
+            "query": "sum(certmanager_certificate_ready_status{namespace=~\"{{.namespace}}\"}) by (issuer_name, issuer_kind)"
+          }
+        ],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ]
+      }
+    },
+    {
+      "id": "24c7b329-36cd-4a0c-9305-c7338510c303",
+      "title": "Certificate State Changes",
+      "description": "Number of certificate ready status changes per namespace over 5-minute window.",
+      "panelTypes": "graph",
+      "isStacked": false,
+      "fillSpans": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "ops",
+      "query": {
+        "queryType": "promql",
+        "id": "561fe892-e527-4aec-81f2-7961a525ed6b",
+        "builder": {
+          "queryData": [
+            {
+              "queryName": "A",
+              "expression": "A",
+              "dataSource": "metrics",
+              "disabled": false,
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false
+              },
+              "aggregateOperator": "count",
+              "spaceAggregation": "sum",
+              "timeAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "orderBy": [],
+              "legend": "",
+              "limit": null,
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{namespace}}",
+            "name": "A",
+            "query": "sum(changes(certmanager_certificate_ready_status[5m])) by (namespace)"
+          }
+        ],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ]
+      }
+    },
+    {
+      "id": "f940d22e-1f77-427c-888d-ddedd853ff31",
+      "title": "ACME Client Request Count",
+      "description": "Rate of ACME HTTP client requests broken down by response status code.",
+      "panelTypes": "graph",
+      "isStacked": false,
+      "fillSpans": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "ops",
+      "query": {
+        "queryType": "promql",
+        "id": "422c1b51-51ae-4a91-a597-efa7e457127b",
+        "builder": {
+          "queryData": [
+            {
+              "queryName": "A",
+              "expression": "A",
+              "dataSource": "metrics",
+              "disabled": false,
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false
+              },
+              "aggregateOperator": "count",
+              "spaceAggregation": "sum",
+              "timeAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "orderBy": [],
+              "legend": "",
+              "limit": null,
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{status}}",
+            "name": "A",
+            "query": "sum(rate(certmanager_http_acme_client_request_count{namespace=~\"{{.namespace}}\"}[5m])) by (status)"
+          }
+        ],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ]
+      }
+    },
+    {
+      "id": "6c354910-9477-45a8-ac67-5e28c78835eb",
+      "title": "Certificates Expiring Soon",
+      "description": "Count of certificates expiring within the next 7 days.",
+      "panelTypes": "value",
+      "isStacked": false,
+      "fillSpans": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [
+        {
+          "index": 0,
+          "value": 1,
+          "color": "#F2495C"
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "none",
+      "query": {
+        "queryType": "promql",
+        "id": "842cc627-2b48-48ba-acd4-120758bca5ce",
+        "builder": {
+          "queryData": [
+            {
+              "queryName": "A",
+              "expression": "A",
+              "dataSource": "metrics",
+              "disabled": false,
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false
+              },
+              "aggregateOperator": "count",
+              "spaceAggregation": "sum",
+              "timeAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "orderBy": [],
+              "legend": "",
+              "limit": null,
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Expiring Within 7 Days",
+            "name": "A",
+            "query": "count(certmanager_certificate_expiration_timestamp_seconds{namespace=~\"{{.namespace}}\"} - time() < 7*24*3600)"
+          }
+        ],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ]
+      }
+    },
+    {
+      "id": "a006358b-2627-4715-ad8c-2e5d6fbd94dc",
+      "title": "Certificate Expiration Timeline",
+      "description": "Days remaining until certificate expiration for each certificate.",
+      "panelTypes": "graph",
+      "isStacked": false,
+      "fillSpans": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "short",
+      "query": {
+        "queryType": "promql",
+        "id": "a5bfd769-b291-4fb9-95e8-9a2e2814168c",
+        "builder": {
+          "queryData": [
+            {
+              "queryName": "A",
+              "expression": "A",
+              "dataSource": "metrics",
+              "disabled": false,
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false
+              },
+              "aggregateOperator": "count",
+              "spaceAggregation": "sum",
+              "timeAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "orderBy": [],
+              "legend": "",
+              "limit": null,
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{name}}",
+            "name": "A",
+            "query": "(certmanager_certificate_expiration_timestamp_seconds{namespace=~\"{{.namespace}}\"} - time()) / 3600 / 24"
+          }
+        ],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ]
+      }
+    },
+    {
+      "id": "7590bd7f-d33a-4069-bcde-7e8511400a3a",
+      "title": "Time Until Next Renewal",
+      "description": "Seconds remaining until each certificates next scheduled renewal.",
+      "panelTypes": "graph",
+      "isStacked": false,
+      "fillSpans": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "s",
+      "query": {
+        "queryType": "promql",
+        "id": "f410e6f6-657c-4347-a01c-4ef597f99cc5",
+        "builder": {
+          "queryData": [
+            {
+              "queryName": "A",
+              "expression": "A",
+              "dataSource": "metrics",
+              "disabled": false,
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false
+              },
+              "aggregateOperator": "count",
+              "spaceAggregation": "sum",
+              "timeAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "orderBy": [],
+              "legend": "",
+              "limit": null,
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "p99 Renewal Duration",
+            "name": "A",
+            "query": "certmanager_certificate_renewal_timestamp_seconds{namespace=~\"{{.namespace}}\"} - time()"
+          }
+        ],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ]
+      }
+    },
+    {
+      "id": "228698f7-53f6-41c9-adcd-beb38d3b0ed2",
+      "title": "Controller Sync Errors",
+      "description": "Rate of controller synchronization errors per controller type.",
+      "panelTypes": "graph",
+      "isStacked": false,
+      "fillSpans": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "ops",
+      "query": {
+        "queryType": "promql",
+        "id": "2cd07aa8-d7c1-4695-82ee-cded5c05301c",
+        "builder": {
+          "queryData": [
+            {
+              "queryName": "A",
+              "expression": "A",
+              "dataSource": "metrics",
+              "disabled": false,
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false
+              },
+              "aggregateOperator": "count",
+              "spaceAggregation": "sum",
+              "timeAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "orderBy": [],
+              "legend": "",
+              "limit": null,
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{controller}}",
+            "name": "A",
+            "query": "sum(rate(certmanager_controller_sync_error_count{namespace=~\"{{.namespace}}\"}[5m])) by (controller)"
+          }
+        ],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ]
+      }
+    },
+    {
+      "id": "de8f605a-3979-4d4a-bdb3-04c8e0c1a88a",
+      "title": "ACME Request Errors",
+      "description": "Rate of ACME HTTP requests returning 4xx or 5xx status codes.",
+      "panelTypes": "graph",
+      "isStacked": false,
+      "fillSpans": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "ops",
+      "query": {
+        "queryType": "promql",
+        "id": "9bec8d70-9709-4e8b-8a04-d293b4c99e66",
+        "builder": {
+          "queryData": [
+            {
+              "queryName": "A",
+              "expression": "A",
+              "dataSource": "metrics",
+              "disabled": false,
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false
+              },
+              "aggregateOperator": "count",
+              "spaceAggregation": "sum",
+              "timeAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "orderBy": [],
+              "legend": "",
+              "limit": null,
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "ACME Errors",
+            "name": "A",
+            "query": "sum(rate(certmanager_http_acme_client_request_count{status=~\"4..|5..\"}[5m]))"
+          }
+        ],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ]
+      }
+    },
+    {
+      "id": "e15781fd-542f-485a-ba0e-5bc59d0545b4",
+      "title": "CPU Usage",
+      "description": "CPU usage rate per cert-manager pod over 5-minute window.",
+      "panelTypes": "graph",
+      "isStacked": false,
+      "fillSpans": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "short",
+      "query": {
+        "queryType": "promql",
+        "id": "01dbad09-acda-44b5-8f04-02919136f0eb",
+        "builder": {
+          "queryData": [
+            {
+              "queryName": "A",
+              "expression": "A",
+              "dataSource": "metrics",
+              "disabled": false,
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false
+              },
+              "aggregateOperator": "count",
+              "spaceAggregation": "sum",
+              "timeAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "orderBy": [],
+              "legend": "",
+              "limit": null,
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "sum(rate(container_cpu_usage_seconds_total{container=\"cert-manager\", namespace=~\"{{.namespace}}\"}[5m])) by (pod)"
+          }
+        ],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ]
+      }
+    },
+    {
+      "id": "545d0fb4-68e5-4c6a-b0ea-8801ea340cd7",
+      "title": "Memory Usage",
+      "description": "Working set memory consumption per cert-manager pod.",
+      "panelTypes": "graph",
+      "isStacked": false,
+      "fillSpans": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "bytes",
+      "query": {
+        "queryType": "promql",
+        "id": "8aa4a65b-bc1d-45cd-a2fd-abf3307f96d0",
+        "builder": {
+          "queryData": [
+            {
+              "queryName": "A",
+              "expression": "A",
+              "dataSource": "metrics",
+              "disabled": false,
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false
+              },
+              "aggregateOperator": "count",
+              "spaceAggregation": "sum",
+              "timeAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "orderBy": [],
+              "legend": "",
+              "limit": null,
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "sum(container_memory_working_set_bytes{container=\"cert-manager\", namespace=~\"{{.namespace}}\"}) by (pod)"
+          }
+        ],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ]
+      }
+    },
+    {
+      "id": "85d46824-bf0b-4a88-8689-69d542efefde",
+      "title": "Pod Restarts",
+      "description": "Total container restart count per cert-manager pod.",
+      "panelTypes": "graph",
+      "isStacked": false,
+      "fillSpans": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "none",
+      "query": {
+        "queryType": "promql",
+        "id": "a26664ec-4f94-406b-aaa4-687b4f586ea8",
+        "builder": {
+          "queryData": [
+            {
+              "queryName": "A",
+              "expression": "A",
+              "dataSource": "metrics",
+              "disabled": false,
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false
+              },
+              "aggregateOperator": "count",
+              "spaceAggregation": "sum",
+              "timeAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "orderBy": [],
+              "legend": "",
+              "limit": null,
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "sum(kube_pod_container_status_restarts_total{container=\"cert-manager\", namespace=~\"{{.namespace}}\"}) by (pod)"
+          }
+        ],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ]
+      }
+    },
+    {
+      "id": "7b36612e-b755-42c7-ae30-b356b60b8562",
+      "title": "API Request Rate",
+      "description": "Rate of Kubernetes API server requests by HTTP method and response code.",
+      "panelTypes": "graph",
+      "isStacked": false,
+      "fillSpans": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "ops",
+      "query": {
+        "queryType": "promql",
+        "id": "c08b828f-2f2f-49d4-8f46-e0bd48d9c2a5",
+        "builder": {
+          "queryData": [
+            {
+              "queryName": "A",
+              "expression": "A",
+              "dataSource": "metrics",
+              "disabled": false,
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false
+              },
+              "aggregateOperator": "count",
+              "spaceAggregation": "sum",
+              "timeAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "orderBy": [],
+              "legend": "",
+              "limit": null,
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{method}} {{code}}",
+            "name": "A",
+            "query": "sum(rate(rest_client_requests_total{namespace=~\"{{.namespace}}\"}[5m])) by (method, code)"
+          }
+        ],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ]
+      }
+    },
+    {
+      "id": "57794e60-36b3-499e-8386-df778f16f7a6",
+      "title": "Workqueue Depth",
+      "description": "Current depth of workqueues used by cert-manager controllers.",
+      "panelTypes": "graph",
+      "isStacked": false,
+      "fillSpans": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "none",
+      "query": {
+        "queryType": "promql",
+        "id": "7cbec561-87d1-41bf-a5dd-65597c9d0366",
+        "builder": {
+          "queryData": [
+            {
+              "queryName": "A",
+              "expression": "A",
+              "dataSource": "metrics",
+              "disabled": false,
+              "aggregateAttribute": {
+                "key": "",
+                "dataType": "",
+                "type": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false
+              },
+              "aggregateOperator": "count",
+              "spaceAggregation": "sum",
+              "timeAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "orderBy": [],
+              "legend": "",
+              "limit": null,
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{name}}",
+            "name": "A",
+            "query": "sum(workqueue_depth{namespace=~\"{{.namespace}}\"}) by (name)"
+          }
+        ],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- 16-panel cert-manager monitoring dashboard using PromQL queries
- Certificate lifecycle: total certs, active certs, expiration tracking, renewal timing
- ACME client: request count by status, error rate (4xx/5xx)
- Controller health: sync count, sync errors, workqueue depth, API request rate
- Resource usage: CPU, memory, pod restarts per cert-manager pod
- 5 template variables: namespace, issuer, certificate_name, cluster, deployment_environment
- Threshold alert on certificates expiring within 7 days

/claim #6023

Generated with [Claude Code](https://claude.com/claude-code)