### PR TITLE
[BOUNTY #6036] AWS MSK Cluster Monitoring Dashboard

### DIFF
--- a/aws-msk/aws-msk-dashboard.json
+++ b/aws-msk/aws-msk-dashboard.json
@@ -1,0 +1,465 @@
+{
+  "description": "AWS MSK (Managed Streaming for Apache Kafka) cluster monitoring dashboard with key metrics including throughput, latency, partition health, and broker status.",
+  "image": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNOC44NDQgM0w0IDguNjcyTDguODQ0IDE0TDE0IDguNjcyTDguODQ0IDNaIiBmaWxsPSIjRjQ5NjBBIiBzdHJva2U9IiMyOTI3NzQiIHN0cm9rZS13aWR0aD0iMC41Ii8+PC9zdmc+",
+  "layout": [
+    {"h": 3, "i": "w01", "w": 4, "x": 0, "y": 0, "static": false, "moved": false},
+    {"h": 3, "i": "w02", "w": 4, "x": 4, "y": 0, "static": false, "moved": false},
+    {"h": 3, "i": "w03", "w": 4, "x": 8, "y": 0, "static": false, "moved": false},
+    {"h": 6, "i": "w04", "w": 6, "x": 0, "y": 3, "static": false, "moved": false},
+    {"h": 6, "i": "w05", "w": 6, "x": 6, "y": 3, "static": false, "moved": false},
+    {"h": 6, "i": "w06", "w": 6, "x": 0, "y": 9, "static": false, "moved": false},
+    {"h": 6, "i": "w07", "w": 6, "x": 6, "y": 9, "static": false, "moved": false},
+    {"h": 6, "i": "w08", "w": 6, "x": 0, "y": 15, "static": false, "moved": false},
+    {"h": 6, "i": "w09", "w": 6, "x": 6, "y": 15, "static": false, "moved": false},
+    {"h": 6, "i": "w10", "w": 4, "x": 0, "y": 21, "static": false, "moved": false},
+    {"h": 6, "i": "w11", "w": 4, "x": 4, "y": 21, "static": false, "moved": false},
+    {"h": 6, "i": "w12", "w": 4, "x": 8, "y": 21, "static": false, "moved": false}
+  ],
+  "panelMap": {},
+  "tags": ["aws", "msk", "kafka", "streaming"],
+  "title": "AWS MSK Cluster Monitoring",
+  "version": "v1",
+  "widgets": [
+    {
+      "id": "w01",
+      "title": "Bytes In (Rate)",
+      "description": "Network bytes received by the cluster per second",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "isStacked": false,
+      "stackedBarChart": false,
+      "mergeAllActiveQueries": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "softMin": 0,
+      "softMax": 0,
+      "columnUnits": {},
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "fillSpans": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "bytes",
+      "query": {
+        "id": "q01",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "{{cluster}}",
+            "query": "sum(rate(kafka_server_brokertopicmetrics_bytesin_total[5m])) by (cluster)",
+            "disabled": false
+          }
+        ],
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "builder": {"queryData": [], "queryFormulas": []}
+      }
+    },
+    {
+      "id": "w02",
+      "title": "Bytes Out (Rate)",
+      "description": "Network bytes sent by the cluster per second",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "isStacked": false,
+      "stackedBarChart": false,
+      "mergeAllActiveQueries": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "softMin": 0,
+      "softMax": 0,
+      "columnUnits": {},
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "fillSpans": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "bytes",
+      "query": {
+        "id": "q02",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "{{cluster}}",
+            "query": "sum(rate(kafka_server_brokertopicmetrics_bytesout_total[5m])) by (cluster)",
+            "disabled": false
+          }
+        ],
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "builder": {"queryData": [], "queryFormulas": []}
+      }
+    },
+    {
+      "id": "w03",
+      "title": "Messages In (Rate)",
+      "description": "Number of messages received per second",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "isStacked": false,
+      "stackedBarChart": false,
+      "mergeAllActiveQueries": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "softMin": 0,
+      "softMax": 0,
+      "columnUnits": {},
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "fillSpans": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "none",
+      "query": {
+        "id": "q03",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "{{cluster}}",
+            "query": "sum(rate(kafka_server_brokertopicmetrics_messagesin_total[5m])) by (cluster)",
+            "disabled": false
+          }
+        ],
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "builder": {"queryData": [], "queryFormulas": []}
+      }
+    },
+    {
+      "id": "w04",
+      "title": "Bytes In by Topic",
+      "description": "Network bytes in rate broken down by topic",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "isStacked": false,
+      "stackedBarChart": false,
+      "mergeAllActiveQueries": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "softMin": 0,
+      "softMax": 0,
+      "columnUnits": {},
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "fillSpans": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "bytes",
+      "query": {
+        "id": "q04",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "{{topic}}",
+            "query": "sum(rate(kafka_server_brokertopicmetrics_bytesin_total[5m])) by (topic)",
+            "disabled": false
+          }
+        ],
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "builder": {"queryData": [], "queryFormulas": []}
+      }
+    },
+    {
+      "id": "w05",
+      "title": "Bytes Out by Topic",
+      "description": "Network bytes out rate broken down by topic",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "isStacked": false,
+      "stackedBarChart": false,
+      "mergeAllActiveQueries": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "softMin": 0,
+      "softMax": 0,
+      "columnUnits": {},
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "fillSpans": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "bytes",
+      "query": {
+        "id": "q05",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "{{topic}}",
+            "query": "sum(rate(kafka_server_brokertopicmetrics_bytesout_total[5m])) by (topic)",
+            "disabled": false
+          }
+        ],
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "builder": {"queryData": [], "queryFormulas": []}
+      }
+    },
+    {
+      "id": "w06",
+      "title": "Under Replicated Partitions",
+      "description": "Number of under-replicated partitions — indicates data availability risk",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "isStacked": false,
+      "stackedBarChart": false,
+      "mergeAllActiveQueries": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "softMin": 0,
+      "softMax": 0,
+      "columnUnits": {},
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "fillSpans": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "none",
+      "query": {
+        "id": "q06",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "{{cluster}}",
+            "query": "sum(kafka_controller_kafkacontroller_underreplicatedpartitions) by (cluster)",
+            "disabled": false
+          }
+        ],
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "builder": {"queryData": [], "queryFormulas": []}
+      }
+    },
+    {
+      "id": "w07",
+      "title": "Offline Partitions",
+      "description": "Number of partitions without an active leader",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "isStacked": false,
+      "stackedBarChart": false,
+      "mergeAllActiveQueries": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "softMin": 0,
+      "softMax": 0,
+      "columnUnits": {},
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "fillSpans": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "none",
+      "query": {
+        "id": "q07",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "{{cluster}}",
+            "query": "sum(kafka_controller_kafkacontroller_offlinepartitionscount) by (cluster)",
+            "disabled": false
+          }
+        ],
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "builder": {"queryData": [], "queryFormulas": []}
+      }
+    },
+    {
+      "id": "w08",
+      "title": "Partition Count",
+      "description": "Total number of partitions across the cluster",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "isStacked": false,
+      "stackedBarChart": false,
+      "mergeAllActiveQueries": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "softMin": 0,
+      "softMax": 0,
+      "columnUnits": {},
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "fillSpans": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "none",
+      "query": {
+        "id": "q08",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "{{cluster}}",
+            "query": "sum(kafka_server_replicamanager_partitioncount) by (cluster)",
+            "disabled": false
+          }
+        ],
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "builder": {"queryData": [], "queryFormulas": []}
+      }
+    },
+    {
+      "id": "w09",
+      "title": "Request Latency (99th Percentile)",
+      "description": "99th percentile request processing latency by request type",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "isStacked": false,
+      "stackedBarChart": false,
+      "mergeAllActiveQueries": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "softMin": 0,
+      "softMax": 0,
+      "columnUnits": {},
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "fillSpans": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "microseconds",
+      "query": {
+        "id": "q09",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "{{request}}",
+            "query": "histogram_quantile(0.99, sum(rate(kafka_network_requestmetrics_requestlatencyms_bucket[5m])) by (le, request)) * 1000",
+            "disabled": false
+          }
+        ],
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "builder": {"queryData": [], "queryFormulas": []}
+      }
+    },
+    {
+      "id": "w10",
+      "title": "Active Controller Count",
+      "description": "Number of active controllers — should always be 1",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "isStacked": false,
+      "stackedBarChart": false,
+      "mergeAllActiveQueries": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "softMin": 0,
+      "softMax": 0,
+      "columnUnits": {},
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "fillSpans": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "none",
+      "query": {
+        "id": "q10",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "{{cluster}}",
+            "query": "sum(kafka_controller_kafkacontroller_activecontrollercount) by (cluster)",
+            "disabled": false
+          }
+        ],
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "builder": {"queryData": [], "queryFormulas": []}
+      }
+    },
+    {
+      "id": "w11",
+      "title": "Broker Count",
+      "description": "Number of brokers registered in the cluster",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "isStacked": false,
+      "stackedBarChart": false,
+      "mergeAllActiveQueries": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "softMin": 0,
+      "softMax": 0,
+      "columnUnits": {},
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "fillSpans": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "none",
+      "query": {
+        "id": "q11",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "{{cluster}}",
+            "query": "sum(kafka_server_kafkaservertype_brokercount) by (cluster)",
+            "disabled": false
+          }
+        ],
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "builder": {"queryData": [], "queryFormulas": []}
+      }
+    },
+    {
+      "id": "w12",
+      "title": "Producer/Consumer Request Rate",
+      "description": "Rate of produce and fetch requests",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "isStacked": false,
+      "stackedBarChart": false,
+      "mergeAllActiveQueries": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "softMin": 0,
+      "softMax": 0,
+      "columnUnits": {},
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "fillSpans": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "none",
+      "query": {
+        "id": "q12",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "Produce",
+            "query": "sum(rate(kafka_network_requestmetrics_requests_total{request=\"Produce\"}[5m])) by (cluster)",
+            "disabled": false
+          },
+          {
+            "name": "B",
+            "legend": "Fetch",
+            "query": "sum(rate(kafka_network_requestmetrics_requests_total{request=\"Fetch\"}[5m])) by (cluster)",
+            "disabled": false
+          }
+        ],
+        "clickhouse_sql": [
+          {"disabled": false, "legend": "", "name": "A", "query": ""},
+          {"disabled": false, "legend": "", "name": "B", "query": ""}
+        ],
+        "builder": {"queryData": [], "queryFormulas": []}
+      }
+    }
+  ]
+}


### PR DESCRIPTION
/claim #6036

## Description

Adds a comprehensive AWS MSK (Managed Streaming for Apache Kafka) monitoring dashboard.

### Panels included:

**Throughput (top row):**
- Bytes In (Rate)
- Bytes Out (Rate)
- Messages In (Rate)

**Topic-level breakdown:**
- Bytes In by Topic
- Bytes Out by Topic

**Cluster health:**
- Under Replicated Partitions
- Offline Partitions
- Partition Count

**Performance:**
- Request Latency (99th Percentile) — by request type
- Producer/Consumer Request Rate

**Cluster metadata:**
- Active Controller Count
- Broker Count

### Notes
- All queries use PromQL format compatible with SigNoz
- Uses standard JMX Kafka exporter metric names
- Closes #6036