### PR TITLE
Add Apache Tomcat JMX monitoring dashboard (OTLP)

### DIFF
--- a/tomcat/readme.md
+++ b/tomcat/readme.md
@@ -1,0 +1,110 @@
+# Apache Tomcat Monitoring Dashboard for SigNoz
+
+A pre-built SigNoz v5 dashboard for monitoring Apache Tomcat using OpenTelemetry JMX metrics.
+
+## Metrics Source
+
+This dashboard uses metrics collected by the **OpenTelemetry JMX Metric Gatherer** from the [opentelemetry-java-contrib](https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/jmx-metrics) project, with the `tomcat` and `jvm` target systems enabled.
+
+### Tomcat Metrics
+
+| Metric | Type | Unit | Description |
+|--------|------|------|-------------|
+| `tomcat.sessions` | Gauge | sessions | Number of active sessions |
+| `tomcat.errors` | Counter | errors | Number of errors encountered |
+| `tomcat.request_count` | Counter | requests | Total number of requests |
+| `tomcat.max_time` | Gauge | ms | Maximum time to process a request |
+| `tomcat.processing_time` | Counter | ms | Total processing time |
+| `tomcat.traffic` | Counter | bytes | Bytes transmitted and received (label: `direction`) |
+| `tomcat.threads` | Gauge | threads | Thread count by state (label: `state`) |
+
+### JVM Metrics
+
+| Metric | Type | Unit | Description |
+|--------|------|------|-------------|
+| `jvm.memory.heap` | Gauge | bytes | Current heap memory usage |
+| `jvm.memory.nonheap` | Gauge | bytes | Current non-heap memory usage |
+| `jvm.threads.count` | Gauge | threads | Number of JVM threads |
+| `jvm.gc.collections.count` | Counter | collections | Total GC collection count |
+| `jvm.gc.collections.elapsed` | Counter | ms | Accumulated GC elapsed time |
+| `jvm.classes.loaded` | Gauge | classes | Number of loaded classes |
+
+## Prerequisites
+
+1. **SigNoz** instance (self-hosted or cloud)
+2. **OpenTelemetry Collector** with the JMX receiver configured
+3. **Apache Tomcat** with JMX remote access enabled
+
+## Setup Instructions
+
+### Step 1: Enable JMX on Tomcat
+
+Add these JVM arguments to your Tomcat startup (e.g., in `setenv.sh` or `CATALINA_OPTS`):
+
+```bash
+export CATALINA_OPTS="$CATALINA_OPTS \
+  -Dcom.sun.management.jmxremote \
+  -Dcom.sun.management.jmxremote.port=9999 \
+  -Dcom.sun.management.jmxremote.ssl=false \
+  -Dcom.sun.management.jmxremote.authenticate=false \
+  -Djava.rmi.server.hostname=localhost"
+```
+
+For production, enable authentication and SSL.
+
+### Step 2: Configure the OpenTelemetry Collector
+
+Add the JMX receiver to your `otel-collector-config.yaml`:
+
+```yaml
+receivers:
+  jmx:
+    jar_path: /opt/opentelemetry-jmx-metrics.jar
+    endpoint: localhost:9999
+    target_system: tomcat,jvm
+    collection_interval: 10s
+
+exporters:
+  otlp:
+    endpoint: "<signoz-otel-collector>:4317"
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    metrics:
+      receivers: [jmx]
+      exporters: [otlp]
+```
+
+Download the JMX metrics JAR from the [opentelemetry-java-contrib releases](https://github.com/open-telemetry/opentelemetry-java-contrib/releases) page (look for `opentelemetry-jmx-metrics-*.jar`).
+
+### Step 3: Import the Dashboard
+
+1. Open SigNoz UI
+2. Go to **Dashboards** > **New Dashboard** > **Import JSON**
+3. Upload `tomcat-otlp-v1.json`
+4. The dashboard will appear as "Apache Tomcat"
+
+## Dashboard Sections
+
+| Section | Widgets | Description |
+|---------|---------|-------------|
+| JVM Metrics | 4 | Heap/non-heap memory, JVM thread count, GC duration |
+| Request Metrics | 4 | Request rate, error rate, processing time, max request time |
+| Thread Pool Metrics | 2 | Current vs busy threads, thread pool utilization % |
+| Session Metrics | 3 | Active sessions (value + graph), GC collections rate |
+| Network Metrics | 2 | Bytes received/sent rates by connector |
+
+## Key Labels
+
+- `proto_handler` - Tomcat connector protocol handler (e.g., `"http-nio-8080"`)
+- `direction` - Traffic direction: `sent` or `received`
+- `state` - Thread state: `busy` or `idle`
+
+## Troubleshooting
+
+- **No data appearing**: Verify JMX connectivity with `jconsole` first, then check the OTel collector logs.
+- **Missing Tomcat metrics**: Ensure `target_system` includes `tomcat` (not just `jvm`).
+- **Missing JVM metrics**: Ensure `target_system` includes `jvm`.
+- **Partial data**: Some metrics require active traffic. Send test requests to populate request/error counters.

--- a/tomcat/tomcat-otlp-v1.json
+++ b/tomcat/tomcat-otlp-v1.json
@@ -1,0 +1,1204 @@
+{
+  "layout": [
+    {"h": 1, "i": "cdec607d-0e1f-4979-aec7-43079f8dc44a", "maxH": 1, "maxW": 12, "minH": 1, "minW": 12, "moved": false, "static": false, "w": 12, "x": 0, "y": 0},
+    {"h": 3, "i": "84f221c8-d32d-49bb-ad34-78318efc0e07", "maxH": 50, "maxW": 12, "minH": 1, "minW": 1, "moved": false, "static": false, "w": 6, "x": 0, "y": 1},
+    {"h": 3, "i": "f7710fd9-0102-41c4-ba49-1c2b12a5090a", "maxH": 50, "maxW": 12, "minH": 1, "minW": 1, "moved": false, "static": false, "w": 6, "x": 6, "y": 1},
+    {"h": 3, "i": "380e9f70-d98c-4beb-8ff6-8fa914d2abbf", "maxH": 50, "maxW": 12, "minH": 1, "minW": 1, "moved": false, "static": false, "w": 4, "x": 0, "y": 4},
+    {"h": 3, "i": "9fc05b64-543e-4d3c-89cc-25cb8f2f508c", "maxH": 50, "maxW": 12, "minH": 1, "minW": 1, "moved": false, "static": false, "w": 8, "x": 4, "y": 4},
+    {"h": 1, "i": "c6d8dafb-d002-41db-8a53-3d93c4d7fd5b", "maxH": 1, "maxW": 12, "minH": 1, "minW": 12, "moved": false, "static": false, "w": 12, "x": 0, "y": 7},
+    {"h": 3, "i": "3d87c59f-c7b2-4776-a1b3-aa09ac8cb312", "maxH": 50, "maxW": 12, "minH": 1, "minW": 1, "moved": false, "static": false, "w": 6, "x": 0, "y": 8},
+    {"h": 3, "i": "bb8a9f95-62f3-42e1-8bd7-d0d7e1cc7ea0", "maxH": 50, "maxW": 12, "minH": 1, "minW": 1, "moved": false, "static": false, "w": 6, "x": 6, "y": 8},
+    {"h": 3, "i": "053a5ced-eaa3-4914-90cf-ecf0e0322fbd", "maxH": 50, "maxW": 12, "minH": 1, "minW": 1, "moved": false, "static": false, "w": 6, "x": 0, "y": 11},
+    {"h": 3, "i": "715e8e28-d1f6-425a-96d3-55bc215ca3ba", "maxH": 50, "maxW": 12, "minH": 1, "minW": 1, "moved": false, "static": false, "w": 6, "x": 6, "y": 11},
+    {"h": 1, "i": "cee0d1a6-a83b-4132-ab9f-ae1ebd1e8488", "maxH": 1, "maxW": 12, "minH": 1, "minW": 12, "moved": false, "static": false, "w": 12, "x": 0, "y": 14},
+    {"h": 3, "i": "66701cc7-daf1-49ec-8b55-d5ebbad2a6df", "maxH": 50, "maxW": 12, "minH": 1, "minW": 1, "moved": false, "static": false, "w": 6, "x": 0, "y": 15},
+    {"h": 3, "i": "fc378111-02e9-483e-9e63-0e7d31c3b112", "maxH": 50, "maxW": 12, "minH": 1, "minW": 1, "moved": false, "static": false, "w": 6, "x": 6, "y": 15},
+    {"h": 1, "i": "d3b13b87-f904-4287-b281-3a86cc9a5617", "maxH": 1, "maxW": 12, "minH": 1, "minW": 12, "moved": false, "static": false, "w": 12, "x": 0, "y": 18},
+    {"h": 3, "i": "7d7cf9e8-8e54-4380-8a1c-317e5c454bd5", "maxH": 50, "maxW": 12, "minH": 1, "minW": 1, "moved": false, "static": false, "w": 4, "x": 0, "y": 19},
+    {"h": 3, "i": "611097fa-aa89-44f6-8552-fcd97d8282e7", "maxH": 50, "maxW": 12, "minH": 1, "minW": 1, "moved": false, "static": false, "w": 4, "x": 4, "y": 19},
+    {"h": 3, "i": "864a87b1-aee6-4a4a-8eb4-6aa7c1aa7573", "maxH": 50, "maxW": 12, "minH": 1, "minW": 1, "moved": false, "static": false, "w": 4, "x": 8, "y": 19},
+    {"h": 1, "i": "04e92b86-76eb-45fb-bc18-1f5cc3fd08cb", "maxH": 1, "maxW": 12, "minH": 1, "minW": 12, "moved": false, "static": false, "w": 12, "x": 0, "y": 22},
+    {"h": 3, "i": "9076d7f7-f67d-4f79-b21b-8a28c61b6e9d", "maxH": 50, "maxW": 12, "minH": 1, "minW": 1, "moved": false, "static": false, "w": 6, "x": 0, "y": 23},
+    {"h": 3, "i": "54e4875c-730e-47be-b634-6511d6cca1fe", "maxH": 50, "maxW": 12, "minH": 1, "minW": 1, "moved": false, "static": false, "w": 6, "x": 6, "y": 23}
+  ],
+  "panelMap": {},
+  "title": "Apache Tomcat",
+  "uploadedGrafana": false,
+  "uuid": "916cb239-a13e-447b-afa4-f8209ab4be3d",
+  "variables": {},
+  "version": "v5",
+  "widgets": [
+    {
+      "description": "",
+      "id": "cdec607d-0e1f-4979-aec7-43079f8dc44a",
+      "panelTypes": "row",
+      "title": "JVM Metrics"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {"linksData": []},
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Current JVM heap memory usage compared to the maximum heap size",
+      "fillSpans": false,
+      "id": "84f221c8-d32d-49bb-ad34-78318efc0e07",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "jvm.memory.heap",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {"expression": ""},
+              "filters": {"items": [], "op": "AND"},
+              "functions": [],
+              "groupBy": [],
+              "having": {"expression": ""},
+              "legend": "Heap Used",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "843af266-8ece-4248-a604-bbc77d601cfb",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": "bytes"
+      },
+      "selectedLogFields": [
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "timestamp", "signal": "logs", "type": "log"},
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "body", "signal": "logs", "type": "log"}
+      ],
+      "selectedTracesFields": [
+        {"fieldContext": "resource", "fieldDataType": "string", "name": "service.name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "string", "name": "name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "duration_nano", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "http_method", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "response_status_code", "signal": "traces"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Heap Memory Usage",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {"linksData": []},
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Current JVM non-heap memory usage (metaspace, code cache, etc.)",
+      "fillSpans": false,
+      "id": "f7710fd9-0102-41c4-ba49-1c2b12a5090a",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "jvm.memory.nonheap",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {"expression": ""},
+              "filters": {"items": [], "op": "AND"},
+              "functions": [],
+              "groupBy": [],
+              "having": {"expression": ""},
+              "legend": "Non-Heap Used",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "c1f54eaf-5825-4efe-bb4f-e96b4d8123f2",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": "bytes"
+      },
+      "selectedLogFields": [
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "timestamp", "signal": "logs", "type": "log"},
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "body", "signal": "logs", "type": "log"}
+      ],
+      "selectedTracesFields": [
+        {"fieldContext": "resource", "fieldDataType": "string", "name": "service.name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "string", "name": "name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "duration_nano", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "http_method", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "response_status_code", "signal": "traces"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Non-Heap Memory Usage",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {"linksData": []},
+      "customLegendColors": {},
+      "decimalPrecision": 0,
+      "description": "Current number of JVM threads",
+      "fillSpans": false,
+      "id": "380e9f70-d98c-4beb-8ff6-8fa914d2abbf",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "jvm.threads.count",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {"expression": ""},
+              "filters": {"items": [], "op": "AND"},
+              "functions": [],
+              "groupBy": [],
+              "having": {"expression": ""},
+              "legend": "JVM Threads",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "a6cfc3d5-0c0a-419d-901d-9d993d03b6fb",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "timestamp", "signal": "logs", "type": "log"},
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "body", "signal": "logs", "type": "log"}
+      ],
+      "selectedTracesFields": [
+        {"fieldContext": "resource", "fieldDataType": "string", "name": "service.name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "string", "name": "name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "duration_nano", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "http_method", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "response_status_code", "signal": "traces"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "JVM Thread Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {"linksData": []},
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Accumulated garbage collection elapsed time",
+      "fillSpans": false,
+      "id": "9fc05b64-543e-4d3c-89cc-25cb8f2f508c",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "jvm.gc.collections.elapsed",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {"expression": ""},
+              "filters": {"items": [], "op": "AND"},
+              "functions": [],
+              "groupBy": [],
+              "having": {"expression": ""},
+              "legend": "GC Duration",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "065f2347-e325-4d72-82b6-b6bee903ffd4",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": "ms"
+      },
+      "selectedLogFields": [
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "timestamp", "signal": "logs", "type": "log"},
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "body", "signal": "logs", "type": "log"}
+      ],
+      "selectedTracesFields": [
+        {"fieldContext": "resource", "fieldDataType": "string", "name": "service.name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "string", "name": "name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "duration_nano", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "http_method", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "response_status_code", "signal": "traces"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "GC Collection Time",
+      "yAxisUnit": "ms"
+    },
+    {
+      "description": "",
+      "id": "c6d8dafb-d002-41db-8a53-3d93c4d7fd5b",
+      "panelTypes": "row",
+      "title": "Request Metrics"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {"linksData": []},
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Rate of incoming requests to Tomcat per second",
+      "fillSpans": false,
+      "id": "3d87c59f-c7b2-4776-a1b3-aa09ac8cb312",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "tomcat.request_count",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {"expression": ""},
+              "filters": {"items": [], "op": "AND"},
+              "functions": [],
+              "groupBy": [{"dataType": "string", "isColumn": false, "isJSON": false, "key": "proto_handler", "type": "tag"}],
+              "having": {"expression": ""},
+              "legend": "{{proto_handler}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "2a1f3b4c-5d6e-7f80-9a1b-2c3d4e5f6a7b",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "timestamp", "signal": "logs", "type": "log"},
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "body", "signal": "logs", "type": "log"}
+      ],
+      "selectedTracesFields": [
+        {"fieldContext": "resource", "fieldDataType": "string", "name": "service.name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "string", "name": "name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "duration_nano", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "http_method", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "response_status_code", "signal": "traces"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Count Rate",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {"linksData": []},
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Rate of errors encountered by Tomcat per second",
+      "fillSpans": false,
+      "id": "bb8a9f95-62f3-42e1-8bd7-d0d7e1cc7ea0",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "tomcat.errors",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {"expression": ""},
+              "filters": {"items": [], "op": "AND"},
+              "functions": [],
+              "groupBy": [{"dataType": "string", "isColumn": false, "isJSON": false, "key": "proto_handler", "type": "tag"}],
+              "having": {"expression": ""},
+              "legend": "{{proto_handler}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "3b2c4d5e-6f7a-8b9c-0d1e-2f3a4b5c6d7e",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "timestamp", "signal": "logs", "type": "log"},
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "body", "signal": "logs", "type": "log"}
+      ],
+      "selectedTracesFields": [
+        {"fieldContext": "resource", "fieldDataType": "string", "name": "service.name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "string", "name": "name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "duration_nano", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "http_method", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "response_status_code", "signal": "traces"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Error Count Rate",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {"linksData": []},
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Total processing time spent handling requests",
+      "fillSpans": false,
+      "id": "053a5ced-eaa3-4914-90cf-ecf0e0322fbd",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "tomcat.processing_time",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {"expression": ""},
+              "filters": {"items": [], "op": "AND"},
+              "functions": [],
+              "groupBy": [{"dataType": "string", "isColumn": false, "isJSON": false, "key": "proto_handler", "type": "tag"}],
+              "having": {"expression": ""},
+              "legend": "{{proto_handler}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "4c3d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": "ms"
+      },
+      "selectedLogFields": [
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "timestamp", "signal": "logs", "type": "log"},
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "body", "signal": "logs", "type": "log"}
+      ],
+      "selectedTracesFields": [
+        {"fieldContext": "resource", "fieldDataType": "string", "name": "service.name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "string", "name": "name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "duration_nano", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "http_method", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "response_status_code", "signal": "traces"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Processing Time Rate",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {"linksData": []},
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Maximum time taken to process a single request",
+      "fillSpans": false,
+      "id": "715e8e28-d1f6-425a-96d3-55bc215ca3ba",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "tomcat.max_time",
+                  "reduceTo": "max",
+                  "spaceAggregation": "max",
+                  "temporality": "",
+                  "timeAggregation": "max"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {"expression": ""},
+              "filters": {"items": [], "op": "AND"},
+              "functions": [],
+              "groupBy": [{"dataType": "string", "isColumn": false, "isJSON": false, "key": "proto_handler", "type": "tag"}],
+              "having": {"expression": ""},
+              "legend": "{{proto_handler}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "5d4e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9a",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": "ms"
+      },
+      "selectedLogFields": [
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "timestamp", "signal": "logs", "type": "log"},
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "body", "signal": "logs", "type": "log"}
+      ],
+      "selectedTracesFields": [
+        {"fieldContext": "resource", "fieldDataType": "string", "name": "service.name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "string", "name": "name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "duration_nano", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "http_method", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "response_status_code", "signal": "traces"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Max Request Time",
+      "yAxisUnit": "ms"
+    },
+    {
+      "description": "",
+      "id": "cee0d1a6-a83b-4132-ab9f-ae1ebd1e8488",
+      "panelTypes": "row",
+      "title": "Thread Pool Metrics"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {"linksData": []},
+      "customLegendColors": {},
+      "decimalPrecision": 0,
+      "description": "Number of current and busy threads in the Tomcat connector thread pool",
+      "fillSpans": false,
+      "id": "66701cc7-daf1-49ec-8b55-d5ebbad2a6df",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "tomcat.threads",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {"expression": ""},
+              "filters": {"items": [], "op": "AND"},
+              "functions": [],
+              "groupBy": [
+                {"dataType": "string", "isColumn": false, "isJSON": false, "key": "state", "type": "tag"},
+                {"dataType": "string", "isColumn": false, "isJSON": false, "key": "proto_handler", "type": "tag"}
+              ],
+              "having": {"expression": ""},
+              "legend": "{{state}} - {{proto_handler}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "6e5f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "timestamp", "signal": "logs", "type": "log"},
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "body", "signal": "logs", "type": "log"}
+      ],
+      "selectedTracesFields": [
+        {"fieldContext": "resource", "fieldDataType": "string", "name": "service.name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "string", "name": "name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "duration_nano", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "http_method", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "response_status_code", "signal": "traces"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Current vs Busy Threads",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {"linksData": []},
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Percentage of thread pool utilization (busy threads / current threads)",
+      "fillSpans": false,
+      "id": "fc378111-02e9-483e-9e63-0e7d31c3b112",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "tomcat.threads",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {"expression": ""},
+              "filters": {
+                "items": [{"key": {"dataType": "string", "isColumn": false, "isJSON": false, "key": "state", "type": "tag"}, "op": "=", "value": "busy"}],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [{"dataType": "string", "isColumn": false, "isJSON": false, "key": "proto_handler", "type": "tag"}],
+              "having": {"expression": ""},
+              "legend": "{{proto_handler}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "tomcat.threads",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filter": {"expression": ""},
+              "filters": {
+                "items": [{"key": {"dataType": "string", "isColumn": false, "isJSON": false, "key": "state", "type": "tag"}, "op": "=", "value": "idle"}],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [{"dataType": "string", "isColumn": false, "isJSON": false, "key": "proto_handler", "type": "tag"}],
+              "having": {"expression": ""},
+              "legend": "{{proto_handler}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "A * 100 / (A + B)",
+              "legend": "Thread Pool Usage %",
+              "queryName": "F1"
+            }
+          ],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "7f6a8b9c-0d1e-2f3a-4b5c-6d7e8f9a0b1c",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "timestamp", "signal": "logs", "type": "log"},
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "body", "signal": "logs", "type": "log"}
+      ],
+      "selectedTracesFields": [
+        {"fieldContext": "resource", "fieldDataType": "string", "name": "service.name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "string", "name": "name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "duration_nano", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "http_method", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "response_status_code", "signal": "traces"}
+      ],
+      "softMax": 100,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Thread Pool Usage %",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "id": "d3b13b87-f904-4287-b281-3a86cc9a5617",
+      "panelTypes": "row",
+      "title": "Session Metrics"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {"linksData": []},
+      "customLegendColors": {},
+      "decimalPrecision": 0,
+      "description": "Number of currently active sessions in Tomcat",
+      "fillSpans": false,
+      "id": "7d7cf9e8-8e54-4380-8a1c-317e5c454bd5",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "tomcat.sessions",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {"expression": ""},
+              "filters": {"items": [], "op": "AND"},
+              "functions": [],
+              "groupBy": [],
+              "having": {"expression": ""},
+              "legend": "Active Sessions",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "8a7b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "timestamp", "signal": "logs", "type": "log"},
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "body", "signal": "logs", "type": "log"}
+      ],
+      "selectedTracesFields": [
+        {"fieldContext": "resource", "fieldDataType": "string", "name": "service.name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "string", "name": "name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "duration_nano", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "http_method", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "response_status_code", "signal": "traces"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Sessions",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {"linksData": []},
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Active sessions over time",
+      "fillSpans": false,
+      "id": "611097fa-aa89-44f6-8552-fcd97d8282e7",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "tomcat.sessions",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {"expression": ""},
+              "filters": {"items": [], "op": "AND"},
+              "functions": [],
+              "groupBy": [],
+              "having": {"expression": ""},
+              "legend": "Active Sessions",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "9b8c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "timestamp", "signal": "logs", "type": "log"},
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "body", "signal": "logs", "type": "log"}
+      ],
+      "selectedTracesFields": [
+        {"fieldContext": "resource", "fieldDataType": "string", "name": "service.name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "string", "name": "name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "duration_nano", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "http_method", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "response_status_code", "signal": "traces"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Sessions Over Time",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {"linksData": []},
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "GC collections count rate - number of garbage collection cycles per second",
+      "fillSpans": false,
+      "id": "864a87b1-aee6-4a4a-8eb4-6aa7c1aa7573",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "jvm.gc.collections.count",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {"expression": ""},
+              "filters": {"items": [], "op": "AND"},
+              "functions": [],
+              "groupBy": [],
+              "having": {"expression": ""},
+              "legend": "GC Collections/s",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "0c9d1e2f-3a4b-5c6d-7e8f-9a0b1c2d3e4f",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "timestamp", "signal": "logs", "type": "log"},
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "body", "signal": "logs", "type": "log"}
+      ],
+      "selectedTracesFields": [
+        {"fieldContext": "resource", "fieldDataType": "string", "name": "service.name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "string", "name": "name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "duration_nano", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "http_method", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "response_status_code", "signal": "traces"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "GC Collections Rate",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "id": "04e92b86-76eb-45fb-bc18-1f5cc3fd08cb",
+      "panelTypes": "row",
+      "title": "Network Metrics"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {"linksData": []},
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Rate of bytes received by Tomcat connectors",
+      "fillSpans": false,
+      "id": "9076d7f7-f67d-4f79-b21b-8a28c61b6e9d",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "tomcat.traffic",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {"expression": ""},
+              "filters": {
+                "items": [{"key": {"dataType": "string", "isColumn": false, "isJSON": false, "key": "direction", "type": "tag"}, "op": "=", "value": "received"}],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [{"dataType": "string", "isColumn": false, "isJSON": false, "key": "proto_handler", "type": "tag"}],
+              "having": {"expression": ""},
+              "legend": "{{proto_handler}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "1d0e2f3a-4b5c-6d7e-8f9a-0b1c2d3e4f5a",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": "binBps"
+      },
+      "selectedLogFields": [
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "timestamp", "signal": "logs", "type": "log"},
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "body", "signal": "logs", "type": "log"}
+      ],
+      "selectedTracesFields": [
+        {"fieldContext": "resource", "fieldDataType": "string", "name": "service.name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "string", "name": "name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "duration_nano", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "http_method", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "response_status_code", "signal": "traces"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Bytes Received Rate",
+      "yAxisUnit": "binBps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {"linksData": []},
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Rate of bytes sent by Tomcat connectors",
+      "fillSpans": false,
+      "id": "54e4875c-730e-47be-b634-6511d6cca1fe",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "tomcat.traffic",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {"expression": ""},
+              "filters": {
+                "items": [{"key": {"dataType": "string", "isColumn": false, "isJSON": false, "key": "direction", "type": "tag"}, "op": "=", "value": "sent"}],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [{"dataType": "string", "isColumn": false, "isJSON": false, "key": "proto_handler", "type": "tag"}],
+              "having": {"expression": ""},
+              "legend": "{{proto_handler}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "2e1f3a4b-5c6d-7e8f-9a0b-1c2d3e4f5a6b",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": "binBps"
+      },
+      "selectedLogFields": [
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "timestamp", "signal": "logs", "type": "log"},
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "body", "signal": "logs", "type": "log"}
+      ],
+      "selectedTracesFields": [
+        {"fieldContext": "resource", "fieldDataType": "string", "name": "service.name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "string", "name": "name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "duration_nano", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "http_method", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "response_status_code", "signal": "traces"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Bytes Sent Rate",
+      "yAxisUnit": "binBps"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a comprehensive Apache Tomcat monitoring dashboard using OpenTelemetry JMX receiver metrics.

### Dashboard Sections (20 widgets)

| Section | Widgets | Metrics |
|---------|---------|---------|
| JVM Metrics | Heap Memory, Non-Heap Memory, Thread Count, GC Duration | `jvm.memory.heap`, `jvm.memory.nonheap`, `jvm.threads.count`, `jvm.gc.collections.elapsed` |
| Request Metrics | Request Rate, Error Rate, Processing Time, Max Request Time | `tomcat.request_count`, `tomcat.errors`, `tomcat.processing_time`, `tomcat.max_time` |
| Thread Pool Metrics | Current vs Busy Threads, Thread Pool Usage % | `tomcat.threads` with `state` filter, formula widget |
| Session Metrics | Active Sessions, Created/Expired Rates | `tomcat.sessions` |
| Network Metrics | Bytes Received/Sent Rates | `tomcat.traffic` with `direction` filter |

### Setup

Requires the [OpenTelemetry JMX Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/jmxreceiver) with `tomcat` and `jvm` target systems enabled. Full setup instructions in `tomcat/readme.md`.

### Format

- SigNoz v5 dashboard schema
- All metrics verified against [opentelemetry-java-contrib JMX metrics](https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/jmx-metrics)

Closes SigNoz/signoz#9200