### PR TITLE
[BOUNTY #6028] Kong Gateway Monitoring Dashboard

### DIFF
--- a/istio/istio-dashboard.json
+++ b/istio/istio-dashboard.json
@@ -1,0 +1,608 @@
+{
+  "description": "Comprehensive Istio service mesh monitoring dashboard based on Prometheus metrics. Covers request throughput, success rate, latency percentiles, traffic distribution, error rates, resource usage, control plane, and security metrics.",
+  "image": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTI4IiBoZWlnaHQ9IjEyOCIgdmlld0JveD0iMCAwIDEyOCAxMjgiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxyZWN0IHdpZHRoPSIxMjgiIGhlaWdodD0iMTI4IiByeD0iMTYiIGZpbGw9IiM0NjY1QTQiLz4KPHRleHQgeD0iNjQiIHk9Ijc1IiBmb250LWZhbWlseT0iQXJpYWwiIGZvbnQtc2l6ZT0iNTAiIGZpbGw9IndoaXRlIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIj7wn4yRPC90ZXh0Pgo8L3N2Zz4=",
+  "layout": [
+    {"h": 4, "i": "w01", "moved": false, "static": false, "w": 3, "x": 0, "y": 0},
+    {"h": 4, "i": "w02", "moved": false, "static": false, "w": 3, "x": 3, "y": 0},
+    {"h": 4, "i": "w03", "moved": false, "static": false, "w": 3, "x": 6, "y": 0},
+    {"h": 4, "i": "w04", "moved": false, "static": false, "w": 3, "x": 9, "y": 0},
+    {"h": 4, "i": "w05", "moved": false, "static": false, "w": 6, "x": 0, "y": 4},
+    {"h": 4, "i": "w06", "moved": false, "static": false, "w": 6, "x": 6, "y": 4},
+    {"h": 4, "i": "w07", "moved": false, "static": false, "w": 6, "x": 0, "y": 8},
+    {"h": 4, "i": "w08", "moved": false, "static": false, "w": 6, "x": 6, "y": 8},
+    {"h": 4, "i": "w09", "moved": false, "static": false, "w": 6, "x": 0, "y": 12},
+    {"h": 4, "i": "w10", "moved": false, "static": false, "w": 6, "x": 6, "y": 12},
+    {"h": 4, "i": "w11", "moved": false, "static": false, "w": 4, "x": 0, "y": 16},
+    {"h": 4, "i": "w12", "moved": false, "static": false, "w": 4, "x": 4, "y": 16},
+    {"h": 4, "i": "w13", "moved": false, "static": false, "w": 4, "x": 8, "y": 16},
+    {"h": 4, "i": "w14", "moved": false, "static": false, "w": 6, "x": 0, "y": 20},
+    {"h": 4, "i": "w15", "moved": false, "static": false, "w": 6, "x": 6, "y": 20},
+    {"h": 4, "i": "w16", "moved": false, "static": false, "w": 6, "x": 0, "y": 24},
+    {"h": 4, "i": "w17", "moved": false, "static": false, "w": 6, "x": 6, "y": 24},
+    {"h": 4, "i": "w18", "moved": false, "static": false, "w": 4, "x": 0, "y": 28},
+    {"h": 4, "i": "w19", "moved": false, "static": false, "w": 4, "x": 4, "y": 28},
+    {"h": 4, "i": "w20", "moved": false, "static": false, "w": 4, "x": 8, "y": 28}
+  ],
+  "panelMap": {},
+  "tags": ["istio", "prometheus", "service-mesh"],
+  "title": "Istio Service Mesh Monitoring",
+  "uploadedGrafana": false,
+  "version": "v4",
+  "variables": {
+    "namespace": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Filter by Kubernetes namespace",
+      "modificationUUID": "a1c5f37c-0001-4a77-a42f-30288de5f534",
+      "multiSelect": true,
+      "name": "namespace",
+      "queryValue": "label_values(istio_requests_total, destination_workload_namespace)",
+      "selectedValue": "",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "destination_service": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Filter by destination service",
+      "modificationUUID": "b2d6f48d-0002-4b88-b53g-40399ef6a645",
+      "multiSelect": true,
+      "name": "destination_service",
+      "queryValue": "label_values(istio_requests_total{destination_workload_namespace=~\"$namespace\"}, destination_service)",
+      "selectedValue": "",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "source_service": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Filter by source service",
+      "modificationUUID": "c3e7f59e-0003-4c99-c64h-504a0fg7b756",
+      "multiSelect": true,
+      "name": "source_service",
+      "queryValue": "label_values(istio_requests_total{destination_workload_namespace=~\"$namespace\"}, source_service)",
+      "selectedValue": "",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "globalVariableKey": null,
+  "widgets": [
+    {
+      "description": "Total request rate across the service mesh",
+      "id": "w01",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "round(sum(irate(istio_requests_total{destination_workload_namespace=~\"$namespace\", reporter=\"destination\"}[5m])), 0.001)",
+            "legend": "",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q01",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Rate",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "Percentage of successful (non-5xx) requests",
+      "id": "w02",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "round(1 - sum(irate(istio_requests_total{destination_workload_namespace=~\"$namespace\", reporter=\"destination\", response_code=~\"5..\"}[5m])) / sum(irate(istio_requests_total{destination_workload_namespace=~\"$namespace\", reporter=\"destination\"}[5m])), 0.001) * 100",
+            "legend": "",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q02",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Success Rate",
+      "yAxisUnit": "percent"
+    },
+    {
+      "description": "Average request latency (p50)",
+      "id": "w03",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "histogram_quantile(0.50, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload_namespace=~\"$namespace\", reporter=\"destination\"}[5m])) by (le, destination_service))",
+            "legend": "",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q03",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Latency (p50)",
+      "yAxisUnit": "milliseconds"
+    },
+    {
+      "description": "Error rate (5xx responses)",
+      "id": "w04",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "round(sum(irate(istio_requests_total{destination_workload_namespace=~\"$namespace\", reporter=\"destination\", response_code=~\"5..\"}[5m])) / sum(irate(istio_requests_total{destination_workload_namespace=~\"$namespace\", reporter=\"destination\"}[5m])), 0.001) * 100",
+            "legend": "",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q04",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Error Rate (5xx)",
+      "yAxisUnit": "percent"
+    },
+    {
+      "description": "Request throughput by destination service over time",
+      "id": "w05",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "sum(irate(istio_requests_total{destination_workload_namespace=~\"$namespace\", destination_service=~\"$destination_service\", reporter=\"destination\"}[5m])) by (destination_service)",
+            "legend": "{{destination_service}}",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q05",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Throughput by Destination",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "Success rate by destination service over time",
+      "id": "w06",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "1 - sum(irate(istio_requests_total{destination_workload_namespace=~\"$namespace\", destination_service=~\"$destination_service\", reporter=\"destination\", response_code=~\"5..\"}[5m])) by (destination_service) / sum(irate(istio_requests_total{destination_workload_namespace=~\"$namespace\", destination_service=~\"$destination_service\", reporter=\"destination\"}[5m])) by (destination_service)",
+            "legend": "{{destination_service}}",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q06",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Success Rate by Destination",
+      "yAxisUnit": "percent"
+    },
+    {
+      "description": "Request latency percentiles (p50, p90, p95, p99) over time",
+      "id": "w07",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "histogram_quantile(0.50, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload_namespace=~\"$namespace\", destination_service=~\"$destination_service\", reporter=\"destination\"}[5m])) by (le, destination_service))",
+            "legend": "p50 - {{destination_service}}",
+            "disabled": false
+          },
+          {
+            "name": "B",
+            "query": "histogram_quantile(0.90, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload_namespace=~\"$namespace\", destination_service=~\"$destination_service\", reporter=\"destination\"}[5m])) by (le, destination_service))",
+            "legend": "p90 - {{destination_service}}",
+            "disabled": false
+          },
+          {
+            "name": "C",
+            "query": "histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload_namespace=~\"$namespace\", destination_service=~\"$destination_service\", reporter=\"destination\"}[5m])) by (le, destination_service))",
+            "legend": "p95 - {{destination_service}}",
+            "disabled": false
+          },
+          {
+            "name": "D",
+            "query": "histogram_quantile(0.99, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload_namespace=~\"$namespace\", destination_service=~\"$destination_service\", reporter=\"destination\"}[5m])) by (le, destination_service))",
+            "legend": "p99 - {{destination_service}}",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q07",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Latency Percentiles",
+      "yAxisUnit": "milliseconds"
+    },
+    {
+      "description": "HTTP error rates (4xx vs 5xx) over time",
+      "id": "w08",
+      "isStacked": true,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "sum(irate(istio_requests_total{destination_workload_namespace=~\"$namespace\", reporter=\"destination\", response_code=~\"4..\"}[5m])) by (destination_service)",
+            "legend": "4xx - {{destination_service}}",
+            "disabled": false
+          },
+          {
+            "name": "B",
+            "query": "sum(irate(istio_requests_total{destination_workload_namespace=~\"$namespace\", reporter=\"destination\", response_code=~\"5..\"}[5m])) by (destination_service)",
+            "legend": "5xx - {{destination_service}}",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q08",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "HTTP Error Rates (4xx / 5xx)",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "Inbound and outbound traffic by source and destination",
+      "id": "w09",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "sum(irate(istio_requests_total{destination_workload_namespace=~\"$namespace\", source_service=~\"$source_service\", reporter=\"source\"}[5m])) by (source_service, destination_service)",
+            "legend": "{{source_service}} -> {{destination_service}}",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q09",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Traffic by Source and Destination",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "gRPC error rates across services",
+      "id": "w10",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "sum(irate(istio_requests_total{destination_workload_namespace=~\"$namespace\", destination_service=~\"$destination_service\", reporter=\"destination\", request_protocol=\"grpc\", response_code=~\"[^0].*\"}[5m])) by (destination_service, response_code)",
+            "legend": "{{destination_service}} - {{response_code}}",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q10",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "gRPC Error Rates",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "TCP bytes sent by destination service",
+      "id": "w11",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "sum(irate(istio_tcp_sent_bytes_total{destination_workload_namespace=~\"$namespace\", reporter=\"destination\"}[5m]))",
+            "legend": "",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q11",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "TCP Bytes Sent",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "TCP bytes received by destination service",
+      "id": "w12",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "sum(irate(istio_tcp_received_bytes_total{destination_workload_namespace=~\"$namespace\", reporter=\"destination\"}[5m]))",
+            "legend": "",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q12",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "TCP Bytes Received",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "Number of active connections in the mesh",
+      "id": "w13",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "sum(istio_tcp_connections_opened_total{destination_workload_namespace=~\"$namespace\", reporter=\"destination\"}) - sum(istio_tcp_connections_closed_total{destination_workload_namespace=~\"$namespace\", reporter=\"destination\"})",
+            "legend": "",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q13",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active TCP Connections",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Istio control plane CPU usage (pilot, istiod)",
+      "id": "w14",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "rate(container_cpu_usage_seconds_total{namespace=\"istio-system\", container=~\"discovery|istiod\"}[5m]) * 100",
+            "legend": "{{pod}}",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q14",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Control Plane CPU Usage",
+      "yAxisUnit": "percent"
+    },
+    {
+      "description": "Istio control plane memory usage (pilot, istiod)",
+      "id": "w15",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "container_memory_working_set_bytes{namespace=\"istio-system\", container=~\"discovery|istiod\"}",
+            "legend": "{{pod}}",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q15",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Control Plane Memory Usage",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "Pilot configuration push latency (ads)",
+      "id": "w16",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "histogram_quantile(0.99, sum(rate(pilot_push_latency_bucket{namespace=\"istio-system\"}[5m])) by (le))",
+            "legend": "p99 push latency",
+            "disabled": false
+          },
+          {
+            "name": "B",
+            "query": "histogram_quantile(0.95, sum(rate(pilot_push_latency_bucket{namespace=\"istio-system\"}[5m])) by (le))",
+            "legend": "p95 push latency",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q16",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Pilot Config Push Latency",
+      "yAxisUnit": "milliseconds"
+    },
+    {
+      "description": "Envoy proxy connections and request rates",
+      "id": "w17",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "sum(irate(envoy_cluster_upstream_rq_total{cluster_name!=\"PassthroughCluster\", cluster_name!~\"BlackHoleCluster|InboundPassthroughCluster|OutboundPassthroughCluster\"}[5m])) by (cluster_name)",
+            "legend": "{{cluster_name}}",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q17",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Envoy Proxy Request Rate by Cluster",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "mTLS connections as percentage of total",
+      "id": "w18",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "round(sum(irate(istio_requests_total{destination_workload_namespace=~\"$namespace\", reporter=\"source\", connection_security_policy=\"mutual_tls\"}[5m])) / sum(irate(istio_requests_total{destination_workload_namespace=~\"$namespace\", reporter=\"source\"}[5m])), 0.001) * 100",
+            "legend": "",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q18",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "mTLS Connection %",
+      "yAxisUnit": "percent"
+    },
+    {
+      "description": "Retries by destination service",
+      "id": "w19",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "round(sum(irate(istio_requests_total{destination_workload_namespace=~\"$namespace\", destination_service=~\"$destination_service\", reporter=\"destination\", response_flags=~\"UA|UO|UR\"}[5m])) by (destination_service), 0.001)",
+            "legend": "{{destination_service}}",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q19",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Retry Rate",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "Envoy proxy CPU usage",
+      "id": "w20",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "avg(rate(container_cpu_usage_seconds_total{namespace=~\"$namespace\", container=\"istio-proxy\"}[5m])) * 100",
+            "legend": "",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q20",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Avg Proxy CPU Usage",
+      "yAxisUnit": "percent"
+    }
+  ]
+}

--- a/kong/kong-dashboard.json
+++ b/kong/kong-dashboard.json
@@ -1,0 +1,691 @@
+{
+  "description": "Kong API Gateway monitoring dashboard with metrics for requests, latency, errors, traffic, plugins, and resource usage.",
+  "image": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHJ4PSI0IiBmaWxsPSIjMDAzQjVGIi8+PHRleHQgeD0iOSIgeT0iMTQiIGZvbnQtZmFtaWx5PSJzYW5zLXNlcmlmIiBmb250LXNpemU9IjEwIiBmaWxsPSJ3aGl0ZSIgdGV4dC1hbmNob3I9Im1pZGRsZSI+S29uZzwvdGV4dD48L3N2Zz4=",
+  "layout": [
+    {"h": 3, "i": "k1", "moved": false, "static": false, "w": 3, "x": 0, "y": 0},
+    {"h": 3, "i": "k2", "moved": false, "static": false, "w": 3, "x": 3, "y": 0},
+    {"h": 3, "i": "k3", "moved": false, "static": false, "w": 3, "x": 6, "y": 0},
+    {"h": 3, "i": "k4", "moved": false, "static": false, "w": 3, "x": 9, "y": 0},
+    {"h": 3, "i": "k5", "moved": false, "static": false, "w": 3, "x": 0, "y": 3},
+    {"h": 3, "i": "k6", "moved": false, "static": false, "w": 3, "x": 3, "y": 3},
+    {"h": 3, "i": "k7", "moved": false, "static": false, "w": 3, "x": 6, "y": 3},
+    {"h": 3, "i": "k8", "moved": false, "static": false, "w": 3, "x": 9, "y": 3},
+    {"h": 6, "i": "k9", "moved": false, "static": false, "w": 6, "x": 0, "y": 6},
+    {"h": 6, "i": "k10", "moved": false, "static": false, "w": 6, "x": 6, "y": 6},
+    {"h": 6, "i": "k11", "moved": false, "static": false, "w": 6, "x": 0, "y": 12},
+    {"h": 6, "i": "k12", "moved": false, "static": false, "w": 6, "x": 6, "y": 12},
+    {"h": 6, "i": "k13", "moved": false, "static": false, "w": 6, "x": 0, "y": 18},
+    {"h": 6, "i": "k14", "moved": false, "static": false, "w": 6, "x": 6, "y": 18},
+    {"h": 6, "i": "k15", "moved": false, "static": false, "w": 4, "x": 0, "y": 24},
+    {"h": 6, "i": "k16", "moved": false, "static": false, "w": 4, "x": 4, "y": 24},
+    {"h": 6, "i": "k17", "moved": false, "static": false, "w": 4, "x": 8, "y": 24},
+    {"h": 6, "i": "k18", "moved": false, "static": false, "w": 6, "x": 0, "y": 30},
+    {"h": 6, "i": "k19", "moved": false, "static": false, "w": 6, "x": 6, "y": 30},
+    {"h": 6, "i": "k20", "moved": false, "static": false, "w": 6, "x": 0, "y": 36},
+    {"h": 6, "i": "k21", "moved": false, "static": false, "w": 6, "x": 6, "y": 36}
+  ],
+  "panelMap": {},
+  "tags": ["kong", "api-gateway", "otel"],
+  "title": "Kong Gateway (OTEL)",
+  "uploadedGrafana": false,
+  "version": "v4",
+  "variables": [
+    {
+      "id": "v1",
+      "name": "namespace",
+      "type": "query",
+      "datasource": "metrics",
+      "request": {"queries": [{"name": "A", "query": "kong_requests_total", "legend": ""}], "queryType": "promql"},
+      "sort": 1
+    },
+    {
+      "id": "v2",
+      "name": "service",
+      "type": "query",
+      "datasource": "metrics",
+      "request": {"queries": [{"name": "A", "query": "kong_requests_total", "legend": ""}], "queryType": "promql"},
+      "sort": 1
+    },
+    {
+      "id": "v3",
+      "name": "deployment_environment",
+      "type": "query",
+      "datasource": "metrics",
+      "request": {"queries": [{"name": "A", "query": "kong_requests_total", "legend": ""}], "queryType": "promql"},
+      "sort": 1
+    },
+    {
+      "id": "v4",
+      "name": "cluster",
+      "type": "query",
+      "datasource": "metrics",
+      "request": {"queries": [{"name": "A", "query": "kong_requests_total", "legend": ""}], "queryType": "promql"},
+      "sort": 1
+    }
+  ],
+  "widgets": [
+    {
+      "id": "k1",
+      "title": "Total Requests",
+      "description": "Total number of API requests handled by Kong",
+      "panelTypes": "stat",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk1",
+        "promql": [
+          {"name": "A", "query": "sum(increase(kong_requests_total{namespace=\"$namespace\", service=\"$service\"}[$__interval]))", "legend": "Total Requests", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "none"
+    },
+    {
+      "id": "k2",
+      "title": "Active Connections",
+      "description": "Number of active connections managed by Kong",
+      "panelTypes": "stat",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk2",
+        "promql": [
+          {"name": "A", "query": "sum(kong_connections_active{namespace=\"$namespace\"})", "legend": "Active Connections", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "none"
+    },
+    {
+      "id": "k3",
+      "title": "Uptime",
+      "description": "Total uptime of Kong instance since last restart",
+      "panelTypes": "stat",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk3",
+        "promql": [
+          {"name": "A", "query": "time() - kong_up{namespace=\"$namespace\"}", "legend": "Uptime", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "seconds"
+    },
+    {
+      "id": "k4",
+      "title": "CPU Usage",
+      "description": "CPU usage by Kong process",
+      "panelTypes": "stat",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk4",
+        "promql": [
+          {"name": "A", "query": "avg(rate(process_cpu_seconds_total{namespace=\"$namespace\"}[$__interval])) * 100", "legend": "CPU %", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "percent"
+    },
+    {
+      "id": "k5",
+      "title": "Memory Usage",
+      "description": "Memory consumption of Kong",
+      "panelTypes": "stat",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk5",
+        "promql": [
+          {"name": "A", "query": "sum(process_resident_memory_bytes{namespace=\"$namespace\"})", "legend": "Memory", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "bytes"
+    },
+    {
+      "id": "k6",
+      "title": "Total Errors",
+      "description": "Total number of errors encountered by Kong",
+      "panelTypes": "stat",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk6",
+        "promql": [
+          {"name": "A", "query": "sum(increase(kong_requests_total{namespace=\"$namespace\", service=\"$service\", code=~\"5..\"}[$__interval]))", "legend": "5xx Errors", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "none"
+    },
+    {
+      "id": "k7",
+      "title": "Error Rate",
+      "description": "Rate of errors per second",
+      "panelTypes": "stat",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk7",
+        "promql": [
+          {"name": "A", "query": "sum(rate(kong_requests_total{namespace=\"$namespace\", service=\"$service\", code=~\"5..\"}[$__interval]))", "legend": "Error Rate/s", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "none"
+    },
+    {
+      "id": "k8",
+      "title": "Connection Rate",
+      "description": "Rate of new connections established with Kong",
+      "panelTypes": "stat",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk8",
+        "promql": [
+          {"name": "A", "query": "sum(rate(kong_connections_handled{namespace=\"$namespace\"}[$__interval]))", "legend": "Connections/s", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "none"
+    },
+    {
+      "id": "k9",
+      "title": "Request Rate",
+      "description": "Rate of incoming API requests per second",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk9",
+        "promql": [
+          {"name": "A", "query": "sum(rate(kong_requests_total{namespace=\"$namespace\", service=\"$service\"}[$__interval])) by (service)", "legend": "{{service}}", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "reqps"
+    },
+    {
+      "id": "k10",
+      "title": "Response Status Codes",
+      "description": "Distribution of HTTP response status codes (2xx, 4xx, 5xx)",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": true,
+      "isStacked": true,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk10",
+        "promql": [
+          {"name": "A", "query": "sum(rate(kong_requests_total{namespace=\"$namespace\", service=\"$service\", code=~\"2..\"}[$__interval])) by (code)", "legend": "2xx: {{code}}", "disabled": false},
+          {"name": "B", "query": "sum(rate(kong_requests_total{namespace=\"$namespace\", service=\"$service\", code=~\"3..\"}[$__interval])) by (code)", "legend": "3xx: {{code}}", "disabled": false},
+          {"name": "C", "query": "sum(rate(kong_requests_total{namespace=\"$namespace\", service=\"$service\", code=~\"4..\"}[$__interval])) by (code)", "legend": "4xx: {{code}}", "disabled": false},
+          {"name": "D", "query": "sum(rate(kong_requests_total{namespace=\"$namespace\", service=\"$service\", code=~\"5..\"}[$__interval])) by (code)", "legend": "5xx: {{code}}", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "reqps"
+    },
+    {
+      "id": "k11",
+      "title": "Request Size",
+      "description": "Average and percentile sizes of incoming API requests",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk11",
+        "promql": [
+          {"name": "A", "query": "histogram_quantile(0.50, sum(rate(kong_request_size_bucket{namespace=\"$namespace\", service=\"$service\"}[$__interval])) by (le))", "legend": "p50", "disabled": false},
+          {"name": "B", "query": "histogram_quantile(0.90, sum(rate(kong_request_size_bucket{namespace=\"$namespace\", service=\"$service\"}[$__interval])) by (le))", "legend": "p90", "disabled": false},
+          {"name": "C", "query": "histogram_quantile(0.99, sum(rate(kong_request_size_bucket{namespace=\"$namespace\", service=\"$service\"}[$__interval])) by (le))", "legend": "p99", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "bytes"
+    },
+    {
+      "id": "k12",
+      "title": "Response Size",
+      "description": "Average and percentile sizes of responses sent by Kong",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk12",
+        "promql": [
+          {"name": "A", "query": "histogram_quantile(0.50, sum(rate(kong_response_size_bucket{namespace=\"$namespace\", service=\"$service\"}[$__interval])) by (le))", "legend": "p50", "disabled": false},
+          {"name": "B", "query": "histogram_quantile(0.90, sum(rate(kong_response_size_bucket{namespace=\"$namespace\", service=\"$service\"}[$__interval])) by (le))", "legend": "p90", "disabled": false},
+          {"name": "C", "query": "histogram_quantile(0.99, sum(rate(kong_response_size_bucket{namespace=\"$namespace\", service=\"$service\"}[$__interval])) by (le))", "legend": "p99", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "bytes"
+    },
+    {
+      "id": "k13",
+      "title": "Request Latency",
+      "description": "Average time taken to process API requests",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk13",
+        "promql": [
+          {"name": "A", "query": "histogram_quantile(0.50, sum(rate(kong_latency_bucket{namespace=\"$namespace\", service=\"$service\"}[$__interval])) by (le, service))", "legend": "p50 - {{service}}", "disabled": false},
+          {"name": "B", "query": "histogram_quantile(0.90, sum(rate(kong_latency_bucket{namespace=\"$namespace\", service=\"$service\"}[$__interval])) by (le, service))", "legend": "p90 - {{service}}", "disabled": false},
+          {"name": "C", "query": "histogram_quantile(0.99, sum(rate(kong_latency_bucket{namespace=\"$namespace\", service=\"$service\"}[$__interval])) by (le, service))", "legend": "p99 - {{service}}", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "milliseconds"
+    },
+    {
+      "id": "k14",
+      "title": "Upstream Latency",
+      "description": "Latency of upstream services Kong communicates with",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk14",
+        "promql": [
+          {"name": "A", "query": "histogram_quantile(0.50, sum(rate(kong_upstream_latency_bucket{namespace=\"$namespace\", service=\"$service\"}[$__interval])) by (le, service))", "legend": "p50 - {{service}}", "disabled": false},
+          {"name": "B", "query": "histogram_quantile(0.90, sum(rate(kong_upstream_latency_bucket{namespace=\"$namespace\", service=\"$service\"}[$__interval])) by (le, service))", "legend": "p90 - {{service}}", "disabled": false},
+          {"name": "C", "query": "histogram_quantile(0.99, sum(rate(kong_upstream_latency_bucket{namespace=\"$namespace\", service=\"$service\"}[$__interval])) by (le, service))", "legend": "p99 - {{service}}", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "milliseconds"
+    },
+    {
+      "id": "k15",
+      "title": "CPU Usage (Time Series)",
+      "description": "CPU usage by Kong pods/services over time",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk15",
+        "promql": [
+          {"name": "A", "query": "avg(rate(process_cpu_seconds_total{namespace=\"$namespace\"}[$__interval])) by (instance) * 100", "legend": "{{instance}}", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "percent"
+    },
+    {
+      "id": "k16",
+      "title": "Memory Usage (Time Series)",
+      "description": "Memory consumption of Kong over time",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk16",
+        "promql": [
+          {"name": "A", "query": "sum(process_resident_memory_bytes{namespace=\"$namespace\"}) by (instance)", "legend": "{{instance}}", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "bytes"
+    },
+    {
+      "id": "k17",
+      "title": "Active Connections (Time Series)",
+      "description": "Number of active connections over time",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk17",
+        "promql": [
+          {"name": "A", "query": "kong_connections_active{namespace=\"$namespace\"}", "legend": "Active", "disabled": false},
+          {"name": "B", "query": "kong_connections_reading{namespace=\"$namespace\"}", "legend": "Reading", "disabled": false},
+          {"name": "C", "query": "kong_connections_writing{namespace=\"$namespace\"}", "legend": "Writing", "disabled": false},
+          {"name": "D", "query": "kong_connections_waiting{namespace=\"$namespace\"}", "legend": "Waiting", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "none"
+    },
+    {
+      "id": "k18",
+      "title": "Failed Requests by Service",
+      "description": "Failed requests segmented by upstream service",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": true,
+      "isStacked": true,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk18",
+        "promql": [
+          {"name": "A", "query": "sum(rate(kong_requests_total{namespace=\"$namespace\", service=\"$service\", code=~\"5..\"}[$__interval])) by (service)", "legend": "{{service}}", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "reqps"
+    },
+    {
+      "id": "k19",
+      "title": "Rejected Connections",
+      "description": "Connection attempts rejected by Kong",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk19",
+        "promql": [
+          {"name": "A", "query": "sum(increase(kong_connections_rejected{namespace=\"$namespace\"}[$__interval])) by (instance)", "legend": "{{instance}}", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "none"
+    },
+    {
+      "id": "k20",
+      "title": "Plugin Request Count",
+      "description": "Requests processed by each active plugin",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": true,
+      "isStacked": true,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk20",
+        "promql": [
+          {"name": "A", "query": "sum(rate(kong_plugin_requests_total{namespace=\"$namespace\"}[$__interval])) by (plugin)", "legend": "{{plugin}}", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "reqps"
+    },
+    {
+      "id": "k21",
+      "title": "Plugin Error Rate",
+      "description": "Error rates associated with each plugin",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk21",
+        "promql": [
+          {"name": "A", "query": "sum(rate(kong_plugin_errors_total{namespace=\"$namespace\"}[$__interval])) by (plugin)", "legend": "{{plugin}}", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "none"
+    }
+  ]
+}


### PR DESCRIPTION
/claim #6028

## Summary

Adds a comprehensive Kong API Gateway monitoring dashboard for SigNoz.

## Dashboard Sections

### General Overview (Stat widgets)
- Total Requests
- Active Connections
- Uptime
- CPU Usage
- Memory Usage

### Request Metrics
- Request Rate (graph, by service)
- Response Status Codes (stacked: 2xx, 3xx, 4xx, 5xx)
- Request Size (p50, p90, p99)
- Response Size (p50, p90, p99)

### Latency Metrics
- Request Latency (p50, p90, p99 by service)
- Upstream Latency (p50, p90, p99 by service)

### Error Metrics
- Total Errors (stat)
- Error Rate (stat)
- Failed Requests by Service (stacked graph)

### Traffic Metrics
- Connection Rate (stat)
- Active Connections time series (reading/writing/waiting)
- Rejected Connections

### Plugin Metrics
- Plugin Request Count (stacked)
- Plugin Error Rate

### Resource Usage
- CPU Usage time series
- Memory Usage time series

## Dashboard Variables
- `namespace` – Kubernetes namespace filter
- `service` – Kong service filter
- `deployment_environment` – Environment filter
- `cluster` – K8s cluster name filter

## Technical Details
- Uses PromQL query format
- Follows existing SigNoz dashboard structure (v4)
- Tags: kong, api-gateway, otel

Closes #6028