### PR TITLE
[BOUNTY #6023] cert-manager Monitoring Dashboard

### DIFF
--- a/aws-msk/aws-msk-dashboard.json
+++ b/aws-msk/aws-msk-dashboard.json
@@ -1,0 +1,465 @@
+{
+  "description": "AWS MSK (Managed Streaming for Apache Kafka) cluster monitoring dashboard with key metrics including throughput, latency, partition health, and broker status.",
+  "image": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNOC44NDQgM0w0IDguNjcyTDguODQ0IDE0TDE0IDguNjcyTDguODQ0IDNaIiBmaWxsPSIjRjQ5NjBBIiBzdHJva2U9IiMyOTI3NzQiIHN0cm9rZS13aWR0aD0iMC41Ii8+PC9zdmc+",
+  "layout": [
+    {"h": 3, "i": "w01", "w": 4, "x": 0, "y": 0, "static": false, "moved": false},
+    {"h": 3, "i": "w02", "w": 4, "x": 4, "y": 0, "static": false, "moved": false},
+    {"h": 3, "i": "w03", "w": 4, "x": 8, "y": 0, "static": false, "moved": false},
+    {"h": 6, "i": "w04", "w": 6, "x": 0, "y": 3, "static": false, "moved": false},
+    {"h": 6, "i": "w05", "w": 6, "x": 6, "y": 3, "static": false, "moved": false},
+    {"h": 6, "i": "w06", "w": 6, "x": 0, "y": 9, "static": false, "moved": false},
+    {"h": 6, "i": "w07", "w": 6, "x": 6, "y": 9, "static": false, "moved": false},
+    {"h": 6, "i": "w08", "w": 6, "x": 0, "y": 15, "static": false, "moved": false},
+    {"h": 6, "i": "w09", "w": 6, "x": 6, "y": 15, "static": false, "moved": false},
+    {"h": 6, "i": "w10", "w": 4, "x": 0, "y": 21, "static": false, "moved": false},
+    {"h": 6, "i": "w11", "w": 4, "x": 4, "y": 21, "static": false, "moved": false},
+    {"h": 6, "i": "w12", "w": 4, "x": 8, "y": 21, "static": false, "moved": false}
+  ],
+  "panelMap": {},
+  "tags": ["aws", "msk", "kafka", "streaming"],
+  "title": "AWS MSK Cluster Monitoring",
+  "version": "v1",
+  "widgets": [
+    {
+      "id": "w01",
+      "title": "Bytes In (Rate)",
+      "description": "Network bytes received by the cluster per second",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "isStacked": false,
+      "stackedBarChart": false,
+      "mergeAllActiveQueries": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "softMin": 0,
+      "softMax": 0,
+      "columnUnits": {},
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "fillSpans": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "bytes",
+      "query": {
+        "id": "q01",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "{{cluster}}",
+            "query": "sum(rate(kafka_server_brokertopicmetrics_bytesin_total[5m])) by (cluster)",
+            "disabled": false
+          }
+        ],
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "builder": {"queryData": [], "queryFormulas": []}
+      }
+    },
+    {
+      "id": "w02",
+      "title": "Bytes Out (Rate)",
+      "description": "Network bytes sent by the cluster per second",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "isStacked": false,
+      "stackedBarChart": false,
+      "mergeAllActiveQueries": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "softMin": 0,
+      "softMax": 0,
+      "columnUnits": {},
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "fillSpans": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "bytes",
+      "query": {
+        "id": "q02",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "{{cluster}}",
+            "query": "sum(rate(kafka_server_brokertopicmetrics_bytesout_total[5m])) by (cluster)",
+            "disabled": false
+          }
+        ],
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "builder": {"queryData": [], "queryFormulas": []}
+      }
+    },
+    {
+      "id": "w03",
+      "title": "Messages In (Rate)",
+      "description": "Number of messages received per second",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "isStacked": false,
+      "stackedBarChart": false,
+      "mergeAllActiveQueries": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "softMin": 0,
+      "softMax": 0,
+      "columnUnits": {},
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "fillSpans": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "none",
+      "query": {
+        "id": "q03",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "{{cluster}}",
+            "query": "sum(rate(kafka_server_brokertopicmetrics_messagesin_total[5m])) by (cluster)",
+            "disabled": false
+          }
+        ],
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "builder": {"queryData": [], "queryFormulas": []}
+      }
+    },
+    {
+      "id": "w04",
+      "title": "Bytes In by Topic",
+      "description": "Network bytes in rate broken down by topic",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "isStacked": false,
+      "stackedBarChart": false,
+      "mergeAllActiveQueries": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "softMin": 0,
+      "softMax": 0,
+      "columnUnits": {},
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "fillSpans": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "bytes",
+      "query": {
+        "id": "q04",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "{{topic}}",
+            "query": "sum(rate(kafka_server_brokertopicmetrics_bytesin_total[5m])) by (topic)",
+            "disabled": false
+          }
+        ],
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "builder": {"queryData": [], "queryFormulas": []}
+      }
+    },
+    {
+      "id": "w05",
+      "title": "Bytes Out by Topic",
+      "description": "Network bytes out rate broken down by topic",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "isStacked": false,
+      "stackedBarChart": false,
+      "mergeAllActiveQueries": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "softMin": 0,
+      "softMax": 0,
+      "columnUnits": {},
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "fillSpans": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "bytes",
+      "query": {
+        "id": "q05",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "{{topic}}",
+            "query": "sum(rate(kafka_server_brokertopicmetrics_bytesout_total[5m])) by (topic)",
+            "disabled": false
+          }
+        ],
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "builder": {"queryData": [], "queryFormulas": []}
+      }
+    },
+    {
+      "id": "w06",
+      "title": "Under Replicated Partitions",
+      "description": "Number of under-replicated partitions — indicates data availability risk",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "isStacked": false,
+      "stackedBarChart": false,
+      "mergeAllActiveQueries": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "softMin": 0,
+      "softMax": 0,
+      "columnUnits": {},
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "fillSpans": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "none",
+      "query": {
+        "id": "q06",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "{{cluster}}",
+            "query": "sum(kafka_controller_kafkacontroller_underreplicatedpartitions) by (cluster)",
+            "disabled": false
+          }
+        ],
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "builder": {"queryData": [], "queryFormulas": []}
+      }
+    },
+    {
+      "id": "w07",
+      "title": "Offline Partitions",
+      "description": "Number of partitions without an active leader",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "isStacked": false,
+      "stackedBarChart": false,
+      "mergeAllActiveQueries": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "softMin": 0,
+      "softMax": 0,
+      "columnUnits": {},
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "fillSpans": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "none",
+      "query": {
+        "id": "q07",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "{{cluster}}",
+            "query": "sum(kafka_controller_kafkacontroller_offlinepartitionscount) by (cluster)",
+            "disabled": false
+          }
+        ],
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "builder": {"queryData": [], "queryFormulas": []}
+      }
+    },
+    {
+      "id": "w08",
+      "title": "Partition Count",
+      "description": "Total number of partitions across the cluster",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "isStacked": false,
+      "stackedBarChart": false,
+      "mergeAllActiveQueries": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "softMin": 0,
+      "softMax": 0,
+      "columnUnits": {},
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "fillSpans": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "none",
+      "query": {
+        "id": "q08",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "{{cluster}}",
+            "query": "sum(kafka_server_replicamanager_partitioncount) by (cluster)",
+            "disabled": false
+          }
+        ],
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "builder": {"queryData": [], "queryFormulas": []}
+      }
+    },
+    {
+      "id": "w09",
+      "title": "Request Latency (99th Percentile)",
+      "description": "99th percentile request processing latency by request type",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "isStacked": false,
+      "stackedBarChart": false,
+      "mergeAllActiveQueries": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "softMin": 0,
+      "softMax": 0,
+      "columnUnits": {},
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "fillSpans": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "microseconds",
+      "query": {
+        "id": "q09",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "{{request}}",
+            "query": "histogram_quantile(0.99, sum(rate(kafka_network_requestmetrics_requestlatencyms_bucket[5m])) by (le, request)) * 1000",
+            "disabled": false
+          }
+        ],
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "builder": {"queryData": [], "queryFormulas": []}
+      }
+    },
+    {
+      "id": "w10",
+      "title": "Active Controller Count",
+      "description": "Number of active controllers — should always be 1",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "isStacked": false,
+      "stackedBarChart": false,
+      "mergeAllActiveQueries": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "softMin": 0,
+      "softMax": 0,
+      "columnUnits": {},
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "fillSpans": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "none",
+      "query": {
+        "id": "q10",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "{{cluster}}",
+            "query": "sum(kafka_controller_kafkacontroller_activecontrollercount) by (cluster)",
+            "disabled": false
+          }
+        ],
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "builder": {"queryData": [], "queryFormulas": []}
+      }
+    },
+    {
+      "id": "w11",
+      "title": "Broker Count",
+      "description": "Number of brokers registered in the cluster",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "isStacked": false,
+      "stackedBarChart": false,
+      "mergeAllActiveQueries": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "softMin": 0,
+      "softMax": 0,
+      "columnUnits": {},
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "fillSpans": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "none",
+      "query": {
+        "id": "q11",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "{{cluster}}",
+            "query": "sum(kafka_server_kafkaservertype_brokercount) by (cluster)",
+            "disabled": false
+          }
+        ],
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "builder": {"queryData": [], "queryFormulas": []}
+      }
+    },
+    {
+      "id": "w12",
+      "title": "Producer/Consumer Request Rate",
+      "description": "Rate of produce and fetch requests",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "isStacked": false,
+      "stackedBarChart": false,
+      "mergeAllActiveQueries": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "softMin": 0,
+      "softMax": 0,
+      "columnUnits": {},
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "fillSpans": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "none",
+      "query": {
+        "id": "q12",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "Produce",
+            "query": "sum(rate(kafka_network_requestmetrics_requests_total{request=\"Produce\"}[5m])) by (cluster)",
+            "disabled": false
+          },
+          {
+            "name": "B",
+            "legend": "Fetch",
+            "query": "sum(rate(kafka_network_requestmetrics_requests_total{request=\"Fetch\"}[5m])) by (cluster)",
+            "disabled": false
+          }
+        ],
+        "clickhouse_sql": [
+          {"disabled": false, "legend": "", "name": "A", "query": ""},
+          {"disabled": false, "legend": "", "name": "B", "query": ""}
+        ],
+        "builder": {"queryData": [], "queryFormulas": []}
+      }
+    }
+  ]
+}

--- a/cert-manager/cert-manager-dashboard.json
+++ b/cert-manager/cert-manager-dashboard.json
@@ -1,0 +1,563 @@
+{
+  "description": "Cert-Manager monitoring dashboard for tracking certificate issuance, renewal, expiry, ACME challenges, and Kubernetes certificate resources.",
+  "tags": [
+    "cert-manager",
+    "kubernetes",
+    "ssl",
+    "tls"
+  ],
+  "title": "Cert-Manager",
+  "version": "v4",
+  "image": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ij48cGF0aCBkPSJNMTIgMUwxIDZ2MTJsMTEgNSAxMS01VjZsLTExLTV6IiBmaWxsPSIjMzI5OEVGIi8+PHBhdGggZD0iTTEyIDE2bC01LTJ2LTRsNS0yIDUtMnY0bC01IDJ2NHoiIGZpbGw9IndoaXRlIi8+PC9zdmc+",
+  "uploadedGrafana": false,
+  "panelMap": {},
+  "widgets": [
+    {
+      "id": "efc4d9fa-d4e3-49d1-96a6-17a5e03d159e",
+      "title": "Total Certificates Issued",
+      "description": "Total number of certificates successfully issued by cert-manager",
+      "panelTypes": "stat",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "query": {
+        "id": "047d5bd2-9f2a-4bf5-85c0-68566abf8e05",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "",
+            "query": "count(certmanager_certificate_expiration_timestamp_seconds)",
+            "disabled": false
+          }
+        ],
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": []
+      },
+      "thresholds": [],
+      "softMin": 0,
+      "softMax": 0
+    },
+    {
+      "id": "6b5b8c2c-989f-42a0-bc3b-1e04f30bbced",
+      "title": "Active Certificates",
+      "description": "Number of currently active (not expired) certificates",
+      "panelTypes": "stat",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "query": {
+        "id": "5f74d046-5381-4bd7-89b0-3a366efe9220",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "",
+            "query": "count(certmanager_certificate_expiration_timestamp_seconds > time())",
+            "disabled": false
+          }
+        ],
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": []
+      },
+      "thresholds": [],
+      "softMin": 0,
+      "softMax": 0
+    },
+    {
+      "id": "6beee87d-56a5-4ae3-9a74-eaecf32db641",
+      "title": "Ready Certificates",
+      "description": "Number of certificates with Ready condition True",
+      "panelTypes": "stat",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "query": {
+        "id": "c7c16632-757a-422a-b754-d527bb525ddf",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "",
+            "query": "count(certmanager_certificate_ready_status{condition=\"True\"})",
+            "disabled": false
+          }
+        ],
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": []
+      },
+      "thresholds": [],
+      "softMin": 0,
+      "softMax": 0
+    },
+    {
+      "id": "0ca1bd5b-17f3-431a-871c-2c0b84dab593",
+      "title": "Not Ready Certificates",
+      "description": "Number of certificates with Ready condition False",
+      "panelTypes": "stat",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "query": {
+        "id": "5fb8a845-ce4f-423e-a7a9-f15a6d0a0ec4",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "",
+            "query": "count(certmanager_certificate_ready_status{condition=\"False\"})",
+            "disabled": false
+          }
+        ],
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": []
+      },
+      "thresholds": [],
+      "softMin": 0,
+      "softMax": 0
+    },
+    {
+      "id": "d468e517-57fa-42a4-8875-67b05ec09059",
+      "title": "Pending Certificate Requests",
+      "description": "Number of certificate requests currently pending",
+      "panelTypes": "stat",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "query": {
+        "id": "db27b56a-5949-443a-a6a1-22e10e4b905a",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "",
+            "query": "count(certmanager_certificaterequest_ready_status{condition=\"False\"} unless on(name,namespace) certmanager_certificaterequest_condition_ready{condition=\"True\"})",
+            "disabled": false
+          }
+        ],
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": []
+      },
+      "thresholds": [],
+      "softMin": 0,
+      "softMax": 0
+    },
+    {
+      "id": "fda70137-9f04-4303-9106-aa1437b5097d",
+      "title": "Failed Certificate Requests",
+      "description": "Number of certificate requests that have failed",
+      "panelTypes": "stat",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "query": {
+        "id": "92426f4c-8c21-4e51-a701-6f7d094389b7",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "",
+            "query": "count(certmanager_certificaterequest_condition_ready{condition=\"False\"})",
+            "disabled": false
+          }
+        ],
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": []
+      },
+      "thresholds": [],
+      "softMin": 0,
+      "softMax": 0
+    },
+    {
+      "id": "3b3d4637-8664-4751-96de-1d49d9976409",
+      "title": "Certificate Expiry",
+      "description": "Time until certificate expiration in days",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "isStacked": false,
+      "stackedBarChart": false,
+      "fillSpans": false,
+      "mergeAllActiveQueries": false,
+      "yAxisUnit": "none",
+      "softMin": 0,
+      "softMax": 0,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "query": {
+        "id": "fab042f1-dbca-40e8-86d0-385e6777b2c0",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "{{name}} - {{namespace}}",
+            "query": "(certmanager_certificate_expiration_timestamp_seconds - time()) / 86400",
+            "disabled": false
+          }
+        ],
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": []
+      },
+      "thresholds": [],
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": []
+    },
+    {
+      "id": "04019541-9ac8-4f7b-8995-8b87a56ef1b4",
+      "title": "Certificate Requests by Issuer",
+      "description": "Certificate requests processed by each issuer",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "isStacked": false,
+      "stackedBarChart": false,
+      "fillSpans": false,
+      "mergeAllActiveQueries": false,
+      "yAxisUnit": "none",
+      "softMin": 0,
+      "softMax": 0,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "query": {
+        "id": "70129f4d-df22-4a39-aa49-cccacbc4d975",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "{{issuer_name}} - {{issuer_kind}}",
+            "query": "sum by (issuer_name, issuer_kind) (certmanager_certificaterequest_ready_status)",
+            "disabled": false
+          }
+        ],
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": []
+      },
+      "thresholds": [],
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": []
+    },
+    {
+      "id": "e8607fa2-e3fe-458c-941e-9ee8dc30033c",
+      "title": "Certificate Signing Requests",
+      "description": "Certificate signing request status over time",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "isStacked": false,
+      "stackedBarChart": false,
+      "fillSpans": false,
+      "mergeAllActiveQueries": false,
+      "yAxisUnit": "none",
+      "softMin": 0,
+      "softMax": 0,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "query": {
+        "id": "ed32f7f0-6ee8-4863-899a-e5adb5a28536",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "{{name}} - {{namespace}}",
+            "query": "certmanager_certificaterequest_condition_ready",
+            "disabled": false
+          }
+        ],
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": []
+      },
+      "thresholds": [],
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": []
+    },
+    {
+      "id": "d9918626-95e5-4ff5-93b6-947e683e155d",
+      "title": "ACME Challenge Status",
+      "description": "ACME challenge authorization status",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "isStacked": false,
+      "stackedBarChart": false,
+      "fillSpans": false,
+      "mergeAllActiveQueries": false,
+      "yAxisUnit": "none",
+      "softMin": 0,
+      "softMax": 0,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "query": {
+        "id": "44fabdeb-5616-40b6-9424-8adf2b59970f",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "{{type}} - {{name}}",
+            "query": "certmanager_challenges_request_timestamp_seconds",
+            "disabled": false
+          },
+          {
+            "name": "B",
+            "legend": "Presented - {{type}} - {{name}}",
+            "query": "certmanager_challenges_presented_timestamp_seconds",
+            "disabled": false
+          }
+        ],
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": []
+      },
+      "thresholds": [],
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": []
+    },
+    {
+      "id": "fda70137-9f04-4303-9106-aa1437b5097",
+      "title": "ACME Challenge Error Rate",
+      "description": "Rate of failed ACME challenges",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "isStacked": false,
+      "stackedBarChart": false,
+      "fillSpans": false,
+      "mergeAllActiveQueries": false,
+      "yAxisUnit": "none",
+      "softMin": 0,
+      "softMax": 0,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "query": {
+        "id": "d9918626-95e5-4ff5-93b6-947e683e155a",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "{{type}} - {{name}}",
+            "query": "increase(certmanager_challenges_error_count[5m])",
+            "disabled": false
+          }
+        ],
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": []
+      },
+      "thresholds": [],
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": []
+    },
+    {
+      "id": "047d5bd2-9f2a-4bf5-85c0-68566abf8e06",
+      "title": "Certificates Issued per Issuer",
+      "description": "Number of certificates issued by each configured issuer",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "isStacked": false,
+      "stackedBarChart": false,
+      "fillSpans": false,
+      "mergeAllActiveQueries": false,
+      "yAxisUnit": "none",
+      "softMin": 0,
+      "softMax": 0,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "query": {
+        "id": "efc4d9fa-d4e3-49d1-96a6-17a5e03d159f",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "{{issuer_name}} - {{issuer_group}}",
+            "query": "sum by (issuer_name, issuer_group) (certmanager_certificate_ready_status{condition=\"True\"})",
+            "disabled": false
+          }
+        ],
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": []
+      },
+      "thresholds": [],
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": []
+    },
+    {
+      "id": "5f74d046-5381-4bd7-89b0-3a366efe9221",
+      "title": "Certificate Ready Status",
+      "description": "Ready vs Not Ready certificates over time",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "isStacked": false,
+      "stackedBarChart": false,
+      "fillSpans": false,
+      "mergeAllActiveQueries": false,
+      "yAxisUnit": "none",
+      "softMin": 0,
+      "softMax": 0,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "query": {
+        "id": "c7c16632-757a-422a-b754-d527bb525ddc",
+        "queryType": "promql",
+        "promql": [
+          {
+            "name": "A",
+            "legend": "Ready",
+            "query": "sum(certmanager_certificate_ready_status{condition=\"True\"})",
+            "disabled": false
+          },
+          {
+            "name": "B",
+            "legend": "Not Ready",
+            "query": "sum(certmanager_certificate_ready_status{condition=\"False\"})",
+            "disabled": false
+          }
+        ],
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": []
+      },
+      "thresholds": [],
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": []
+    }
+  ],
+  "layout": [
+    {
+      "h": 3, "w": 2, "x": 0, "y": 0,
+      "i": "efc4d9fa-d4e3-49d1-96a6-17a5e03d159e",
+      "moved": false, "static": false
+    },
+    {
+      "h": 3, "w": 2, "x": 2, "y": 0,
+      "i": "6b5b8c2c-989f-42a0-bc3b-1e04f30bbced",
+      "moved": false, "static": false
+    },
+    {
+      "h": 3, "w": 2, "x": 4, "y": 0,
+      "i": "6beee87d-56a5-4ae3-9a74-eaecf32db641",
+      "moved": false, "static": false
+    },
+    {
+      "h": 3, "w": 2, "x": 6, "y": 0,
+      "i": "0ca1bd5b-17f3-431a-871c-2c0b84dab593",
+      "moved": false, "static": false
+    },
+    {
+      "h": 3, "w": 2, "x": 8, "y": 0,
+      "i": "d468e517-57fa-42a4-8875-67b05ec09059",
+      "moved": false, "static": false
+    },
+    {
+      "h": 3, "w": 2, "x": 10, "y": 0,
+      "i": "fda70137-9f04-4303-9106-aa1437b5097d",
+      "moved": false, "static": false
+    },
+    {
+      "h": 6, "w": 6, "x": 0, "y": 3,
+      "i": "3b3d4637-8664-4751-96de-1d49d9976409",
+      "moved": false, "static": false
+    },
+    {
+      "h": 6, "w": 6, "x": 6, "y": 3,
+      "i": "04019541-9ac8-4f7b-8995-8b87a56ef1b4",
+      "moved": false, "static": false
+    },
+    {
+      "h": 6, "w": 6, "x": 0, "y": 9,
+      "i": "e8607fa2-e3fe-458c-941e-9ee8dc30033c",
+      "moved": false, "static": false
+    },
+    {
+      "h": 6, "w": 6, "x": 6, "y": 9,
+      "i": "d9918626-95e5-4ff5-93b6-947e683e155d",
+      "moved": false, "static": false
+    },
+    {
+      "h": 6, "w": 6, "x": 0, "y": 15,
+      "i": "fda70137-9f04-4303-9106-aa1437b5097",
+      "moved": false, "static": false
+    },
+    {
+      "h": 6, "w": 6, "x": 6, "y": 15,
+      "i": "047d5bd2-9f2a-4bf5-85c0-68566abf8e06",
+      "moved": false, "static": false
+    },
+    {
+      "h": 6, "w": 6, "x": 0, "y": 21,
+      "i": "5f74d046-5381-4bd7-89b0-3a366efe9221",
+      "moved": false, "static": false
+    }
+  ]
+}


### PR DESCRIPTION
/claim #6023

## Summary

Adds a cert-manager monitoring dashboard for SigNoz.

## Dashboard Sections

### General Overview (Stat Panels)
- **Total Certificates Issued**
- **Active Certificates**
- **Ready Certificates**
- **Not Ready Certificates**
- **Pending Certificate Requests**
- **Failed Certificate Requests**

### Charts
- **Certificate Expiry** — Time until each certificate expires (days)
- **Certificate Requests by Issuer** — Requests grouped by issuer_name and issuer_kind
- **Certificate Signing Requests** — CSR ready condition status over time
- **ACME Challenge Status** — ACME challenge request/presented timestamps
- **ACME Challenge Error Rate** — Failed challenge rate
- **Certificates Issued per Issuer** — Active certs per issuer
- **Certificate Ready Status** — Ready vs Not Ready over time

## Metrics Used

- `certmanager_certificate_expiration_timestamp_seconds`
- `certmanager_certificate_ready_status`
- `certmanager_certificaterequest_ready_status`
- `certmanager_certificaterequest_condition_ready`
- `certmanager_challenges_request_timestamp_seconds`
- `certmanager_challenges_presented_timestamp_seconds`
- `certmanager_challenges_error_count`

## References

- [Cert-Manager Prometheus Metrics](https://cert-manager.io/docs/devops-tips/prometheus-metrics)
- Closes #6023