### PR TITLE
Add Kong Gateway Monitoring Dashboard

### DIFF
--- a/kong-gateway/README.md
+++ b/kong-gateway/README.md
@@ -1,0 +1,29 @@
+# Kong Gateway Dashboard - Prometheus
+
+## Overview
+Monitor Kong API Gateway health, performance, traffic and errors.
+
+## Metrics Ingestion
+Configure Kong with Prometheus metrics enabled and scrape with OpenTelemetry Collector:
+
+```yaml
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: kong
+          scrape_interval: 15s
+          kubernetes_sd_configs:
+            - role: pod
+              namespaces:
+                names:
+                  - <kong-namespace>
+          relabel_configs:
+            - source_labels: [__address__]
+              target_label: __address__
+              replacement: $1:8100
+```
+
+## Variables
+- `{{namespace}}`: Kubernetes namespace where Kong is deployed
+- `{{deployment.environment}}`: Deployment environment

--- a/kong-gateway/kong-gateway-prometheus-v1.json
+++ b/kong-gateway/kong-gateway-prometheus-v1.json
@@ -1,0 +1,823 @@
+{
+  "description": "Monitor Kong API Gateway health, performance, traffic and errors",
+  "layout": [
+    {
+      "h": 6,
+      "i": "34cb53d1-d20b-4edb-84d9-b050f5cf6d75",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 6,
+      "i": "59dd2fab-be4e-4648-8229-2be109795a5f",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 0
+    },
+    {
+      "h": 6,
+      "i": "8764820a-c7f5-4e30-a541-7fa7d07b49b6",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 0
+    },
+    {
+      "h": 6,
+      "i": "b4245105-65f6-4888-a2cb-694544d1e7ce",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 6
+    },
+    {
+      "h": 6,
+      "i": "5b940e22-7ec6-4d00-9d27-4185f19f5a5a",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 6
+    },
+    {
+      "h": 6,
+      "i": "02bdf973-9a98-4ad5-a992-58a9e5af1a62",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 6
+    },
+    {
+      "h": 6,
+      "i": "14542bed-77af-4748-94a9-e18142ea0513",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 12
+    },
+    {
+      "h": 6,
+      "i": "dfe3e048-e952-48c1-8eec-0982aeb89cf5",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 12
+    },
+    {
+      "h": 6,
+      "i": "15adb4c6-740c-4f02-aeef-ee72ee7bf202",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 12
+    },
+    {
+      "h": 6,
+      "i": "c663daa3-0659-4fb4-be75-e6752ba49aea",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 18
+    },
+    {
+      "h": 6,
+      "i": "6e0a94d9-fa65-426b-8fb2-c51fb8df4d8d",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 18
+    },
+    {
+      "h": 6,
+      "i": "d2739648-f6f4-4824-bc43-cebbc333ca79",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 18
+    },
+    {
+      "h": 6,
+      "i": "70741004-666c-4927-8dc2-f175dcceeaad",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 24
+    },
+    {
+      "h": 6,
+      "i": "9830d0ab-22dd-446a-8afe-6c65ca39e262",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 24
+    },
+    {
+      "h": 6,
+      "i": "a257db67-a952-4a95-b063-fde05e754291",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 24
+    },
+    {
+      "h": 6,
+      "i": "027a5e57-d90f-4f6d-9f1f-58a8fc80fda5",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 30
+    },
+    {
+      "h": 6,
+      "i": "c42fe468-4d07-4b45-8b31-1afe58b6d6c1",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 30
+    }
+  ],
+  "name": "",
+  "panelMap": {},
+  "tags": [],
+  "title": "Kong Gateway",
+  "uploadedGrafana": false,
+  "variables": {
+    "ff4cb828-5738-4b5d-bae2-46c98911a886": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Kubernetes namespace",
+      "id": "ff4cb828-5738-4b5d-bae2-46c98911a886",
+      "modificationUUID": "b1fcae95-0e00-447d-9dee-5fee123d79b6",
+      "multiSelect": false,
+      "name": "namespace",
+      "order": 0,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'namespace'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name LIKE '%kong%'\nAND (unix_milli >= $__unixMilliStart() AND unix_milli <= $__unixMilliEnd())",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "bf9fb146-613b-495e-8221-17cb0ee07b45": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Deployment environment",
+      "id": "bf9fb146-613b-495e-8221-17cb0ee07b45",
+      "modificationUUID": "b3304743-7f94-41ec-9ee5-1999c9aced9f",
+      "multiSelect": false,
+      "name": "deployment.environment",
+      "order": 1,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'deployment.environment')) as `deployment.environment`\nFROM signoz_metrics.time_series_v4\nWHERE metric_name LIKE '%kong%'\nAND (unix_milli >= $__unixMilliStart() AND unix_milli <= $__unixMilliEnd())",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "version": "v4",
+  "widgets": [
+    {
+      "description": "Total API requests handled by Kong",
+      "fillSpans": false,
+      "id": "34cb53d1-d20b-4edb-84d9-b050f5cf6d75",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "stat",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c49fe862-c4e3-4cbb-98c7-82be6858b143",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "sum(rate(kong_http_requests_total{deployment_environment=\"$deployment_environment\", namespace=\"$namespace\"}[$__rate_interval]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Requests",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Currently active connections",
+      "fillSpans": false,
+      "id": "59dd2fab-be4e-4648-8229-2be109795a5f",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "stat",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ba73c5bd-4d1d-4467-b3b7-6a588a104c7c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "sum(kong_connections_active{deployment_environment=\"$deployment_environment\", namespace=\"$namespace\"})"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Connections",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "CPU usage by Kong process",
+      "fillSpans": false,
+      "id": "8764820a-c7f5-4e30-a541-7fa7d07b49b6",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "64c9cd40-695b-46a4-b91a-3a780b806f10",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{instance}}",
+            "name": "A",
+            "query": "sum(rate(process_cpu_seconds_total{deployment_environment=\"$deployment_environment\", namespace=\"$namespace\", job=~\".*kong.*\"}[$__rate_interval])) by (instance) * 100"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "CPU Usage",
+      "yAxisUnit": "percent"
+    },
+    {
+      "description": "Memory consumption",
+      "fillSpans": false,
+      "id": "b4245105-65f6-4888-a2cb-694544d1e7ce",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "31351ccc-154e-4cbe-85ac-bebce6b651d5",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{instance}}",
+            "name": "A",
+            "query": "sum(process_resident_memory_bytes{deployment_environment=\"$deployment_environment\", namespace=\"$namespace\", job=~\".*kong.*\"}) by (instance)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memory Usage",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "Kong uptime since last restart",
+      "fillSpans": false,
+      "id": "5b940e22-7ec6-4d00-9d27-4185f19f5a5a",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9d03bd0a-a219-4edf-8a67-4e6350dd7192",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{instance}}",
+            "name": "A",
+            "query": "time() - process_start_time_seconds{deployment_environment=\"$deployment_environment\", namespace=\"$namespace\", job=~\".*kong.*\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Uptime",
+      "yAxisUnit": "seconds"
+    },
+    {
+      "description": "Requests per second by service",
+      "fillSpans": false,
+      "id": "02bdf973-9a98-4ad5-a992-58a9e5af1a62",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "fc0dbcdb-997a-4df0-8a2d-b54f80ec36e6",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{service}}",
+            "name": "A",
+            "query": "sum(rate(kong_http_requests_total{deployment_environment=\"$deployment_environment\", namespace=\"$namespace\"}[$__rate_interval])) by (service)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Rate",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "HTTP response status code distribution",
+      "fillSpans": false,
+      "id": "14542bed-77af-4748-94a9-e18142ea0513",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b7fff5ba-ab99-46a6-98dc-05454bbbf455",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{code}}",
+            "name": "A",
+            "query": "sum(rate(kong_http_requests_total{deployment_environment=\"$deployment_environment\", namespace=\"$namespace\"}[$__rate_interval])) by (code)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Response Status Codes",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Average incoming request size",
+      "fillSpans": false,
+      "id": "dfe3e048-e952-48c1-8eec-0982aeb89cf5",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "2ef03406-81c8-4a51-9ec3-06d491f4d255",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{service}}",
+            "name": "A",
+            "query": "sum(rate(kong_http_requests_size_bytes{deployment_environment=\"$deployment_environment\", namespace=\"$namespace\"}[$__rate_interval])) by (service) / sum(rate(kong_http_requests_total{deployment_environment=\"$deployment_environment\", namespace=\"$namespace\"}[$__rate_interval])) by (service)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Size (Avg)",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "Average response size",
+      "fillSpans": false,
+      "id": "15adb4c6-740c-4f02-aeef-ee72ee7bf202",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c01a5fb4-d89f-4e3c-858e-aa420b7a6ce5",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{service}}",
+            "name": "A",
+            "query": "sum(rate(kong_http_responses_size_bytes{deployment_environment=\"$deployment_environment\", namespace=\"$namespace\"}[$__rate_interval])) by (service) / sum(rate(kong_http_requests_total{deployment_environment=\"$deployment_environment\", namespace=\"$namespace\"}[$__rate_interval])) by (service)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Response Size (Avg)",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "Average latency per service",
+      "fillSpans": false,
+      "id": "c663daa3-0659-4fb4-be75-e6752ba49aea",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "e0bd55d0-3efd-4ce6-85f6-b5e494399ac0",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{service}}",
+            "name": "A",
+            "query": "sum(rate(kong_http_requests_latency_sum{deployment_environment=\"$deployment_environment\", namespace=\"$namespace\"}[$__rate_interval])) by (service) / sum(rate(kong_http_requests_latency_count{deployment_environment=\"$deployment_environment\", namespace=\"$namespace\"}[$__rate_interval])) by (service)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Average Request Latency",
+      "yAxisUnit": "ms"
+    },
+    {
+      "description": "Latency percentiles",
+      "fillSpans": false,
+      "id": "6e0a94d9-fa65-426b-8fb2-c51fb8df4d8d",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "4c4d8860-a750-474b-af3c-d436ee943eca",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "P50 - {{service}}",
+            "name": "A",
+            "query": "histogram_quantile(0.50, sum(rate(kong_http_requests_latency_bucket{deployment_environment=\"$deployment_environment\", namespace=\"$namespace\"}[$__rate_interval])) by (le, service))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Latency (P50/P90/P99)",
+      "yAxisUnit": "ms"
+    },
+    {
+      "description": "Upstream service latency",
+      "fillSpans": false,
+      "id": "d2739648-f6f4-4824-bc43-cebbc333ca79",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a0af75c7-e75c-48c4-989f-9cfc11c517f8",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{service}}",
+            "name": "A",
+            "query": "sum(rate(kong_http_upstream_latency_sum{deployment_environment=\"$deployment_environment\", namespace=\"$namespace\"}[$__rate_interval])) by (service) / sum(rate(kong_http_upstream_latency_count{deployment_environment=\"$deployment_environment\", namespace=\"$namespace\"}[$__rate_interval])) by (service)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Upstream Latency",
+      "yAxisUnit": "ms"
+    },
+    {
+      "description": "Total 5xx errors by service",
+      "fillSpans": false,
+      "id": "70741004-666c-4927-8dc2-f175dcceeaad",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "5890c021-2891-4437-89b7-6d3583806c49",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{service}}",
+            "name": "A",
+            "query": "sum(rate(kong_http_requests_total{deployment_environment=\"$deployment_environment\", namespace=\"$namespace\", code=~\"5..\"}[$__rate_interval])) by (service)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Errors (5xx)",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Rate of client and server errors",
+      "fillSpans": false,
+      "id": "9830d0ab-22dd-446a-8afe-6c65ca39e262",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "51f1bb93-4d9b-49f1-a7b5-60582a7337c4",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "sum(rate(kong_http_requests_total{deployment_environment=\"$deployment_environment\", namespace=\"$namespace\", code=~\"[45]..\"}[$__rate_interval]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Error Rate (4xx+5xx)",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Failed requests by upstream service",
+      "fillSpans": false,
+      "id": "a257db67-a952-4a95-b063-fde05e754291",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "73f72b13-7a9e-464e-a183-1e48877ba150",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{service}}",
+            "name": "A",
+            "query": "sum(rate(kong_http_requests_total{deployment_environment=\"$deployment_environment\", namespace=\"$namespace\", code=~\"[45]..\"}[$__rate_interval])) by (service)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Failed Requests by Service",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "New connections per second",
+      "fillSpans": false,
+      "id": "027a5e57-d90f-4f6d-9f1f-58a8fc80fda5",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "bb0f7202-dfdf-419f-9a75-91fddff17a7c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "sum(rate(kong_connections_total{deployment_environment=\"$deployment_environment\", namespace=\"$namespace\"}[$__rate_interval]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Connections Rate",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Rejected connection attempts",
+      "fillSpans": false,
+      "id": "c42fe468-4d07-4b45-8b31-1afe58b6d6c1",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "192917dc-c458-41ca-8eb4-00e57b62332b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "sum(kong_connections_rejected{deployment_environment=\"$deployment_environment\", namespace=\"$namespace\"})"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Rejected Connections",
+      "yAxisUnit": "none"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds a Kong Gateway monitoring dashboard with panels for:
- General overview (requests, connections, CPU, memory, uptime)
- Request metrics (rate, status codes, sizes)
- Latency metrics (avg, percentiles, upstream)
- Error metrics (5xx, error rate, failed by service)
- Traffic metrics (connections, rejections)

Closes /claim #6028

## Screenshots
Dashboard JSON follows the SigNoz v4 format with PromQL queries.