### PR TITLE
feat: add CloudNativePG PostgreSQL operator monitoring dashboard

### DIFF
--- a/cloudnativepg/cloudnativepg-prometheus-v1.json
+++ b/cloudnativepg/cloudnativepg-prometheus-v1.json
@@ -1,0 +1,1884 @@
+{
+  "layout": [
+    { "h": 1, "i": "row-cluster-overview", "moved": false, "static": false, "w": 24, "x": 0, "y": 0 },
+    { "h": 4, "i": "w-collector-up", "moved": false, "static": false, "w": 6, "x": 0, "y": 1 },
+    { "h": 4, "i": "w-streaming-replicas", "moved": false, "static": false, "w": 6, "x": 6, "y": 1 },
+    { "h": 4, "i": "w-switchover-required", "moved": false, "static": false, "w": 6, "x": 12, "y": 1 },
+    { "h": 4, "i": "w-fencing-on", "moved": false, "static": false, "w": 6, "x": 18, "y": 1 },
+    { "h": 1, "i": "row-wal-replication", "moved": false, "static": false, "w": 24, "x": 0, "y": 5 },
+    { "h": 5, "i": "w-replication-lag", "moved": false, "static": false, "w": 8, "x": 0, "y": 6 },
+    { "h": 5, "i": "w-wal-size", "moved": false, "static": false, "w": 8, "x": 8, "y": 6 },
+    { "h": 5, "i": "w-wal-bytes", "moved": false, "static": false, "w": 8, "x": 16, "y": 6 },
+    { "h": 5, "i": "w-wal-archive-ready", "moved": false, "static": false, "w": 12, "x": 0, "y": 11 },
+    { "h": 5, "i": "w-replication-slot-lag", "moved": false, "static": false, "w": 12, "x": 12, "y": 11 },
+    { "h": 1, "i": "row-connections", "moved": false, "static": false, "w": 24, "x": 0, "y": 16 },
+    { "h": 5, "i": "w-backends-total", "moved": false, "static": false, "w": 8, "x": 0, "y": 17 },
+    { "h": 5, "i": "w-backends-waiting", "moved": false, "static": false, "w": 8, "x": 8, "y": 17 },
+    { "h": 5, "i": "w-max-tx-duration", "moved": false, "static": false, "w": 8, "x": 16, "y": 17 },
+    { "h": 1, "i": "row-performance", "moved": false, "static": false, "w": 24, "x": 0, "y": 22 },
+    { "h": 5, "i": "w-xact-commits", "moved": false, "static": false, "w": 8, "x": 0, "y": 23 },
+    { "h": 5, "i": "w-xact-rollbacks", "moved": false, "static": false, "w": 8, "x": 8, "y": 23 },
+    { "h": 5, "i": "w-tup-inserted", "moved": false, "static": false, "w": 8, "x": 16, "y": 23 },
+    { "h": 5, "i": "w-tup-updated", "moved": false, "static": false, "w": 8, "x": 0, "y": 28 },
+    { "h": 5, "i": "w-tup-deleted", "moved": false, "static": false, "w": 8, "x": 8, "y": 28 },
+    { "h": 5, "i": "w-tup-fetched", "moved": false, "static": false, "w": 8, "x": 16, "y": 28 },
+    { "h": 1, "i": "row-storage", "moved": false, "static": false, "w": 24, "x": 0, "y": 33 },
+    { "h": 5, "i": "w-db-size", "moved": false, "static": false, "w": 8, "x": 0, "y": 34 },
+    { "h": 5, "i": "w-temp-files", "moved": false, "static": false, "w": 8, "x": 8, "y": 34 },
+    { "h": 5, "i": "w-temp-bytes", "moved": false, "static": false, "w": 8, "x": 16, "y": 34 }
+  ],
+  "panelMap": {},
+  "title": "CloudNativePG",
+  "uploadedGrafana": false,
+  "uuid": "cloudnativepg-prometheus-v1",
+  "variables": {
+    "var-cluster": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "CloudNativePG cluster name",
+      "id": "var-cluster",
+      "key": "var-cluster",
+      "modificationUUID": "var-cluster-mod",
+      "multiSelect": true,
+      "name": "cluster",
+      "order": 0,
+      "queryValue": "SELECT DISTINCT JSONExtractString(labels, 'cluster') as value FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'cnpg_collector_up' ORDER BY value ASC",
+      "selectedValue": [],
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "var-namespace": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "Kubernetes namespace",
+      "id": "var-namespace",
+      "key": "var-namespace",
+      "modificationUUID": "var-namespace-mod",
+      "multiSelect": true,
+      "name": "namespace",
+      "order": 1,
+      "queryValue": "SELECT DISTINCT JSONExtractString(labels, 'namespace') as value FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'cnpg_collector_up' ORDER BY value ASC",
+      "selectedValue": [],
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "version": "v5",
+  "widgets": [
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": { "linksData": [] },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Section: Cluster Overview",
+      "fillSpans": false,
+      "id": "row-cluster-overview",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "row",
+      "query": {
+        "builder": { "queryData": [], "queryFormulas": [], "queryTraceOperator": [] },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "row-cluster-overview-q",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [
+        { "dataType": "string", "id": "serviceName--string--tag--false", "isColumn": true, "isJSON": false, "key": "serviceName", "name": "serviceName", "type": "tag" },
+        { "dataType": "string", "id": "name--string--tag--false", "isColumn": true, "isJSON": false, "key": "name", "name": "name", "type": "tag" }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Cluster Overview",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": { "linksData": [] },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "1 if PostgreSQL is up and the collector can reach it, 0 otherwise. Grouped by cluster and pod.",
+      "fillSpans": false,
+      "id": "w-collector-up",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_collector_up--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_collector_up",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": { "items": [], "op": "AND" },
+              "functions": [],
+              "groupBy": [
+                { "dataType": "string", "id": "cluster--string--tag--false", "isColumn": false, "isJSON": false, "key": "cluster", "type": "tag" },
+                { "dataType": "string", "id": "pod--string--tag--false", "isColumn": false, "isJSON": false, "key": "pod", "type": "tag" }
+              ],
+              "having": [],
+              "legend": "{{cluster}} / {{pod}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "w-collector-up-q",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [
+        { "dataType": "string", "id": "serviceName--string--tag--false", "isColumn": true, "isJSON": false, "key": "serviceName", "name": "serviceName", "type": "tag" },
+        { "dataType": "string", "id": "name--string--tag--false", "isColumn": true, "isJSON": false, "key": "name", "name": "name", "type": "tag" }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [
+        { "color": "#e84045", "index": 0, "moveThreshold": false, "type": "below", "value": 1 }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Instances Up",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": { "linksData": [] },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Number of streaming replicas connected to this primary instance.",
+      "fillSpans": false,
+      "id": "w-streaming-replicas",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_pg_replication_streaming_replicas--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_pg_replication_streaming_replicas",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": { "items": [], "op": "AND" },
+              "functions": [],
+              "groupBy": [
+                { "dataType": "string", "id": "cluster--string--tag--false", "isColumn": false, "isJSON": false, "key": "cluster", "type": "tag" }
+              ],
+              "having": [],
+              "legend": "{{cluster}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "w-streaming-replicas-q",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [
+        { "dataType": "string", "id": "serviceName--string--tag--false", "isColumn": true, "isJSON": false, "key": "serviceName", "name": "serviceName", "type": "tag" },
+        { "dataType": "string", "id": "name--string--tag--false", "isColumn": true, "isJSON": false, "key": "name", "name": "name", "type": "tag" }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Streaming Replicas",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": { "linksData": [] },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "1 if a manual switchover is required (e.g. after primary failure with no automatic failover), 0 otherwise.",
+      "fillSpans": false,
+      "id": "w-switchover-required",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_collector_manual_switchover_required--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_collector_manual_switchover_required",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": { "items": [], "op": "AND" },
+              "functions": [],
+              "groupBy": [
+                { "dataType": "string", "id": "cluster--string--tag--false", "isColumn": false, "isJSON": false, "key": "cluster", "type": "tag" }
+              ],
+              "having": [],
+              "legend": "{{cluster}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "w-switchover-required-q",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [
+        { "dataType": "string", "id": "serviceName--string--tag--false", "isColumn": true, "isJSON": false, "key": "serviceName", "name": "serviceName", "type": "tag" },
+        { "dataType": "string", "id": "name--string--tag--false", "isColumn": true, "isJSON": false, "key": "name", "name": "name", "type": "tag" }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [
+        { "color": "#e84045", "index": 0, "moveThreshold": false, "type": "above", "value": 0 }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Manual Switchover Required",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": { "linksData": [] },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "1 if the instance is fenced (isolated from the network), 0 otherwise. A fenced instance will not serve connections.",
+      "fillSpans": false,
+      "id": "w-fencing-on",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_collector_fencing_on--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_collector_fencing_on",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": { "items": [], "op": "AND" },
+              "functions": [],
+              "groupBy": [
+                { "dataType": "string", "id": "cluster--string--tag--false", "isColumn": false, "isJSON": false, "key": "cluster", "type": "tag" },
+                { "dataType": "string", "id": "pod--string--tag--false", "isColumn": false, "isJSON": false, "key": "pod", "type": "tag" }
+              ],
+              "having": [],
+              "legend": "{{cluster}} / {{pod}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "w-fencing-on-q",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [
+        { "dataType": "string", "id": "serviceName--string--tag--false", "isColumn": true, "isJSON": false, "key": "serviceName", "name": "serviceName", "type": "tag" },
+        { "dataType": "string", "id": "name--string--tag--false", "isColumn": true, "isJSON": false, "key": "name", "name": "name", "type": "tag" }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [
+        { "color": "#e84045", "index": 0, "moveThreshold": false, "type": "above", "value": 0 }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Fencing Active",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": { "linksData": [] },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Section: WAL & Replication",
+      "fillSpans": false,
+      "id": "row-wal-replication",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "row",
+      "query": {
+        "builder": { "queryData": [], "queryFormulas": [], "queryTraceOperator": [] },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "row-wal-replication-q",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [
+        { "dataType": "string", "id": "serviceName--string--tag--false", "isColumn": true, "isJSON": false, "key": "serviceName", "name": "serviceName", "type": "tag" },
+        { "dataType": "string", "id": "name--string--tag--false", "isColumn": true, "isJSON": false, "key": "name", "name": "name", "type": "tag" }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "WAL & Replication",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": { "linksData": [] },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Replication lag in seconds between the primary and each replica. High values indicate replicas are falling behind.",
+      "fillSpans": false,
+      "id": "w-replication-lag",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_pg_replication_lag--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_pg_replication_lag",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": { "items": [], "op": "AND" },
+              "functions": [],
+              "groupBy": [
+                { "dataType": "string", "id": "cluster--string--tag--false", "isColumn": false, "isJSON": false, "key": "cluster", "type": "tag" },
+                { "dataType": "string", "id": "pod--string--tag--false", "isColumn": false, "isJSON": false, "key": "pod", "type": "tag" }
+              ],
+              "having": [],
+              "legend": "{{cluster}} / {{pod}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "w-replication-lag-q",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [
+        { "dataType": "string", "id": "serviceName--string--tag--false", "isColumn": true, "isJSON": false, "key": "serviceName", "name": "serviceName", "type": "tag" },
+        { "dataType": "string", "id": "name--string--tag--false", "isColumn": true, "isJSON": false, "key": "name", "name": "name", "type": "tag" }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Replication Lag (seconds)",
+      "yAxisUnit": "s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": { "linksData": [] },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Total size in bytes of WAL segment files in the pg_wal directory. Sustained growth may indicate archiving problems.",
+      "fillSpans": false,
+      "id": "w-wal-size",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_collector_pg_wal--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_collector_pg_wal",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": { "items": [], "op": "AND" },
+              "functions": [],
+              "groupBy": [
+                { "dataType": "string", "id": "cluster--string--tag--false", "isColumn": false, "isJSON": false, "key": "cluster", "type": "tag" },
+                { "dataType": "string", "id": "pod--string--tag--false", "isColumn": false, "isJSON": false, "key": "pod", "type": "tag" }
+              ],
+              "having": [],
+              "legend": "{{cluster}} / {{pod}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "w-wal-size-q",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [
+        { "dataType": "string", "id": "serviceName--string--tag--false", "isColumn": true, "isJSON": false, "key": "serviceName", "name": "serviceName", "type": "tag" },
+        { "dataType": "string", "id": "name--string--tag--false", "isColumn": true, "isJSON": false, "key": "name", "name": "name", "type": "tag" }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "WAL Directory Size",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": { "linksData": [] },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Total WAL data generated in bytes (PostgreSQL 14+). Useful for estimating write amplification and storage requirements.",
+      "fillSpans": false,
+      "id": "w-wal-bytes",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_collector_wal_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_collector_wal_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": { "items": [], "op": "AND" },
+              "functions": [],
+              "groupBy": [
+                { "dataType": "string", "id": "cluster--string--tag--false", "isColumn": false, "isJSON": false, "key": "cluster", "type": "tag" },
+                { "dataType": "string", "id": "pod--string--tag--false", "isColumn": false, "isJSON": false, "key": "pod", "type": "tag" }
+              ],
+              "having": [],
+              "legend": "{{cluster}} / {{pod}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "w-wal-bytes-q",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [
+        { "dataType": "string", "id": "serviceName--string--tag--false", "isColumn": true, "isJSON": false, "key": "serviceName", "name": "serviceName", "type": "tag" },
+        { "dataType": "string", "id": "name--string--tag--false", "isColumn": true, "isJSON": false, "key": "name", "name": "name", "type": "tag" }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "WAL Generation Rate",
+      "yAxisUnit": "binBps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": { "linksData": [] },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Number of WAL segments ready to be archived. A growing count indicates the WAL archiver is not keeping up.",
+      "fillSpans": false,
+      "id": "w-wal-archive-ready",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_collector_pg_wal_archive_status--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_collector_pg_wal_archive_status",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "filter-archive-status",
+                    "key": { "dataType": "string", "id": "status--string--tag--false", "isColumn": false, "isJSON": false, "key": "status", "type": "tag" },
+                    "op": "=",
+                    "value": "ready"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                { "dataType": "string", "id": "cluster--string--tag--false", "isColumn": false, "isJSON": false, "key": "cluster", "type": "tag" },
+                { "dataType": "string", "id": "pod--string--tag--false", "isColumn": false, "isJSON": false, "key": "pod", "type": "tag" }
+              ],
+              "having": [],
+              "legend": "{{cluster}} / {{pod}} — ready",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_collector_pg_wal_archive_status--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_collector_pg_wal_archive_status",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "filter-archive-status-done",
+                    "key": { "dataType": "string", "id": "status--string--tag--false", "isColumn": false, "isJSON": false, "key": "status", "type": "tag" },
+                    "op": "=",
+                    "value": "done"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                { "dataType": "string", "id": "cluster--string--tag--false", "isColumn": false, "isJSON": false, "key": "cluster", "type": "tag" },
+                { "dataType": "string", "id": "pod--string--tag--false", "isColumn": false, "isJSON": false, "key": "pod", "type": "tag" }
+              ],
+              "having": [],
+              "legend": "{{cluster}} / {{pod}} — done",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "w-wal-archive-ready-q",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [
+        { "dataType": "string", "id": "serviceName--string--tag--false", "isColumn": true, "isJSON": false, "key": "serviceName", "name": "serviceName", "type": "tag" },
+        { "dataType": "string", "id": "name--string--tag--false", "isColumn": true, "isJSON": false, "key": "name", "name": "name", "type": "tag" }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "WAL Archive Queue (Ready / Done)",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": { "linksData": [] },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "WAL bytes difference between primary and each replication slot. Large values indicate slot consumers are lagging and may cause WAL accumulation.",
+      "fillSpans": false,
+      "id": "w-replication-slot-lag",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_pg_replication_slots_pg_wal_lsn_diff--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_pg_replication_slots_pg_wal_lsn_diff",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": { "items": [], "op": "AND" },
+              "functions": [],
+              "groupBy": [
+                { "dataType": "string", "id": "cluster--string--tag--false", "isColumn": false, "isJSON": false, "key": "cluster", "type": "tag" },
+                { "dataType": "string", "id": "slot_name--string--tag--false", "isColumn": false, "isJSON": false, "key": "slot_name", "type": "tag" }
+              ],
+              "having": [],
+              "legend": "{{cluster}} / {{slot_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "w-replication-slot-lag-q",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [
+        { "dataType": "string", "id": "serviceName--string--tag--false", "isColumn": true, "isJSON": false, "key": "serviceName", "name": "serviceName", "type": "tag" },
+        { "dataType": "string", "id": "name--string--tag--false", "isColumn": true, "isJSON": false, "key": "name", "name": "name", "type": "tag" }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Replication Slot Lag (bytes)",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": { "linksData": [] },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Section: Connections",
+      "fillSpans": false,
+      "id": "row-connections",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "row",
+      "query": {
+        "builder": { "queryData": [], "queryFormulas": [], "queryTraceOperator": [] },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "row-connections-q",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [
+        { "dataType": "string", "id": "serviceName--string--tag--false", "isColumn": true, "isJSON": false, "key": "serviceName", "name": "serviceName", "type": "tag" },
+        { "dataType": "string", "id": "name--string--tag--false", "isColumn": true, "isJSON": false, "key": "name", "name": "name", "type": "tag" }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Connections",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": { "linksData": [] },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Total number of backend connections grouped by database, user, application, and state. Helps identify which clients are consuming connections.",
+      "fillSpans": false,
+      "id": "w-backends-total",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_backends_total--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_backends_total",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": { "items": [], "op": "AND" },
+              "functions": [],
+              "groupBy": [
+                { "dataType": "string", "id": "cluster--string--tag--false", "isColumn": false, "isJSON": false, "key": "cluster", "type": "tag" },
+                { "dataType": "string", "id": "datname--string--tag--false", "isColumn": false, "isJSON": false, "key": "datname", "type": "tag" },
+                { "dataType": "string", "id": "state--string--tag--false", "isColumn": false, "isJSON": false, "key": "state", "type": "tag" }
+              ],
+              "having": [],
+              "legend": "{{cluster}} / {{datname}} [{{state}}]",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "w-backends-total-q",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [
+        { "dataType": "string", "id": "serviceName--string--tag--false", "isColumn": true, "isJSON": false, "key": "serviceName", "name": "serviceName", "type": "tag" },
+        { "dataType": "string", "id": "name--string--tag--false", "isColumn": true, "isJSON": false, "key": "name", "name": "name", "type": "tag" }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": true,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Connections by State",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": { "linksData": [] },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Number of backends waiting on locks. A sustained value above 0 indicates lock contention.",
+      "fillSpans": false,
+      "id": "w-backends-waiting",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_backends_waiting_total--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_backends_waiting_total",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": { "items": [], "op": "AND" },
+              "functions": [],
+              "groupBy": [
+                { "dataType": "string", "id": "cluster--string--tag--false", "isColumn": false, "isJSON": false, "key": "cluster", "type": "tag" },
+                { "dataType": "string", "id": "pod--string--tag--false", "isColumn": false, "isJSON": false, "key": "pod", "type": "tag" }
+              ],
+              "having": [],
+              "legend": "{{cluster}} / {{pod}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "w-backends-waiting-q",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [
+        { "dataType": "string", "id": "serviceName--string--tag--false", "isColumn": true, "isJSON": false, "key": "serviceName", "name": "serviceName", "type": "tag" },
+        { "dataType": "string", "id": "name--string--tag--false", "isColumn": true, "isJSON": false, "key": "name", "name": "name", "type": "tag" }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Connections Waiting on Locks",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": { "linksData": [] },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Maximum duration in seconds of any currently open transaction. Long-running transactions can block autovacuum and cause table bloat.",
+      "fillSpans": false,
+      "id": "w-max-tx-duration",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_backends_max_tx_duration_seconds--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_backends_max_tx_duration_seconds",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": { "items": [], "op": "AND" },
+              "functions": [],
+              "groupBy": [
+                { "dataType": "string", "id": "cluster--string--tag--false", "isColumn": false, "isJSON": false, "key": "cluster", "type": "tag" },
+                { "dataType": "string", "id": "datname--string--tag--false", "isColumn": false, "isJSON": false, "key": "datname", "type": "tag" }
+              ],
+              "having": [],
+              "legend": "{{cluster}} / {{datname}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "max",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "w-max-tx-duration-q",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [
+        { "dataType": "string", "id": "serviceName--string--tag--false", "isColumn": true, "isJSON": false, "key": "serviceName", "name": "serviceName", "type": "tag" },
+        { "dataType": "string", "id": "name--string--tag--false", "isColumn": true, "isJSON": false, "key": "name", "name": "name", "type": "tag" }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Longest Open Transaction (seconds)",
+      "yAxisUnit": "s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": { "linksData": [] },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Section: Performance",
+      "fillSpans": false,
+      "id": "row-performance",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "row",
+      "query": {
+        "builder": { "queryData": [], "queryFormulas": [], "queryTraceOperator": [] },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "row-performance-q",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [
+        { "dataType": "string", "id": "serviceName--string--tag--false", "isColumn": true, "isJSON": false, "key": "serviceName", "name": "serviceName", "type": "tag" },
+        { "dataType": "string", "id": "name--string--tag--false", "isColumn": true, "isJSON": false, "key": "name", "name": "name", "type": "tag" }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Performance",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": { "linksData": [] },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Rate of committed transactions per second across all databases. A drop may indicate application problems or reduced load.",
+      "fillSpans": false,
+      "id": "w-xact-commits",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_pg_stat_database_xact_commit--float64--Counter--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_pg_stat_database_xact_commit",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": { "items": [], "op": "AND" },
+              "functions": [],
+              "groupBy": [
+                { "dataType": "string", "id": "cluster--string--tag--false", "isColumn": false, "isJSON": false, "key": "cluster", "type": "tag" },
+                { "dataType": "string", "id": "datname--string--tag--false", "isColumn": false, "isJSON": false, "key": "datname", "type": "tag" }
+              ],
+              "having": [],
+              "legend": "{{cluster}} / {{datname}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "w-xact-commits-q",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [
+        { "dataType": "string", "id": "serviceName--string--tag--false", "isColumn": true, "isJSON": false, "key": "serviceName", "name": "serviceName", "type": "tag" },
+        { "dataType": "string", "id": "name--string--tag--false", "isColumn": true, "isJSON": false, "key": "name", "name": "name", "type": "tag" }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Transaction Commits / sec",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": { "linksData": [] },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Rate of rolled-back transactions per second. A spike may indicate application errors, deadlocks, or connection timeouts.",
+      "fillSpans": false,
+      "id": "w-xact-rollbacks",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_pg_stat_database_xact_rollback--float64--Counter--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_pg_stat_database_xact_rollback",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": { "items": [], "op": "AND" },
+              "functions": [],
+              "groupBy": [
+                { "dataType": "string", "id": "cluster--string--tag--false", "isColumn": false, "isJSON": false, "key": "cluster", "type": "tag" },
+                { "dataType": "string", "id": "datname--string--tag--false", "isColumn": false, "isJSON": false, "key": "datname", "type": "tag" }
+              ],
+              "having": [],
+              "legend": "{{cluster}} / {{datname}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "w-xact-rollbacks-q",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [
+        { "dataType": "string", "id": "serviceName--string--tag--false", "isColumn": true, "isJSON": false, "key": "serviceName", "name": "serviceName", "type": "tag" },
+        { "dataType": "string", "id": "name--string--tag--false", "isColumn": true, "isJSON": false, "key": "name", "name": "name", "type": "tag" }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Transaction Rollbacks / sec",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": { "linksData": [] },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Rate of rows inserted per second across all databases.",
+      "fillSpans": false,
+      "id": "w-tup-inserted",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_pg_stat_database_tup_inserted--float64--Counter--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_pg_stat_database_tup_inserted",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": { "items": [], "op": "AND" },
+              "functions": [],
+              "groupBy": [
+                { "dataType": "string", "id": "cluster--string--tag--false", "isColumn": false, "isJSON": false, "key": "cluster", "type": "tag" },
+                { "dataType": "string", "id": "datname--string--tag--false", "isColumn": false, "isJSON": false, "key": "datname", "type": "tag" }
+              ],
+              "having": [],
+              "legend": "{{cluster}} / {{datname}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "w-tup-inserted-q",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [
+        { "dataType": "string", "id": "serviceName--string--tag--false", "isColumn": true, "isJSON": false, "key": "serviceName", "name": "serviceName", "type": "tag" },
+        { "dataType": "string", "id": "name--string--tag--false", "isColumn": true, "isJSON": false, "key": "name", "name": "name", "type": "tag" }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Tuples Inserted / sec",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": { "linksData": [] },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Rate of rows updated per second. High update rates combined with low autovacuum activity can cause table bloat.",
+      "fillSpans": false,
+      "id": "w-tup-updated",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_pg_stat_database_tup_updated--float64--Counter--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_pg_stat_database_tup_updated",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": { "items": [], "op": "AND" },
+              "functions": [],
+              "groupBy": [
+                { "dataType": "string", "id": "cluster--string--tag--false", "isColumn": false, "isJSON": false, "key": "cluster", "type": "tag" },
+                { "dataType": "string", "id": "datname--string--tag--false", "isColumn": false, "isJSON": false, "key": "datname", "type": "tag" }
+              ],
+              "having": [],
+              "legend": "{{cluster}} / {{datname}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "w-tup-updated-q",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [
+        { "dataType": "string", "id": "serviceName--string--tag--false", "isColumn": true, "isJSON": false, "key": "serviceName", "name": "serviceName", "type": "tag" },
+        { "dataType": "string", "id": "name--string--tag--false", "isColumn": true, "isJSON": false, "key": "name", "name": "name", "type": "tag" }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Tuples Updated / sec",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": { "linksData": [] },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Rate of rows deleted per second.",
+      "fillSpans": false,
+      "id": "w-tup-deleted",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_pg_stat_database_tup_deleted--float64--Counter--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_pg_stat_database_tup_deleted",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": { "items": [], "op": "AND" },
+              "functions": [],
+              "groupBy": [
+                { "dataType": "string", "id": "cluster--string--tag--false", "isColumn": false, "isJSON": false, "key": "cluster", "type": "tag" },
+                { "dataType": "string", "id": "datname--string--tag--false", "isColumn": false, "isJSON": false, "key": "datname", "type": "tag" }
+              ],
+              "having": [],
+              "legend": "{{cluster}} / {{datname}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "w-tup-deleted-q",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [
+        { "dataType": "string", "id": "serviceName--string--tag--false", "isColumn": true, "isJSON": false, "key": "serviceName", "name": "serviceName", "type": "tag" },
+        { "dataType": "string", "id": "name--string--tag--false", "isColumn": true, "isJSON": false, "key": "name", "name": "name", "type": "tag" }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Tuples Deleted / sec",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": { "linksData": [] },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Rate of rows returned by queries (full scans + index scans). A high ratio of tup_returned vs tup_fetched may indicate missing indexes.",
+      "fillSpans": false,
+      "id": "w-tup-fetched",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_pg_stat_database_tup_fetched--float64--Counter--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_pg_stat_database_tup_fetched",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": { "items": [], "op": "AND" },
+              "functions": [],
+              "groupBy": [
+                { "dataType": "string", "id": "cluster--string--tag--false", "isColumn": false, "isJSON": false, "key": "cluster", "type": "tag" },
+                { "dataType": "string", "id": "datname--string--tag--false", "isColumn": false, "isJSON": false, "key": "datname", "type": "tag" }
+              ],
+              "having": [],
+              "legend": "Fetched — {{cluster}} / {{datname}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_pg_stat_database_tup_returned--float64--Counter--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_pg_stat_database_tup_returned",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": { "items": [], "op": "AND" },
+              "functions": [],
+              "groupBy": [
+                { "dataType": "string", "id": "cluster--string--tag--false", "isColumn": false, "isJSON": false, "key": "cluster", "type": "tag" },
+                { "dataType": "string", "id": "datname--string--tag--false", "isColumn": false, "isJSON": false, "key": "datname", "type": "tag" }
+              ],
+              "having": [],
+              "legend": "Returned — {{cluster}} / {{datname}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "w-tup-fetched-q",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [
+        { "dataType": "string", "id": "serviceName--string--tag--false", "isColumn": true, "isJSON": false, "key": "serviceName", "name": "serviceName", "type": "tag" },
+        { "dataType": "string", "id": "name--string--tag--false", "isColumn": true, "isJSON": false, "key": "name", "name": "name", "type": "tag" }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Tuples Fetched vs Returned / sec",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": { "linksData": [] },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Section: Storage",
+      "fillSpans": false,
+      "id": "row-storage",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "row",
+      "query": {
+        "builder": { "queryData": [], "queryFormulas": [], "queryTraceOperator": [] },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "row-storage-q",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [
+        { "dataType": "string", "id": "serviceName--string--tag--false", "isColumn": true, "isJSON": false, "key": "serviceName", "name": "serviceName", "type": "tag" },
+        { "dataType": "string", "id": "name--string--tag--false", "isColumn": true, "isJSON": false, "key": "name", "name": "name", "type": "tag" }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Storage",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": { "linksData": [] },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Disk size of each database in bytes. Monitor for growth trends to plan storage capacity.",
+      "fillSpans": false,
+      "id": "w-db-size",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_pg_database_size_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_pg_database_size_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": { "items": [], "op": "AND" },
+              "functions": [],
+              "groupBy": [
+                { "dataType": "string", "id": "cluster--string--tag--false", "isColumn": false, "isJSON": false, "key": "cluster", "type": "tag" },
+                { "dataType": "string", "id": "datname--string--tag--false", "isColumn": false, "isJSON": false, "key": "datname", "type": "tag" }
+              ],
+              "having": [],
+              "legend": "{{cluster}} / {{datname}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "w-db-size-q",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [
+        { "dataType": "string", "id": "serviceName--string--tag--false", "isColumn": true, "isJSON": false, "key": "serviceName", "name": "serviceName", "type": "tag" },
+        { "dataType": "string", "id": "name--string--tag--false", "isColumn": true, "isJSON": false, "key": "name", "name": "name", "type": "tag" }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Database Size",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": { "linksData": [] },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Number of temporary files created by query sort/hash operations. High values may indicate insufficient work_mem.",
+      "fillSpans": false,
+      "id": "w-temp-files",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_pg_stat_database_temp_files--float64--Counter--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_pg_stat_database_temp_files",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": { "items": [], "op": "AND" },
+              "functions": [],
+              "groupBy": [
+                { "dataType": "string", "id": "cluster--string--tag--false", "isColumn": false, "isJSON": false, "key": "cluster", "type": "tag" },
+                { "dataType": "string", "id": "datname--string--tag--false", "isColumn": false, "isJSON": false, "key": "datname", "type": "tag" }
+              ],
+              "having": [],
+              "legend": "{{cluster}} / {{datname}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "w-temp-files-q",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [
+        { "dataType": "string", "id": "serviceName--string--tag--false", "isColumn": true, "isJSON": false, "key": "serviceName", "name": "serviceName", "type": "tag" },
+        { "dataType": "string", "id": "name--string--tag--false", "isColumn": true, "isJSON": false, "key": "name", "name": "name", "type": "tag" }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Temp Files Created / sec",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": { "linksData": [] },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Amount of data written to temporary files by queries. Large values with high work_mem may indicate complex query plans.",
+      "fillSpans": false,
+      "id": "w-temp-bytes",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_pg_stat_database_temp_bytes--float64--Counter--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_pg_stat_database_temp_bytes",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": { "items": [], "op": "AND" },
+              "functions": [],
+              "groupBy": [
+                { "dataType": "string", "id": "cluster--string--tag--false", "isColumn": false, "isJSON": false, "key": "cluster", "type": "tag" },
+                { "dataType": "string", "id": "datname--string--tag--false", "isColumn": false, "isJSON": false, "key": "datname", "type": "tag" }
+              ],
+              "having": [],
+              "legend": "{{cluster}} / {{datname}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "w-temp-bytes-q",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [
+        { "dataType": "string", "id": "serviceName--string--tag--false", "isColumn": true, "isJSON": false, "key": "serviceName", "name": "serviceName", "type": "tag" },
+        { "dataType": "string", "id": "name--string--tag--false", "isColumn": true, "isJSON": false, "key": "name", "name": "name", "type": "tag" }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Temp Storage Written / sec",
+      "yAxisUnit": "binBps"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds a SigNoz dashboard for monitoring PostgreSQL clusters managed by the [CloudNativePG](https://cloudnative-pg.io/) Kubernetes operator.

**File:** `cloudnativepg/cloudnativepg-prometheus-v1.json`

## Dashboard Overview

**Title:** CloudNativePG
**UUID:** `cloudnativepg-prometheus-v1`
**Version:** v5
**Widget count:** 26

---

## Sections & Metrics

### Cluster Overview
- **Instances Up** — number of running PostgreSQL instances in the cluster
- **Streaming Replicas** — number of active streaming replication standbys
- **Manual Switchover Required** — alert indicator for pending manual switchover
- **Fencing Active** — indicator for active fencing on the cluster

### WAL & Replication
- **Replication Lag (seconds)** — seconds of lag between primary and replicas
- **WAL Directory Size** — total size of the WAL directory
- **WAL Generation Rate** — rate of WAL segments being generated
- **WAL Archive Queue (Ready / Done)** — WAL segments pending archive vs archived
- **Replication Slot Lag (bytes)** — byte lag per replication slot

### Connections
- **Active Connections by State** — connections broken down by state (active, idle, idle in transaction, etc.)
- **Connections Waiting on Locks** — number of backends blocked waiting for a lock
- **Longest Open Transaction (seconds)** — duration of the oldest open transaction

### Performance
- **Transaction Commits / sec** — commit throughput
- **Transaction Rollbacks / sec** — rollback rate
- **Tuples Inserted / sec** — insert throughput
- **Tuples Updated / sec** — update throughput
- **Tuples Deleted / sec** — delete throughput
- **Tuples Fetched vs Returned / sec** — index efficiency ratio

### Storage
- **Database Size** — size of each database in the cluster
- **Temp Files Created / sec** — rate of temporary file creation (spill to disk)
- **Temp Storage Written / sec** — bytes written to temporary files per second

---

## Prerequisites

- CloudNativePG operator installed in your Kubernetes cluster
- CloudNativePG Prometheus metrics enabled (built-in exporter on port `9187`)
- Prometheus scraping the CloudNativePG pods
- SigNoz set up to receive metrics from Prometheus (via the OpenTelemetry Collector or remote write)

## How to Import

1. In SigNoz, go to **Dashboards → New Dashboard → Import JSON**
2. Upload `cloudnativepg/cloudnativepg-prometheus-v1.json`
3. The dashboard will appear under the name **CloudNativePG**

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)