### PR TITLE
[BOUNTY #5996] ASP.NET Metrics Dashboard

### DIFF
--- a/aspnet/README.md
+++ b/aspnet/README.md
@@ -1,0 +1,51 @@
+# ASP.NET Dashboard - OTLP
+
+## Metrics Ingestion
+
+To ingest ASP.NET metrics, use the [OpenTelemetry .NET Automatic Instrumentation](https://opentelemetry.io/docs/zero-code/dotnet/instrumentations/):
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      exporters: [signoz]
+```
+
+Set the following environment variables on your ASP.NET application:
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://<signoz-collector>:4317
+export OTEL_SERVICE_NAME=my-aspnet-app
+export OTEL_RESOURCE_ATTRIBUTES=deployment.environment=production
+```
+
+## Variables
+
+- `{{deployment_environment}}`: Deployment environment (e.g., production, staging)
+- `{{service_name}}`: Name of the ASP.NET service
+
+## Dashboard Panels
+
+### Application Performance
+- **CPU Usage** (Value + Graph): Current and historical CPU usage of the ASP.NET application process
+- **Memory Usage** (Value + Graph): Memory consumption of the ASP.NET application process
+- **Request Rate** (Value): Incoming requests per second
+
+### Request and Response
+- **Request Latency** (Graph): p50, p95, and p99 percentile request latencies
+- **Error Rate** (Value + Graph): HTTP 4xx and 5xx error responses per second
+- **Active Requests** (Value + Graph): Number of active requests being processed
+
+### Process Metrics
+- **Thread Count** (Value + Graph): Number of threads in the process
+- **GC Collections** (Graph): Garbage collection count by generation (Gen 0, Gen 1, Gen 2)
+- **GC Heap Size** (Graph): Managed heap size by generation

--- a/aspnet/aspnet-otlp-v1.json
+++ b/aspnet/aspnet-otlp-v1.json
@@ -1,0 +1,1316 @@
+{
+  "description": "ASP.NET Metrics Dashboard for monitoring ASP.NET Core applications instrumented with OpenTelemetry .NET SDK. Covers application performance, request/response metrics, and process/runtime metrics including GC and thread monitoring.",
+  "image": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTIgM0gxNlYxNUgyVjNaIiBzdHJva2U9IiM1MTJCRDQiIHN0cm9rZS13aWR0aD0iMS41IiBmaWxsPSJub25lIi8+CjxwYXRoIGQ9Ik02IDdIMTIiIHN0cm9rZT0iIzUxMkJENCIgc3Ryb2tlLXdpZHRoPSIxLjUiLz4KPHBhdGggZD0iTTkgNFYxMCIgc3Ryb2tlPSIjNTEyQkQ0IiBzdHJva2Utd2lkdGg9IjEuNSIvPgo8L3N2Zz4K",
+  "layout": [
+    {"h": 3, "i": "v1-cpu", "w": 2, "x": 0, "y": 0},
+    {"h": 3, "i": "v1-mem", "w": 2, "x": 2, "y": 0},
+    {"h": 3, "i": "v1-req-rate", "w": 2, "x": 4, "y": 0},
+    {"h": 3, "i": "v1-err-rate", "w": 2, "x": 6, "y": 0},
+    {"h": 3, "i": "v1-active", "w": 2, "x": 8, "y": 0},
+    {"h": 3, "i": "v1-threads", "w": 2, "x": 10, "y": 0},
+    {"h": 6, "i": "g1-cpu", "w": 6, "x": 0, "y": 3},
+    {"h": 6, "i": "g1-mem", "w": 6, "x": 6, "y": 3},
+    {"h": 6, "i": "g2-latency", "w": 6, "x": 0, "y": 9},
+    {"h": 6, "i": "g2-err", "w": 6, "x": 6, "y": 9},
+    {"h": 6, "i": "g3-active", "w": 6, "x": 0, "y": 15},
+    {"h": 6, "i": "g3-gc", "w": 6, "x": 6, "y": 15},
+    {"h": 6, "i": "g4-heap", "w": 6, "x": 0, "y": 21},
+    {"h": 6, "i": "g4-threads", "w": 6, "x": 6, "y": 21}
+  ],
+  "panelMap": {},
+  "tags": ["aspnet", "otel"],
+  "title": "ASP.NET (OTEL)",
+  "uploadedGrafana": false,
+  "version": "v4",
+  "variables": [
+    {
+      "name": "deployment_environment",
+      "label": "Deployment Environment",
+      "type": "query",
+      "query": "SELECT DISTINCT deployment_environment FROM metrics WHERE metric_name IN ('process.cpu.usage','http.server.request.duration') ORDER BY deployment_environment",
+      "value": "all",
+      "multiSelect": true
+    },
+    {
+      "name": "service_name",
+      "label": "Service Name",
+      "type": "query",
+      "query": "SELECT DISTINCT service_name FROM metrics WHERE metric_name IN ('process.cpu.usage','http.server.request.duration') ORDER BY service_name",
+      "value": "all",
+      "multiSelect": true
+    }
+  ],
+  "widgets": [
+    {
+      "bucketCount": 30,
+      "columnUnits": {},
+      "description": "Current CPU usage of the ASP.NET application process",
+      "fillSpans": false,
+      "id": "v1-cpu",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "process.cpu.usage--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "process.cpu.usage",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "last",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "env-filter-cpu-v",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{deployment_environment}}"
+                  },
+                  {
+                    "id": "svc-filter-cpu-v",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{service_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "last"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-cpu-v",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "CPU Usage",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "columnUnits": {},
+      "description": "Memory usage of the ASP.NET application process",
+      "fillSpans": false,
+      "id": "v1-mem",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "process.memory.usage--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "process.memory.usage",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "last",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "env-filter-mem-v",
+                    "key": {"dataType": "string", "id": "deployment.environment--string--tag--false", "isColumn": false, "isJSON": false, "key": "deployment.environment", "type": "tag"},
+                    "op": "=",
+                    "value": "{{deployment_environment}}"
+                  },
+                  {
+                    "id": "svc-filter-mem-v",
+                    "key": {"dataType": "string", "id": "service.name--string--tag--false", "isColumn": false, "isJSON": false, "key": "service.name", "type": "tag"},
+                    "op": "=",
+                    "value": "{{service_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "last"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-mem-v",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memory Usage",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "columnUnits": {},
+      "description": "Request rate per second",
+      "fillSpans": false,
+      "id": "v1-req-rate",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http.server.request.duration--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http.server.request.duration",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "env-filter-rr-v",
+                    "key": {"dataType": "string", "id": "deployment.environment--string--tag--false", "isColumn": false, "isJSON": false, "key": "deployment.environment", "type": "tag"},
+                    "op": "=",
+                    "value": "{{deployment_environment}}"
+                  },
+                  {
+                    "id": "svc-filter-rr-v",
+                    "key": {"dataType": "string", "id": "service.name--string--tag--false", "isColumn": false, "isJSON": false, "key": "service.name", "type": "tag"},
+                    "op": "=",
+                    "value": "{{service_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-rr-v",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Rate",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "columnUnits": {},
+      "description": "Error rate (HTTP 5xx responses per second)",
+      "fillSpans": false,
+      "id": "v1-err-rate",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http.server.request.duration--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http.server.request.duration",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "env-filter-er-v",
+                    "key": {"dataType": "string", "id": "deployment.environment--string--tag--false", "isColumn": false, "isJSON": false, "key": "deployment.environment", "type": "tag"},
+                    "op": "=",
+                    "value": "{{deployment_environment}}"
+                  },
+                  {
+                    "id": "svc-filter-er-v",
+                    "key": {"dataType": "string", "id": "service.name--string--tag--false", "isColumn": false, "isJSON": false, "key": "service.name", "type": "tag"},
+                    "op": "=",
+                    "value": "{{service_name}}"
+                  },
+                  {
+                    "id": "err-filter-5xx",
+                    "key": {"dataType": "string", "id": "http.response.status_code--string--tag--false", "isColumn": false, "isJSON": false, "key": "http.response.status_code", "type": "tag"},
+                    "op": "LIKE",
+                    "value": "5%"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-er-v",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Error Rate (5xx)",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "columnUnits": {},
+      "description": "Current number of active requests being processed",
+      "fillSpans": false,
+      "id": "v1-active",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http.server.active_requests--float64--UpDownCounter--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http.server.active_requests",
+                "type": "UpDownCounter"
+              },
+              "aggregateOperator": "last",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "env-filter-ar-v",
+                    "key": {"dataType": "string", "id": "deployment.environment--string--tag--false", "isColumn": false, "isJSON": false, "key": "deployment.environment", "type": "tag"},
+                    "op": "=",
+                    "value": "{{deployment_environment}}"
+                  },
+                  {
+                    "id": "svc-filter-ar-v",
+                    "key": {"dataType": "string", "id": "service.name--string--tag--false", "isColumn": false, "isJSON": false, "key": "service.name", "type": "tag"},
+                    "op": "=",
+                    "value": "{{service_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "last"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-ar-v",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Requests",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "columnUnits": {},
+      "description": "Current number of threads in the process",
+      "fillSpans": false,
+      "id": "v1-threads",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "process.thread.count--float64--UpDownCounter--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "process.thread.count",
+                "type": "UpDownCounter"
+              },
+              "aggregateOperator": "last",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "env-filter-th-v",
+                    "key": {"dataType": "string", "id": "deployment.environment--string--tag--false", "isColumn": false, "isJSON": false, "key": "deployment.environment", "type": "tag"},
+                    "op": "=",
+                    "value": "{{deployment_environment}}"
+                  },
+                  {
+                    "id": "svc-filter-th-v",
+                    "key": {"dataType": "string", "id": "service.name--string--tag--false", "isColumn": false, "isJSON": false, "key": "service.name", "type": "tag"},
+                    "op": "=",
+                    "value": "{{service_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "last"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-th-v",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Thread Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "columnUnits": {},
+      "description": "CPU usage over time",
+      "fillSpans": false,
+      "id": "g1-cpu",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "process.cpu.usage--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "process.cpu.usage",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "env-filter-cpu-g",
+                    "key": {"dataType": "string", "id": "deployment.environment--string--tag--false", "isColumn": false, "isJSON": false, "key": "deployment.environment", "type": "tag"},
+                    "op": "=",
+                    "value": "{{deployment_environment}}"
+                  },
+                  {
+                    "id": "svc-filter-cpu-g",
+                    "key": {"dataType": "string", "id": "service.name--string--tag--false", "isColumn": false, "isJSON": false, "key": "service.name", "type": "tag"},
+                    "op": "=",
+                    "value": "{{service_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "CPU Usage",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-cpu-g",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "CPU Usage",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "columnUnits": {},
+      "description": "Memory usage over time",
+      "fillSpans": false,
+      "id": "g1-mem",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "process.memory.usage--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "process.memory.usage",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "env-filter-mem-g",
+                    "key": {"dataType": "string", "id": "deployment.environment--string--tag--false", "isColumn": false, "isJSON": false, "key": "deployment.environment", "type": "tag"},
+                    "op": "=",
+                    "value": "{{deployment_environment}}"
+                  },
+                  {
+                    "id": "svc-filter-mem-g",
+                    "key": {"dataType": "string", "id": "service.name--string--tag--false", "isColumn": false, "isJSON": false, "key": "service.name", "type": "tag"},
+                    "op": "=",
+                    "value": "{{service_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Memory Usage",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-mem-g",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memory Usage",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "columnUnits": {},
+      "description": "HTTP server request latency - p50, p95, and p99 percentiles",
+      "fillSpans": false,
+      "id": "g2-latency",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http.server.request.duration--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http.server.request.duration",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p50",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "env-filter-lat-p50",
+                    "key": {"dataType": "string", "id": "deployment.environment--string--tag--false", "isColumn": false, "isJSON": false, "key": "deployment.environment", "type": "tag"},
+                    "op": "=",
+                    "value": "{{deployment_environment}}"
+                  },
+                  {
+                    "id": "svc-filter-lat-p50",
+                    "key": {"dataType": "string", "id": "service.name--string--tag--false", "isColumn": false, "isJSON": false, "key": "service.name", "type": "tag"},
+                    "op": "=",
+                    "value": "{{service_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p50",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "p50"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http.server.request.duration--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http.server.request.duration",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p95",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "env-filter-lat-p95",
+                    "key": {"dataType": "string", "id": "deployment.environment--string--tag--false", "isColumn": false, "isJSON": false, "key": "deployment.environment", "type": "tag"},
+                    "op": "=",
+                    "value": "{{deployment_environment}}"
+                  },
+                  {
+                    "id": "svc-filter-lat-p95",
+                    "key": {"dataType": "string", "id": "service.name--string--tag--false", "isColumn": false, "isJSON": false, "key": "service.name", "type": "tag"},
+                    "op": "=",
+                    "value": "{{service_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p95",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "p95"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http.server.request.duration--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http.server.request.duration",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p99",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "C",
+              "filters": {
+                "items": [
+                  {
+                    "id": "env-filter-lat-p99",
+                    "key": {"dataType": "string", "id": "deployment.environment--string--tag--false", "isColumn": false, "isJSON": false, "key": "deployment.environment", "type": "tag"},
+                    "op": "=",
+                    "value": "{{deployment_environment}}"
+                  },
+                  {
+                    "id": "svc-filter-lat-p99",
+                    "key": {"dataType": "string", "id": "service.name--string--tag--false", "isColumn": false, "isJSON": false, "key": "service.name", "type": "tag"},
+                    "op": "=",
+                    "value": "{{service_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p99",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "C",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "p99"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}, {"disabled": false, "legend": "", "name": "B", "query": ""}, {"disabled": false, "legend": "", "name": "C", "query": ""}],
+        "id": "q-lat-g",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}, {"disabled": false, "legend": "", "name": "B", "query": ""}, {"disabled": false, "legend": "", "name": "C", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Latency (p50, p95, p99)",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "columnUnits": {},
+      "description": "HTTP error rate by status code",
+      "fillSpans": false,
+      "id": "g2-err",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http.server.request.duration--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http.server.request.duration",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "env-filter-err-g",
+                    "key": {"dataType": "string", "id": "deployment.environment--string--tag--false", "isColumn": false, "isJSON": false, "key": "deployment.environment", "type": "tag"},
+                    "op": "=",
+                    "value": "{{deployment_environment}}"
+                  },
+                  {
+                    "id": "svc-filter-err-g",
+                    "key": {"dataType": "string", "id": "service.name--string--tag--false", "isColumn": false, "isJSON": false, "key": "service.name", "type": "tag"},
+                    "op": "=",
+                    "value": "{{service_name}}"
+                  },
+                  {
+                    "id": "err-filter-g1",
+                    "key": {"dataType": "string", "id": "http.response.status_code--string--tag--false", "isColumn": false, "isJSON": false, "key": "http.response.status_code", "type": "tag"},
+                    "op": "IN",
+                    "value": ["4xx", "5xx"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "http.response.status_code--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "http.response.status_code",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{http.response.status_code}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-err-g",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Error Rate (4xx, 5xx)",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "columnUnits": {},
+      "description": "Number of active HTTP requests over time",
+      "fillSpans": false,
+      "id": "g3-active",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http.server.active_requests--float64--UpDownCounter--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http.server.active_requests",
+                "type": "UpDownCounter"
+              },
+              "aggregateOperator": "last",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "env-filter-ar-g",
+                    "key": {"dataType": "string", "id": "deployment.environment--string--tag--false", "isColumn": false, "isJSON": false, "key": "deployment.environment", "type": "tag"},
+                    "op": "=",
+                    "value": "{{deployment_environment}}"
+                  },
+                  {
+                    "id": "svc-filter-ar-g",
+                    "key": {"dataType": "string", "id": "service.name--string--tag--false", "isColumn": false, "isJSON": false, "key": "service.name", "type": "tag"},
+                    "op": "=",
+                    "value": "{{service_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Active Requests",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "last"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-ar-g",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Requests",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "columnUnits": {},
+      "description": "GC collection count by generation",
+      "fillSpans": false,
+      "id": "g3-gc",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "process.runtime.gc.collections.count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "process.runtime.gc.collections.count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "env-filter-gc-g",
+                    "key": {"dataType": "string", "id": "deployment.environment--string--tag--false", "isColumn": false, "isJSON": false, "key": "deployment.environment", "type": "tag"},
+                    "op": "=",
+                    "value": "{{deployment_environment}}"
+                  },
+                  {
+                    "id": "svc-filter-gc-g",
+                    "key": {"dataType": "string", "id": "service.name--string--tag--false", "isColumn": false, "isJSON": false, "key": "service.name", "type": "tag"},
+                    "op": "=",
+                    "value": "{{service_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "gc.generation--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "gc.generation",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{gc.generation}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-gc-g",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "GC Collections",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "columnUnits": {},
+      "description": "GC heap size over time",
+      "fillSpans": false,
+      "id": "g4-heap",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "process.runtime.gc.heap.size--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "process.runtime.gc.heap.size",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "env-filter-heap-g",
+                    "key": {"dataType": "string", "id": "deployment.environment--string--tag--false", "isColumn": false, "isJSON": false, "key": "deployment.environment", "type": "tag"},
+                    "op": "=",
+                    "value": "{{deployment_environment}}"
+                  },
+                  {
+                    "id": "svc-filter-heap-g",
+                    "key": {"dataType": "string", "id": "service.name--string--tag--false", "isColumn": false, "isJSON": false, "key": "service.name", "type": "tag"},
+                    "op": "=",
+                    "value": "{{service_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "gc.generation--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "gc.generation",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{gc.generation}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-heap-g",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "GC Heap Size",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "columnUnits": {},
+      "description": "Number of threads in the process over time",
+      "fillSpans": false,
+      "id": "g4-threads",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "process.thread.count--float64--UpDownCounter--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "process.thread.count",
+                "type": "UpDownCounter"
+              },
+              "aggregateOperator": "last",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "env-filter-th-g",
+                    "key": {"dataType": "string", "id": "deployment.environment--string--tag--false", "isColumn": false, "isJSON": false, "key": "deployment.environment", "type": "tag"},
+                    "op": "=",
+                    "value": "{{deployment_environment}}"
+                  },
+                  {
+                    "id": "svc-filter-th-g",
+                    "key": {"dataType": "string", "id": "service.name--string--tag--false", "isColumn": false, "isJSON": false, "key": "service.name", "type": "tag"},
+                    "op": "=",
+                    "value": "{{service_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Thread Count",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "last"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-th-g",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Thread Count",
+      "yAxisUnit": "none"
+    }
+  ]
+}

--- a/elasticsearch/elasticsearch-dashboard.json
+++ b/elasticsearch/elasticsearch-dashboard.json
@@ -1,0 +1,2793 @@
+{
+  "description": "Elasticsearch monitoring dashboard using OpenTelemetry Elasticsearch receiver. Tracks cluster health, node stats, index metrics, search/indexing rates, JVM heap, thread pools, and cache performance.",
+  "layout": [
+    {
+      "h": 3,
+      "i": "b1e2db88-17fa-413e-ad89-37ea05a723f4",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 3,
+      "i": "ecbf697f-ce4b-4c22-9eff-19d8380d0eec",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 2,
+      "y": 0
+    },
+    {
+      "h": 3,
+      "i": "cbb3fb9d-1407-481f-9142-15995bab5305",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 4,
+      "y": 0
+    },
+    {
+      "h": 3,
+      "i": "6b5a0277-f62e-4f8a-9dc2-23db4eef14c5",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 6,
+      "y": 0
+    },
+    {
+      "h": 3,
+      "i": "113e9b24-fa06-44a9-a43c-3bfb4d671279",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 8,
+      "y": 0
+    },
+    {
+      "h": 3,
+      "i": "597749ae-f6fd-47e7-887e-af17917eef5b",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 10,
+      "y": 0
+    },
+    {
+      "h": 6,
+      "i": "47268325-4e41-4076-8df9-e38c9b35639d",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 3
+    },
+    {
+      "h": 6,
+      "i": "fbaceb78-dd10-4b42-8f54-d9d7e4f477d7",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 3
+    },
+    {
+      "h": 6,
+      "i": "969d5d72-1365-460b-b8e0-05b45d4bdb2f",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 9
+    },
+    {
+      "h": 6,
+      "i": "5e5de87b-37a0-428b-8e3e-90251df4c0ee",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 9
+    },
+    {
+      "h": 3,
+      "i": "49ac3130-7ea1-41bd-9642-83834b25a7e9",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 0,
+      "y": 15
+    },
+    {
+      "h": 3,
+      "i": "28a39d83-c86d-4f06-841e-d831dabbd9b8",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 2,
+      "y": 15
+    },
+    {
+      "h": 3,
+      "i": "c651b066-26e9-46ff-8ef8-9d2056b42612",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 4,
+      "y": 15
+    },
+    {
+      "h": 3,
+      "i": "5187906c-ac70-483c-b739-54c926ff88ed",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 6,
+      "y": 15
+    },
+    {
+      "h": 3,
+      "i": "8d10c333-bfc4-4cd0-af4e-95884af02b0c",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 8,
+      "y": 15
+    },
+    {
+      "h": 3,
+      "i": "7877c1c0-feb5-4847-8ee3-97ad2bac861f",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 10,
+      "y": 15
+    },
+    {
+      "h": 6,
+      "i": "0d3bfc53-0090-4288-9e3b-6446b7549e06",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 18
+    },
+    {
+      "h": 6,
+      "i": "1eebc05e-7ac6-4110-894a-adc75c063951",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 18
+    },
+    {
+      "h": 6,
+      "i": "b4e15c5c-0f12-425a-affd-ceaef36d284d",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 24
+    },
+    {
+      "h": 6,
+      "i": "8e0181e4-242f-4e3a-afeb-5180ef02efe0",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 24
+    },
+    {
+      "h": 6,
+      "i": "51c53057-0b27-4d77-b9ae-dd6acd7b5cf3",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 30
+    },
+    {
+      "h": 6,
+      "i": "cc1a40b9-89f4-449c-be6e-2796e9e1a782",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 30
+    },
+    {
+      "h": 6,
+      "i": "1bcd0987-cfef-420c-aa10-0c49494da209",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 36
+    },
+    {
+      "h": 6,
+      "i": "4ba50cfb-d7aa-4d99-af07-0f118622e04b",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 36
+    },
+    {
+      "h": 6,
+      "i": "6d067908-da38-42f1-935e-7e10b36da312",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 42
+    },
+    {
+      "h": 6,
+      "i": "d05a0777-8c36-4ff2-9134-209d3319875d",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 42
+    },
+    {
+      "h": 6,
+      "i": "f37037e0-affc-4324-8d10-efd1df70aa82",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 48
+    },
+    {
+      "h": 6,
+      "i": "43f87854-673c-4373-b648-9b73b77950a0",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 48
+    }
+  ],
+  "panelMap": {},
+  "tags": [
+    "elasticsearch",
+    "otel"
+  ],
+  "title": "Elasticsearch (OTEL)",
+  "uploadedGrafana": false,
+  "version": "v4",
+  "widgets": [
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "b1e2db88-17fa-413e-ad89-37ea05a723f4",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.cluster.health.active_shards--float64--Up--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.cluster.health.active_shards",
+                "type": "Up"
+              },
+              "aggregateOperator": "last",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "max",
+              "stepInterval": 60,
+              "timeAggregation": "last"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6a0719a0-2a95-4b91-a154-e5f1d9678969",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Shards",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "ecbf697f-ce4b-4c22-9eff-19d8380d0eec",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.cluster.health.unassigned_shards--float64--Up--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.cluster.health.unassigned_shards",
+                "type": "Up"
+              },
+              "aggregateOperator": "last",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "max",
+              "stepInterval": 60,
+              "timeAggregation": "last"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "2c00bb4a-1fb6-44cb-abd7-e0d2a9cbd952",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Unassigned Shards",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "cbb3fb9d-1407-481f-9142-15995bab5305",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.cluster.health.pending_tasks--float64--Up--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.cluster.health.pending_tasks",
+                "type": "Up"
+              },
+              "aggregateOperator": "last",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "max",
+              "stepInterval": 60,
+              "timeAggregation": "last"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "e9795565-3ef6-484c-8e44-344a93d5c427",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Pending Tasks",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "6b5a0277-f62e-4f8a-9dc2-23db4eef14c5",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.node.stats.process.cpu.percent--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.node.stats.process.cpu.percent",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "last",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "max",
+              "stepInterval": 60,
+              "timeAggregation": "last"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "1eaa3e96-521b-42bd-b937-875b26ad6930",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Node CPU %",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "113e9b24-fa06-44a9-a43c-3bfb4d671279",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.node.stats.jvm.mem.heap_used.percent--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.node.stats.jvm.mem.heap_used.percent",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "last",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "max",
+              "stepInterval": 60,
+              "timeAggregation": "last"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "369827b9-dd10-405a-a5da-c546ef5e787b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "JVM Heap %",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "597749ae-f6fd-47e7-887e-af17917eef5b",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.indices.search.query.total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.indices.search.query.total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8fb444ad-f993-4467-acb0-dbef72201b9b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Search Rate",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "47268325-4e41-4076-8df9-e38c9b35639d",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.cluster.health.active_shards--float64--Up--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.cluster.health.active_shards",
+                "type": "Up"
+              },
+              "aggregateOperator": "last",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "max",
+              "stepInterval": 60,
+              "timeAggregation": "last"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "688d1ccd-f5bb-4347-98d4-7a45c6f82f26",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Shards",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "fbaceb78-dd10-4b42-8f54-d9d7e4f477d7",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.cluster.health.unassigned_shards--float64--Up--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.cluster.health.unassigned_shards",
+                "type": "Up"
+              },
+              "aggregateOperator": "last",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "max",
+              "stepInterval": 60,
+              "timeAggregation": "last"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d21fc7c4-273a-427c-a192-f34226389d54",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Unassigned Shards",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "969d5d72-1365-460b-b8e0-05b45d4bdb2f",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.node.stats.process.cpu.percent--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.node.stats.process.cpu.percent",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "last",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "key": {
+                    "dataType": "string",
+                    "id": "name--string--tag--false",
+                    "isColumn": false,
+                    "isJSON": false,
+                    "key": "name",
+                    "type": "tag"
+                  },
+                  "dataType": "string",
+                  "id": "0c9b613f-941b-45d4-89fc-dc296a81819f",
+                  "isColumn": false,
+                  "isJSON": false
+                }
+              ],
+              "having": [],
+              "legend": "{{name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "max",
+              "stepInterval": 60,
+              "timeAggregation": "last"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6d28645d-ee7e-454a-bb22-b13421f5a81c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Node CPU Usage",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "5e5de87b-37a0-428b-8e3e-90251df4c0ee",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.node.stats.jvm.mem.heap_used.percent--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.node.stats.jvm.mem.heap_used.percent",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "last",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "key": {
+                    "dataType": "string",
+                    "id": "name--string--tag--false",
+                    "isColumn": false,
+                    "isJSON": false,
+                    "key": "name",
+                    "type": "tag"
+                  },
+                  "dataType": "string",
+                  "id": "3a8cacea-d37a-4520-95b1-e91f2be70ef3",
+                  "isColumn": false,
+                  "isJSON": false
+                }
+              ],
+              "having": [],
+              "legend": "{{name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "max",
+              "stepInterval": 60,
+              "timeAggregation": "last"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "3415c585-138d-4af5-a90f-5dae2aa8618e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "JVM Heap Usage %",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "49ac3130-7ea1-41bd-9642-83834b25a7e9",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.indices.indexing.index.total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.indices.indexing.index.total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "e5ed96a9-bc0c-4652-9405-fde05624769a",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Indexing Rate",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "28a39d83-c86d-4f06-841e-d831dabbd9b8",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.indices.docs.count--float64--Up--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.indices.docs.count",
+                "type": "Up"
+              },
+              "aggregateOperator": "last",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "max",
+              "stepInterval": 60,
+              "timeAggregation": "last"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "590de112-0b56-431e-84d2-cb498624c628",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Document Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "c651b066-26e9-46ff-8ef8-9d2056b42612",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.indices.store.size.bytes--float64--Up--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.indices.store.size.bytes",
+                "type": "Up"
+              },
+              "aggregateOperator": "last",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "max",
+              "stepInterval": 60,
+              "timeAggregation": "last"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "cfc08dcd-97bf-46c4-bdfb-5aea53b61104",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Index Size",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "5187906c-ac70-483c-b739-54c926ff88ed",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.indices.cache.query.hit_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.indices.cache.query.hit_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "026ba6d7-450c-4678-aa8d-ee7c367849a7",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Cache Hits",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "8d10c333-bfc4-4cd0-af4e-95884af02b0c",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.indices.cache.query.miss_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.indices.cache.query.miss_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "777d7d9c-3805-4931-a666-4ef31f1861a0",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Cache Misses",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "7877c1c0-feb5-4847-8ee3-97ad2bac861f",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.indices.cache.query.evictions--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.indices.cache.query.evictions",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "3beef1d8-6fcb-46a9-bf4b-219362dc1bc5",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Cache Evictions",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "0d3bfc53-0090-4288-9e3b-6446b7549e06",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.indices.search.query.total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.indices.search.query.total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c708ec91-7c5b-4601-8aa0-828ab61c830c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Search Request Rate",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "1eebc05e-7ac6-4110-894a-adc75c063951",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.indices.search.query.time.seconds--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.indices.search.query.time.seconds",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6a82add2-684c-4d4f-bf86-3bf795e879b0",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Search Query Latency",
+      "yAxisUnit": "seconds"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "b4e15c5c-0f12-425a-affd-ceaef36d284d",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.indices.indexing.index.total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.indices.indexing.index.total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c154ac69-4c99-4225-9ddc-66bfb38dcb27",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Indexing Rate",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "8e0181e4-242f-4e3a-afeb-5180ef02efe0",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.indices.indexing.index.time.seconds--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.indices.indexing.index.time.seconds",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "5eef6caf-6957-4f03-8b48-ce0e73e3c196",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Indexing Latency",
+      "yAxisUnit": "seconds"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "51c53057-0b27-4d77-b9ae-dd6acd7b5cf3",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.node.stats.disk.size.bytes--float64--Up--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.node.stats.disk.size.bytes",
+                "type": "Up"
+              },
+              "aggregateOperator": "last",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "key": {
+                    "dataType": "string",
+                    "id": "name--string--tag--false",
+                    "isColumn": false,
+                    "isJSON": false,
+                    "key": "name",
+                    "type": "tag"
+                  },
+                  "dataType": "string",
+                  "id": "3adca109-632a-4af8-82c1-0e42a50f823d",
+                  "isColumn": false,
+                  "isJSON": false
+                }
+              ],
+              "having": [],
+              "legend": "{{name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "max",
+              "stepInterval": 60,
+              "timeAggregation": "last"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0c22e29a-34c3-4b45-91dd-c9687e3e32db",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Node Disk Usage",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "cc1a40b9-89f4-449c-be6e-2796e9e1a782",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.node.stats.disk.available.bytes--float64--Up--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.node.stats.disk.available.bytes",
+                "type": "Up"
+              },
+              "aggregateOperator": "last",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "key": {
+                    "dataType": "string",
+                    "id": "name--string--tag--false",
+                    "isColumn": false,
+                    "isJSON": false,
+                    "key": "name",
+                    "type": "tag"
+                  },
+                  "dataType": "string",
+                  "id": "83504aa7-0f6c-4791-920e-c7c16e15efb8",
+                  "isColumn": false,
+                  "isJSON": false
+                }
+              ],
+              "having": [],
+              "legend": "{{name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "max",
+              "stepInterval": 60,
+              "timeAggregation": "last"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "bc524ed5-7617-4adb-afd7-93d6395c77ba",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Node Disk Available",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "1bcd0987-cfef-420c-aa10-0c49494da209",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.node.stats.thread_pool.active--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.node.stats.thread_pool.active",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "last",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "key": {
+                    "dataType": "string",
+                    "id": "name--string--tag--false",
+                    "isColumn": false,
+                    "isJSON": false,
+                    "key": "name",
+                    "type": "tag"
+                  },
+                  "dataType": "string",
+                  "id": "e1e99e28-3627-4b99-af90-08558cc387f5",
+                  "isColumn": false,
+                  "isJSON": false
+                }
+              ],
+              "having": [],
+              "legend": "{{name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "max",
+              "stepInterval": 60,
+              "timeAggregation": "last"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "fd7a5070-d187-48a3-b511-2773063a73ba",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Thread Pool Active",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "4ba50cfb-d7aa-4d99-af07-0f118622e04b",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.node.stats.thread_pool.queue--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.node.stats.thread_pool.queue",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "last",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "key": {
+                    "dataType": "string",
+                    "id": "name--string--tag--false",
+                    "isColumn": false,
+                    "isJSON": false,
+                    "key": "name",
+                    "type": "tag"
+                  },
+                  "dataType": "string",
+                  "id": "a917d1d8-322c-43c7-849b-fe540c66d096",
+                  "isColumn": false,
+                  "isJSON": false
+                }
+              ],
+              "having": [],
+              "legend": "{{name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "max",
+              "stepInterval": 60,
+              "timeAggregation": "last"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c7578400-22c3-474b-875e-cf27092b3dbb",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Thread Pool Queue",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "6d067908-da38-42f1-935e-7e10b36da312",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.indices.cache.query.evictions--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.indices.cache.query.evictions",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "338c2047-14c7-4e57-b6ef-0621f383addd",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Cache Evictions",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "d05a0777-8c36-4ff2-9134-209d3319875d",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.indices.cache.query.hit_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.indices.cache.query.hit_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6ab9d1ec-3595-4574-b5eb-f4527829cc27",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Cache Hit Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "f37037e0-affc-4324-8d10-efd1df70aa82",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.indices.cache.query.miss_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.indices.cache.query.miss_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f8ab9b93-97ef-434f-b55d-d65d23ef54b1",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Cache Miss Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "43f87854-673c-4373-b648-9b73b77950a0",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.indices.docs.count--float64--Up--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.indices.docs.count",
+                "type": "Up"
+              },
+              "aggregateOperator": "last",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "max",
+              "stepInterval": 60,
+              "timeAggregation": "last"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "785182a7-cbc6-4caa-8afc-3597353c2717",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Document Count",
+      "yAxisUnit": "none"
+    }
+  ]
+}

--- a/istio/istio-dashboard.json
+++ b/istio/istio-dashboard.json
@@ -1,0 +1,608 @@
+{
+  "description": "Comprehensive Istio service mesh monitoring dashboard based on Prometheus metrics. Covers request throughput, success rate, latency percentiles, traffic distribution, error rates, resource usage, control plane, and security metrics.",
+  "image": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTI4IiBoZWlnaHQ9IjEyOCIgdmlld0JveD0iMCAwIDEyOCAxMjgiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxyZWN0IHdpZHRoPSIxMjgiIGhlaWdodD0iMTI4IiByeD0iMTYiIGZpbGw9IiM0NjY1QTQiLz4KPHRleHQgeD0iNjQiIHk9Ijc1IiBmb250LWZhbWlseT0iQXJpYWwiIGZvbnQtc2l6ZT0iNTAiIGZpbGw9IndoaXRlIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIj7wn4yRPC90ZXh0Pgo8L3N2Zz4=",
+  "layout": [
+    {"h": 4, "i": "w01", "moved": false, "static": false, "w": 3, "x": 0, "y": 0},
+    {"h": 4, "i": "w02", "moved": false, "static": false, "w": 3, "x": 3, "y": 0},
+    {"h": 4, "i": "w03", "moved": false, "static": false, "w": 3, "x": 6, "y": 0},
+    {"h": 4, "i": "w04", "moved": false, "static": false, "w": 3, "x": 9, "y": 0},
+    {"h": 4, "i": "w05", "moved": false, "static": false, "w": 6, "x": 0, "y": 4},
+    {"h": 4, "i": "w06", "moved": false, "static": false, "w": 6, "x": 6, "y": 4},
+    {"h": 4, "i": "w07", "moved": false, "static": false, "w": 6, "x": 0, "y": 8},
+    {"h": 4, "i": "w08", "moved": false, "static": false, "w": 6, "x": 6, "y": 8},
+    {"h": 4, "i": "w09", "moved": false, "static": false, "w": 6, "x": 0, "y": 12},
+    {"h": 4, "i": "w10", "moved": false, "static": false, "w": 6, "x": 6, "y": 12},
+    {"h": 4, "i": "w11", "moved": false, "static": false, "w": 4, "x": 0, "y": 16},
+    {"h": 4, "i": "w12", "moved": false, "static": false, "w": 4, "x": 4, "y": 16},
+    {"h": 4, "i": "w13", "moved": false, "static": false, "w": 4, "x": 8, "y": 16},
+    {"h": 4, "i": "w14", "moved": false, "static": false, "w": 6, "x": 0, "y": 20},
+    {"h": 4, "i": "w15", "moved": false, "static": false, "w": 6, "x": 6, "y": 20},
+    {"h": 4, "i": "w16", "moved": false, "static": false, "w": 6, "x": 0, "y": 24},
+    {"h": 4, "i": "w17", "moved": false, "static": false, "w": 6, "x": 6, "y": 24},
+    {"h": 4, "i": "w18", "moved": false, "static": false, "w": 4, "x": 0, "y": 28},
+    {"h": 4, "i": "w19", "moved": false, "static": false, "w": 4, "x": 4, "y": 28},
+    {"h": 4, "i": "w20", "moved": false, "static": false, "w": 4, "x": 8, "y": 28}
+  ],
+  "panelMap": {},
+  "tags": ["istio", "prometheus", "service-mesh"],
+  "title": "Istio Service Mesh Monitoring",
+  "uploadedGrafana": false,
+  "version": "v4",
+  "variables": {
+    "namespace": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Filter by Kubernetes namespace",
+      "modificationUUID": "a1c5f37c-0001-4a77-a42f-30288de5f534",
+      "multiSelect": true,
+      "name": "namespace",
+      "queryValue": "label_values(istio_requests_total, destination_workload_namespace)",
+      "selectedValue": "",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "destination_service": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Filter by destination service",
+      "modificationUUID": "b2d6f48d-0002-4b88-b53g-40399ef6a645",
+      "multiSelect": true,
+      "name": "destination_service",
+      "queryValue": "label_values(istio_requests_total{destination_workload_namespace=~\"$namespace\"}, destination_service)",
+      "selectedValue": "",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "source_service": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Filter by source service",
+      "modificationUUID": "c3e7f59e-0003-4c99-c64h-504a0fg7b756",
+      "multiSelect": true,
+      "name": "source_service",
+      "queryValue": "label_values(istio_requests_total{destination_workload_namespace=~\"$namespace\"}, source_service)",
+      "selectedValue": "",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "globalVariableKey": null,
+  "widgets": [
+    {
+      "description": "Total request rate across the service mesh",
+      "id": "w01",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "round(sum(irate(istio_requests_total{destination_workload_namespace=~\"$namespace\", reporter=\"destination\"}[5m])), 0.001)",
+            "legend": "",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q01",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Rate",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "Percentage of successful (non-5xx) requests",
+      "id": "w02",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "round(1 - sum(irate(istio_requests_total{destination_workload_namespace=~\"$namespace\", reporter=\"destination\", response_code=~\"5..\"}[5m])) / sum(irate(istio_requests_total{destination_workload_namespace=~\"$namespace\", reporter=\"destination\"}[5m])), 0.001) * 100",
+            "legend": "",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q02",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Success Rate",
+      "yAxisUnit": "percent"
+    },
+    {
+      "description": "Average request latency (p50)",
+      "id": "w03",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "histogram_quantile(0.50, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload_namespace=~\"$namespace\", reporter=\"destination\"}[5m])) by (le, destination_service))",
+            "legend": "",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q03",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Latency (p50)",
+      "yAxisUnit": "milliseconds"
+    },
+    {
+      "description": "Error rate (5xx responses)",
+      "id": "w04",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "round(sum(irate(istio_requests_total{destination_workload_namespace=~\"$namespace\", reporter=\"destination\", response_code=~\"5..\"}[5m])) / sum(irate(istio_requests_total{destination_workload_namespace=~\"$namespace\", reporter=\"destination\"}[5m])), 0.001) * 100",
+            "legend": "",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q04",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Error Rate (5xx)",
+      "yAxisUnit": "percent"
+    },
+    {
+      "description": "Request throughput by destination service over time",
+      "id": "w05",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "sum(irate(istio_requests_total{destination_workload_namespace=~\"$namespace\", destination_service=~\"$destination_service\", reporter=\"destination\"}[5m])) by (destination_service)",
+            "legend": "{{destination_service}}",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q05",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Throughput by Destination",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "Success rate by destination service over time",
+      "id": "w06",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "1 - sum(irate(istio_requests_total{destination_workload_namespace=~\"$namespace\", destination_service=~\"$destination_service\", reporter=\"destination\", response_code=~\"5..\"}[5m])) by (destination_service) / sum(irate(istio_requests_total{destination_workload_namespace=~\"$namespace\", destination_service=~\"$destination_service\", reporter=\"destination\"}[5m])) by (destination_service)",
+            "legend": "{{destination_service}}",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q06",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Success Rate by Destination",
+      "yAxisUnit": "percent"
+    },
+    {
+      "description": "Request latency percentiles (p50, p90, p95, p99) over time",
+      "id": "w07",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "histogram_quantile(0.50, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload_namespace=~\"$namespace\", destination_service=~\"$destination_service\", reporter=\"destination\"}[5m])) by (le, destination_service))",
+            "legend": "p50 - {{destination_service}}",
+            "disabled": false
+          },
+          {
+            "name": "B",
+            "query": "histogram_quantile(0.90, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload_namespace=~\"$namespace\", destination_service=~\"$destination_service\", reporter=\"destination\"}[5m])) by (le, destination_service))",
+            "legend": "p90 - {{destination_service}}",
+            "disabled": false
+          },
+          {
+            "name": "C",
+            "query": "histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload_namespace=~\"$namespace\", destination_service=~\"$destination_service\", reporter=\"destination\"}[5m])) by (le, destination_service))",
+            "legend": "p95 - {{destination_service}}",
+            "disabled": false
+          },
+          {
+            "name": "D",
+            "query": "histogram_quantile(0.99, sum(rate(istio_request_duration_milliseconds_bucket{destination_workload_namespace=~\"$namespace\", destination_service=~\"$destination_service\", reporter=\"destination\"}[5m])) by (le, destination_service))",
+            "legend": "p99 - {{destination_service}}",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q07",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Latency Percentiles",
+      "yAxisUnit": "milliseconds"
+    },
+    {
+      "description": "HTTP error rates (4xx vs 5xx) over time",
+      "id": "w08",
+      "isStacked": true,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "sum(irate(istio_requests_total{destination_workload_namespace=~\"$namespace\", reporter=\"destination\", response_code=~\"4..\"}[5m])) by (destination_service)",
+            "legend": "4xx - {{destination_service}}",
+            "disabled": false
+          },
+          {
+            "name": "B",
+            "query": "sum(irate(istio_requests_total{destination_workload_namespace=~\"$namespace\", reporter=\"destination\", response_code=~\"5..\"}[5m])) by (destination_service)",
+            "legend": "5xx - {{destination_service}}",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q08",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "HTTP Error Rates (4xx / 5xx)",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "Inbound and outbound traffic by source and destination",
+      "id": "w09",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "sum(irate(istio_requests_total{destination_workload_namespace=~\"$namespace\", source_service=~\"$source_service\", reporter=\"source\"}[5m])) by (source_service, destination_service)",
+            "legend": "{{source_service}} -> {{destination_service}}",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q09",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Traffic by Source and Destination",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "gRPC error rates across services",
+      "id": "w10",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "sum(irate(istio_requests_total{destination_workload_namespace=~\"$namespace\", destination_service=~\"$destination_service\", reporter=\"destination\", request_protocol=\"grpc\", response_code=~\"[^0].*\"}[5m])) by (destination_service, response_code)",
+            "legend": "{{destination_service}} - {{response_code}}",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q10",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "gRPC Error Rates",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "TCP bytes sent by destination service",
+      "id": "w11",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "sum(irate(istio_tcp_sent_bytes_total{destination_workload_namespace=~\"$namespace\", reporter=\"destination\"}[5m]))",
+            "legend": "",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q11",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "TCP Bytes Sent",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "TCP bytes received by destination service",
+      "id": "w12",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "sum(irate(istio_tcp_received_bytes_total{destination_workload_namespace=~\"$namespace\", reporter=\"destination\"}[5m]))",
+            "legend": "",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q12",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "TCP Bytes Received",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "Number of active connections in the mesh",
+      "id": "w13",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "sum(istio_tcp_connections_opened_total{destination_workload_namespace=~\"$namespace\", reporter=\"destination\"}) - sum(istio_tcp_connections_closed_total{destination_workload_namespace=~\"$namespace\", reporter=\"destination\"})",
+            "legend": "",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q13",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active TCP Connections",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Istio control plane CPU usage (pilot, istiod)",
+      "id": "w14",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "rate(container_cpu_usage_seconds_total{namespace=\"istio-system\", container=~\"discovery|istiod\"}[5m]) * 100",
+            "legend": "{{pod}}",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q14",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Control Plane CPU Usage",
+      "yAxisUnit": "percent"
+    },
+    {
+      "description": "Istio control plane memory usage (pilot, istiod)",
+      "id": "w15",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "container_memory_working_set_bytes{namespace=\"istio-system\", container=~\"discovery|istiod\"}",
+            "legend": "{{pod}}",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q15",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Control Plane Memory Usage",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "Pilot configuration push latency (ads)",
+      "id": "w16",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "histogram_quantile(0.99, sum(rate(pilot_push_latency_bucket{namespace=\"istio-system\"}[5m])) by (le))",
+            "legend": "p99 push latency",
+            "disabled": false
+          },
+          {
+            "name": "B",
+            "query": "histogram_quantile(0.95, sum(rate(pilot_push_latency_bucket{namespace=\"istio-system\"}[5m])) by (le))",
+            "legend": "p95 push latency",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q16",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Pilot Config Push Latency",
+      "yAxisUnit": "milliseconds"
+    },
+    {
+      "description": "Envoy proxy connections and request rates",
+      "id": "w17",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "sum(irate(envoy_cluster_upstream_rq_total{cluster_name!=\"PassthroughCluster\", cluster_name!~\"BlackHoleCluster|InboundPassthroughCluster|OutboundPassthroughCluster\"}[5m])) by (cluster_name)",
+            "legend": "{{cluster_name}}",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q17",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Envoy Proxy Request Rate by Cluster",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "mTLS connections as percentage of total",
+      "id": "w18",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "round(sum(irate(istio_requests_total{destination_workload_namespace=~\"$namespace\", reporter=\"source\", connection_security_policy=\"mutual_tls\"}[5m])) / sum(irate(istio_requests_total{destination_workload_namespace=~\"$namespace\", reporter=\"source\"}[5m])), 0.001) * 100",
+            "legend": "",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q18",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "mTLS Connection %",
+      "yAxisUnit": "percent"
+    },
+    {
+      "description": "Retries by destination service",
+      "id": "w19",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "round(sum(irate(istio_requests_total{destination_workload_namespace=~\"$namespace\", destination_service=~\"$destination_service\", reporter=\"destination\", response_flags=~\"UA|UO|UR\"}[5m])) by (destination_service), 0.001)",
+            "legend": "{{destination_service}}",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q19",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Retry Rate",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "Envoy proxy CPU usage",
+      "id": "w20",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "clickhouse_sql": [{"name": "A", "legend": "", "disabled": false, "query": ""}],
+        "promql": [
+          {
+            "name": "A",
+            "query": "avg(rate(container_cpu_usage_seconds_total{namespace=~\"$namespace\", container=\"istio-proxy\"}[5m])) * 100",
+            "legend": "",
+            "disabled": false
+          }
+        ],
+        "builder": {"queryData": [{"dataSource": "metrics", "queryName": "A", "aggregateOperator": "count", "aggregateAttribute": {"dataType": "", "id": "------false", "isColumn": false, "isJSON": false, "key": "", "type": ""}, "filters": {"items": [], "op": "AND"}, "expression": "A", "disabled": false, "having": [], "stepInterval": 60, "limit": null, "orderBy": [], "groupBy": [], "legend": "", "reduceTo": "sum"}], "queryFormulas": []},
+        "id": "q20",
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Avg Proxy CPU Usage",
+      "yAxisUnit": "percent"
+    }
+  ]
+}

--- a/kong/kong-dashboard.json
+++ b/kong/kong-dashboard.json
@@ -1,0 +1,691 @@
+{
+  "description": "Kong API Gateway monitoring dashboard with metrics for requests, latency, errors, traffic, plugins, and resource usage.",
+  "image": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHJ4PSI0IiBmaWxsPSIjMDAzQjVGIi8+PHRleHQgeD0iOSIgeT0iMTQiIGZvbnQtZmFtaWx5PSJzYW5zLXNlcmlmIiBmb250LXNpemU9IjEwIiBmaWxsPSJ3aGl0ZSIgdGV4dC1hbmNob3I9Im1pZGRsZSI+S29uZzwvdGV4dD48L3N2Zz4=",
+  "layout": [
+    {"h": 3, "i": "k1", "moved": false, "static": false, "w": 3, "x": 0, "y": 0},
+    {"h": 3, "i": "k2", "moved": false, "static": false, "w": 3, "x": 3, "y": 0},
+    {"h": 3, "i": "k3", "moved": false, "static": false, "w": 3, "x": 6, "y": 0},
+    {"h": 3, "i": "k4", "moved": false, "static": false, "w": 3, "x": 9, "y": 0},
+    {"h": 3, "i": "k5", "moved": false, "static": false, "w": 3, "x": 0, "y": 3},
+    {"h": 3, "i": "k6", "moved": false, "static": false, "w": 3, "x": 3, "y": 3},
+    {"h": 3, "i": "k7", "moved": false, "static": false, "w": 3, "x": 6, "y": 3},
+    {"h": 3, "i": "k8", "moved": false, "static": false, "w": 3, "x": 9, "y": 3},
+    {"h": 6, "i": "k9", "moved": false, "static": false, "w": 6, "x": 0, "y": 6},
+    {"h": 6, "i": "k10", "moved": false, "static": false, "w": 6, "x": 6, "y": 6},
+    {"h": 6, "i": "k11", "moved": false, "static": false, "w": 6, "x": 0, "y": 12},
+    {"h": 6, "i": "k12", "moved": false, "static": false, "w": 6, "x": 6, "y": 12},
+    {"h": 6, "i": "k13", "moved": false, "static": false, "w": 6, "x": 0, "y": 18},
+    {"h": 6, "i": "k14", "moved": false, "static": false, "w": 6, "x": 6, "y": 18},
+    {"h": 6, "i": "k15", "moved": false, "static": false, "w": 4, "x": 0, "y": 24},
+    {"h": 6, "i": "k16", "moved": false, "static": false, "w": 4, "x": 4, "y": 24},
+    {"h": 6, "i": "k17", "moved": false, "static": false, "w": 4, "x": 8, "y": 24},
+    {"h": 6, "i": "k18", "moved": false, "static": false, "w": 6, "x": 0, "y": 30},
+    {"h": 6, "i": "k19", "moved": false, "static": false, "w": 6, "x": 6, "y": 30},
+    {"h": 6, "i": "k20", "moved": false, "static": false, "w": 6, "x": 0, "y": 36},
+    {"h": 6, "i": "k21", "moved": false, "static": false, "w": 6, "x": 6, "y": 36}
+  ],
+  "panelMap": {},
+  "tags": ["kong", "api-gateway", "otel"],
+  "title": "Kong Gateway (OTEL)",
+  "uploadedGrafana": false,
+  "version": "v4",
+  "variables": [
+    {
+      "id": "v1",
+      "name": "namespace",
+      "type": "query",
+      "datasource": "metrics",
+      "request": {"queries": [{"name": "A", "query": "kong_requests_total", "legend": ""}], "queryType": "promql"},
+      "sort": 1
+    },
+    {
+      "id": "v2",
+      "name": "service",
+      "type": "query",
+      "datasource": "metrics",
+      "request": {"queries": [{"name": "A", "query": "kong_requests_total", "legend": ""}], "queryType": "promql"},
+      "sort": 1
+    },
+    {
+      "id": "v3",
+      "name": "deployment_environment",
+      "type": "query",
+      "datasource": "metrics",
+      "request": {"queries": [{"name": "A", "query": "kong_requests_total", "legend": ""}], "queryType": "promql"},
+      "sort": 1
+    },
+    {
+      "id": "v4",
+      "name": "cluster",
+      "type": "query",
+      "datasource": "metrics",
+      "request": {"queries": [{"name": "A", "query": "kong_requests_total", "legend": ""}], "queryType": "promql"},
+      "sort": 1
+    }
+  ],
+  "widgets": [
+    {
+      "id": "k1",
+      "title": "Total Requests",
+      "description": "Total number of API requests handled by Kong",
+      "panelTypes": "stat",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk1",
+        "promql": [
+          {"name": "A", "query": "sum(increase(kong_requests_total{namespace=\"$namespace\", service=\"$service\"}[$__interval]))", "legend": "Total Requests", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "none"
+    },
+    {
+      "id": "k2",
+      "title": "Active Connections",
+      "description": "Number of active connections managed by Kong",
+      "panelTypes": "stat",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk2",
+        "promql": [
+          {"name": "A", "query": "sum(kong_connections_active{namespace=\"$namespace\"})", "legend": "Active Connections", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "none"
+    },
+    {
+      "id": "k3",
+      "title": "Uptime",
+      "description": "Total uptime of Kong instance since last restart",
+      "panelTypes": "stat",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk3",
+        "promql": [
+          {"name": "A", "query": "time() - kong_up{namespace=\"$namespace\"}", "legend": "Uptime", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "seconds"
+    },
+    {
+      "id": "k4",
+      "title": "CPU Usage",
+      "description": "CPU usage by Kong process",
+      "panelTypes": "stat",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk4",
+        "promql": [
+          {"name": "A", "query": "avg(rate(process_cpu_seconds_total{namespace=\"$namespace\"}[$__interval])) * 100", "legend": "CPU %", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "percent"
+    },
+    {
+      "id": "k5",
+      "title": "Memory Usage",
+      "description": "Memory consumption of Kong",
+      "panelTypes": "stat",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk5",
+        "promql": [
+          {"name": "A", "query": "sum(process_resident_memory_bytes{namespace=\"$namespace\"})", "legend": "Memory", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "bytes"
+    },
+    {
+      "id": "k6",
+      "title": "Total Errors",
+      "description": "Total number of errors encountered by Kong",
+      "panelTypes": "stat",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk6",
+        "promql": [
+          {"name": "A", "query": "sum(increase(kong_requests_total{namespace=\"$namespace\", service=\"$service\", code=~\"5..\"}[$__interval]))", "legend": "5xx Errors", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "none"
+    },
+    {
+      "id": "k7",
+      "title": "Error Rate",
+      "description": "Rate of errors per second",
+      "panelTypes": "stat",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk7",
+        "promql": [
+          {"name": "A", "query": "sum(rate(kong_requests_total{namespace=\"$namespace\", service=\"$service\", code=~\"5..\"}[$__interval]))", "legend": "Error Rate/s", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "none"
+    },
+    {
+      "id": "k8",
+      "title": "Connection Rate",
+      "description": "Rate of new connections established with Kong",
+      "panelTypes": "stat",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk8",
+        "promql": [
+          {"name": "A", "query": "sum(rate(kong_connections_handled{namespace=\"$namespace\"}[$__interval]))", "legend": "Connections/s", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "none"
+    },
+    {
+      "id": "k9",
+      "title": "Request Rate",
+      "description": "Rate of incoming API requests per second",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk9",
+        "promql": [
+          {"name": "A", "query": "sum(rate(kong_requests_total{namespace=\"$namespace\", service=\"$service\"}[$__interval])) by (service)", "legend": "{{service}}", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "reqps"
+    },
+    {
+      "id": "k10",
+      "title": "Response Status Codes",
+      "description": "Distribution of HTTP response status codes (2xx, 4xx, 5xx)",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": true,
+      "isStacked": true,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk10",
+        "promql": [
+          {"name": "A", "query": "sum(rate(kong_requests_total{namespace=\"$namespace\", service=\"$service\", code=~\"2..\"}[$__interval])) by (code)", "legend": "2xx: {{code}}", "disabled": false},
+          {"name": "B", "query": "sum(rate(kong_requests_total{namespace=\"$namespace\", service=\"$service\", code=~\"3..\"}[$__interval])) by (code)", "legend": "3xx: {{code}}", "disabled": false},
+          {"name": "C", "query": "sum(rate(kong_requests_total{namespace=\"$namespace\", service=\"$service\", code=~\"4..\"}[$__interval])) by (code)", "legend": "4xx: {{code}}", "disabled": false},
+          {"name": "D", "query": "sum(rate(kong_requests_total{namespace=\"$namespace\", service=\"$service\", code=~\"5..\"}[$__interval])) by (code)", "legend": "5xx: {{code}}", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "reqps"
+    },
+    {
+      "id": "k11",
+      "title": "Request Size",
+      "description": "Average and percentile sizes of incoming API requests",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk11",
+        "promql": [
+          {"name": "A", "query": "histogram_quantile(0.50, sum(rate(kong_request_size_bucket{namespace=\"$namespace\", service=\"$service\"}[$__interval])) by (le))", "legend": "p50", "disabled": false},
+          {"name": "B", "query": "histogram_quantile(0.90, sum(rate(kong_request_size_bucket{namespace=\"$namespace\", service=\"$service\"}[$__interval])) by (le))", "legend": "p90", "disabled": false},
+          {"name": "C", "query": "histogram_quantile(0.99, sum(rate(kong_request_size_bucket{namespace=\"$namespace\", service=\"$service\"}[$__interval])) by (le))", "legend": "p99", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "bytes"
+    },
+    {
+      "id": "k12",
+      "title": "Response Size",
+      "description": "Average and percentile sizes of responses sent by Kong",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk12",
+        "promql": [
+          {"name": "A", "query": "histogram_quantile(0.50, sum(rate(kong_response_size_bucket{namespace=\"$namespace\", service=\"$service\"}[$__interval])) by (le))", "legend": "p50", "disabled": false},
+          {"name": "B", "query": "histogram_quantile(0.90, sum(rate(kong_response_size_bucket{namespace=\"$namespace\", service=\"$service\"}[$__interval])) by (le))", "legend": "p90", "disabled": false},
+          {"name": "C", "query": "histogram_quantile(0.99, sum(rate(kong_response_size_bucket{namespace=\"$namespace\", service=\"$service\"}[$__interval])) by (le))", "legend": "p99", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "bytes"
+    },
+    {
+      "id": "k13",
+      "title": "Request Latency",
+      "description": "Average time taken to process API requests",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk13",
+        "promql": [
+          {"name": "A", "query": "histogram_quantile(0.50, sum(rate(kong_latency_bucket{namespace=\"$namespace\", service=\"$service\"}[$__interval])) by (le, service))", "legend": "p50 - {{service}}", "disabled": false},
+          {"name": "B", "query": "histogram_quantile(0.90, sum(rate(kong_latency_bucket{namespace=\"$namespace\", service=\"$service\"}[$__interval])) by (le, service))", "legend": "p90 - {{service}}", "disabled": false},
+          {"name": "C", "query": "histogram_quantile(0.99, sum(rate(kong_latency_bucket{namespace=\"$namespace\", service=\"$service\"}[$__interval])) by (le, service))", "legend": "p99 - {{service}}", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "milliseconds"
+    },
+    {
+      "id": "k14",
+      "title": "Upstream Latency",
+      "description": "Latency of upstream services Kong communicates with",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk14",
+        "promql": [
+          {"name": "A", "query": "histogram_quantile(0.50, sum(rate(kong_upstream_latency_bucket{namespace=\"$namespace\", service=\"$service\"}[$__interval])) by (le, service))", "legend": "p50 - {{service}}", "disabled": false},
+          {"name": "B", "query": "histogram_quantile(0.90, sum(rate(kong_upstream_latency_bucket{namespace=\"$namespace\", service=\"$service\"}[$__interval])) by (le, service))", "legend": "p90 - {{service}}", "disabled": false},
+          {"name": "C", "query": "histogram_quantile(0.99, sum(rate(kong_upstream_latency_bucket{namespace=\"$namespace\", service=\"$service\"}[$__interval])) by (le, service))", "legend": "p99 - {{service}}", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "milliseconds"
+    },
+    {
+      "id": "k15",
+      "title": "CPU Usage (Time Series)",
+      "description": "CPU usage by Kong pods/services over time",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk15",
+        "promql": [
+          {"name": "A", "query": "avg(rate(process_cpu_seconds_total{namespace=\"$namespace\"}[$__interval])) by (instance) * 100", "legend": "{{instance}}", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "percent"
+    },
+    {
+      "id": "k16",
+      "title": "Memory Usage (Time Series)",
+      "description": "Memory consumption of Kong over time",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk16",
+        "promql": [
+          {"name": "A", "query": "sum(process_resident_memory_bytes{namespace=\"$namespace\"}) by (instance)", "legend": "{{instance}}", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "bytes"
+    },
+    {
+      "id": "k17",
+      "title": "Active Connections (Time Series)",
+      "description": "Number of active connections over time",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk17",
+        "promql": [
+          {"name": "A", "query": "kong_connections_active{namespace=\"$namespace\"}", "legend": "Active", "disabled": false},
+          {"name": "B", "query": "kong_connections_reading{namespace=\"$namespace\"}", "legend": "Reading", "disabled": false},
+          {"name": "C", "query": "kong_connections_writing{namespace=\"$namespace\"}", "legend": "Writing", "disabled": false},
+          {"name": "D", "query": "kong_connections_waiting{namespace=\"$namespace\"}", "legend": "Waiting", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "none"
+    },
+    {
+      "id": "k18",
+      "title": "Failed Requests by Service",
+      "description": "Failed requests segmented by upstream service",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": true,
+      "isStacked": true,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk18",
+        "promql": [
+          {"name": "A", "query": "sum(rate(kong_requests_total{namespace=\"$namespace\", service=\"$service\", code=~\"5..\"}[$__interval])) by (service)", "legend": "{{service}}", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "reqps"
+    },
+    {
+      "id": "k19",
+      "title": "Rejected Connections",
+      "description": "Connection attempts rejected by Kong",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk19",
+        "promql": [
+          {"name": "A", "query": "sum(increase(kong_connections_rejected{namespace=\"$namespace\"}[$__interval])) by (instance)", "legend": "{{instance}}", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "none"
+    },
+    {
+      "id": "k20",
+      "title": "Plugin Request Count",
+      "description": "Requests processed by each active plugin",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": true,
+      "isStacked": true,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk20",
+        "promql": [
+          {"name": "A", "query": "sum(rate(kong_plugin_requests_total{namespace=\"$namespace\"}[$__interval])) by (plugin)", "legend": "{{plugin}}", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "reqps"
+    },
+    {
+      "id": "k21",
+      "title": "Plugin Error Rate",
+      "description": "Error rates associated with each plugin",
+      "panelTypes": "graph",
+      "opacity": "1",
+      "nullZeroValues": "zero",
+      "timePreferance": "GLOBAL_TIME",
+      "stackedBarChart": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "fillSpans": false,
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 0,
+      "thresholds": [],
+      "query": {
+        "id": "qk21",
+        "promql": [
+          {"name": "A", "query": "sum(rate(kong_plugin_errors_total{namespace=\"$namespace\"}[$__interval])) by (plugin)", "legend": "{{plugin}}", "disabled": false}
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [{"dataType": "string", "name": "body", "type": ""}, {"dataType": "string", "name": "timestamp", "type": ""}],
+      "selectedTracesFields": [{"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"}, {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"}, {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"}, {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"}, {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}],
+      "yAxisUnit": "none"
+    }
+  ]
+}


### PR DESCRIPTION
/claim #5996

## Summary

Adds a comprehensive ASP.NET Metrics Dashboard for monitoring ASP.NET Core applications instrumented with OpenTelemetry .NET SDK.

## Dashboard Sections

### Application Performance
- **CPU Usage** (Value + Graph) - `process.cpu.usage`
- **Memory Usage** (Value + Graph) - `process.memory.usage`
- **Request Rate** (Value) - `http.server.request.duration` count

### Request and Response
- **Request Latency** (Graph) - p50, p95, p99 percentiles from `http.server.request.duration` histogram
- **Error Rate** (Value + Graph) - HTTP 4xx/5xx responses
- **Active Requests** (Value + Graph) - `http.server.active_requests`

### Process Metrics
- **Thread Count** (Value + Graph) - `process.thread.count`
- **GC Collections** (Graph) - `process.runtime.gc.collections.count` by generation
- **GC Heap Size** (Graph) - `process.runtime.gc.heap.size` by generation

## Variables
- `{{deployment_environment}}`: Deployment environment
- `{{service_name}}`: ASP.NET service name

## Files Added
- `aspnet/aspnet-otlp-v1.json` - Dashboard JSON
- `aspnet/README.md` - Documentation with setup instructions

## Reference
- Based on [OTLP .NET instrumentation metrics](https://opentelemetry.io/docs/zero-code/dotnet/instrumentations/)
- Inspired by [Grafana ASP.NET OTEL dashboard #17706](https://grafana.com/grafana/dashboards/17706-asp-net-otel-metrics/)

Closes #5996