### PR TITLE
Add AWS MSK Cluster Monitoring Dashboard

### DIFF
--- a/aws-msk-cluster/README.md
+++ b/aws-msk-cluster/README.md
@@ -1,0 +1,20 @@
+# AWS MSK Cluster Monitoring Dashboard - Prometheus
+
+## Overview
+Monitor AWS MSK cluster health, topics, partitions and consumer lag.
+
+## Metrics Ingestion
+Use the JMX Exporter with Kafka broker and scrape via OpenTelemetry Collector:
+
+```yaml
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: msk
+          static_configs:
+            - targets: ['<broker1>:11001', '<broker2>:11001']
+```
+
+## Variables
+- `{{deployment.environment}}`: Deployment environment

--- a/aws-msk-cluster/aws-msk-cluster-prometheus-v1.json
+++ b/aws-msk-cluster/aws-msk-cluster-prometheus-v1.json
@@ -1,0 +1,534 @@
+{
+  "description": "Monitor AWS MSK cluster health, topics, partitions and consumer lag",
+  "layout": [
+    {
+      "h": 6,
+      "i": "e8115ef1-5ac2-46a7-b4fb-f40874f0a982",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 6,
+      "i": "56db917e-115e-47fb-81e2-8ad7ca732150",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 0
+    },
+    {
+      "h": 6,
+      "i": "38d5ad75-f27e-4afe-a122-63f1ec6d7c6e",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 0
+    },
+    {
+      "h": 6,
+      "i": "41038d84-dc96-4164-b490-0e78dabe6fe5",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 6
+    },
+    {
+      "h": 6,
+      "i": "2e61c8fd-0b98-4dd5-b77e-938440bb66ee",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 6
+    },
+    {
+      "h": 6,
+      "i": "9c45a8fe-96cb-4178-b88c-baaa9afae472",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 6
+    },
+    {
+      "h": 6,
+      "i": "3f9f4ad8-154b-4207-9b7e-a7ac75673d27",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 12
+    },
+    {
+      "h": 6,
+      "i": "3c0b259d-3606-4fcc-b817-c3c59d64598c",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 12
+    },
+    {
+      "h": 6,
+      "i": "7fb6ab2b-c365-411d-ad77-67b9af4cb2d7",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 12
+    },
+    {
+      "h": 6,
+      "i": "baff20ae-04c4-4458-a07e-9204a7f7ddc9",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 18
+    },
+    {
+      "h": 6,
+      "i": "2ff71bd5-cc29-402a-8857-66ea806c6274",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 18
+    }
+  ],
+  "name": "",
+  "panelMap": {},
+  "tags": [],
+  "title": "AWS MSK Cluster",
+  "uploadedGrafana": false,
+  "variables": {
+    "834d19ec-41cf-432d-b448-2d86d43cc855": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Deployment environment",
+      "id": "834d19ec-41cf-432d-b448-2d86d43cc855",
+      "modificationUUID": "40db2d15-88ab-4d4a-ba02-bc53a8abcdd9",
+      "multiSelect": false,
+      "name": "deployment.environment",
+      "order": 0,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'deployment.environment')) as `deployment.environment`\nFROM signoz_metrics.time_series_v4\nWHERE metric_name LIKE '%kafka%'\nAND (unix_milli >= $__unixMilliStart() AND unix_milli <= $__unixMilliEnd())",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "version": "v4",
+  "widgets": [
+    {
+      "description": "CPU utilization per broker",
+      "fillSpans": false,
+      "id": "e8115ef1-5ac2-46a7-b4fb-f40874f0a982",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "88c74394-a1dd-4338-81cf-9eb24cb78954",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{instance}}",
+            "name": "A",
+            "query": "avg(kafka_server_BrokerTopicMetrics_CpuPercent{deployment_environment=\"$deployment_environment\"}) by (instance)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Broker CPU Usage",
+      "yAxisUnit": "percent"
+    },
+    {
+      "description": "Memory consumption per broker",
+      "fillSpans": false,
+      "id": "56db917e-115e-47fb-81e2-8ad7ca732150",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6f1655c3-8907-4265-a4d9-33ca0b42c94c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{instance}}",
+            "name": "A",
+            "query": "avg(process_resident_memory_bytes{deployment_environment=\"$deployment_environment\", job=~\".*kafka.*\"}) by (instance)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Broker Memory Usage",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "Network bytes in per broker",
+      "fillSpans": false,
+      "id": "38d5ad75-f27e-4afe-a122-63f1ec6d7c6e",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "7baa29f3-f2ea-421d-9fa6-05fc24ec3a29",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{instance}}",
+            "name": "A",
+            "query": "sum(rate(kafka_network_request_bytes_total{deployment_environment=\"$deployment_environment\"}[$__rate_interval])) by (instance)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Network In",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "Network bytes out per broker",
+      "fillSpans": false,
+      "id": "41038d84-dc96-4164-b490-0e78dabe6fe5",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b57c7e1c-07ac-46d5-a420-4a2de0a82d8e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{instance}}",
+            "name": "A",
+            "query": "sum(rate(kafka_network_response_bytes_total{deployment_environment=\"$deployment_environment\"}[$__rate_interval])) by (instance)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Network Out",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "Disk space used per broker",
+      "fillSpans": false,
+      "id": "2e61c8fd-0b98-4dd5-b77e-938440bb66ee",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d7f8d9f7-3686-46a4-a48d-9a64ccc6e436",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{instance}}",
+            "name": "A",
+            "query": "sum(kafka_log_log_Size{deployment_environment=\"$deployment_environment\"}) by (instance)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Disk Usage",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "Messages produced per topic",
+      "fillSpans": false,
+      "id": "9c45a8fe-96cb-4178-b88c-baaa9afae472",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f6ca23f1-45ff-4060-8880-9fe03e658691",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{topic}}",
+            "name": "A",
+            "query": "sum(rate(kafka_server_BrokerTopicMetrics_MessagesInPerSec{deployment_environment=\"$deployment_environment\"}[$__rate_interval])) by (topic)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Messages In Per Sec",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Data produced per topic",
+      "fillSpans": false,
+      "id": "3f9f4ad8-154b-4207-9b7e-a7ac75673d27",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "1cfc010f-420a-46b7-914d-cf267665afe1",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{topic}}",
+            "name": "A",
+            "query": "sum(rate(kafka_server_BrokerTopicMetrics_BytesInPerSec{deployment_environment=\"$deployment_environment\"}[$__rate_interval])) by (topic)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Bytes In Per Sec",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "Data consumed per topic",
+      "fillSpans": false,
+      "id": "3c0b259d-3606-4fcc-b817-c3c59d64598c",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "2fdb4643-19c0-43d8-a270-3233d11d93fc",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{topic}}",
+            "name": "A",
+            "query": "sum(rate(kafka_server_BrokerTopicMetrics_BytesOutPerSec{deployment_environment=\"$deployment_environment\"}[$__rate_interval])) by (topic)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Bytes Out Per Sec",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "Count of under-replicated partitions",
+      "fillSpans": false,
+      "id": "7fb6ab2b-c365-411d-ad77-67b9af4cb2d7",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6e3a8440-4a7f-4b85-8d7b-6f4ae962cda5",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "kafka_controller_under_replicated_partitions{deployment_environment=\"$deployment_environment\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Under-Replicated Partitions",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Number of partitions per broker",
+      "fillSpans": false,
+      "id": "baff20ae-04c4-4458-a07e-9204a7f7ddc9",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "84b3a021-1aed-4d4d-bcd3-08923d88c5bb",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "kafka_server_replicamanager_partitioncount{deployment_environment=\"$deployment_environment\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Partition Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Consumer group lag by topic",
+      "fillSpans": false,
+      "id": "2ff71bd5-cc29-402a-8857-66ea806c6274",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d2a14a38-0f08-47a0-aee0-8c288d954d41",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{consumergroup}} - {{topic}}",
+            "name": "A",
+            "query": "sum(kafka_consumer_group_lag{deployment_environment=\"$deployment_environment\"}) by (consumergroup, topic)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Consumer Group Lag",
+      "yAxisUnit": "none"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds an AWS MSK Cluster monitoring dashboard with panels for:
- Broker metrics (CPU, memory, network, disk)
- Topic metrics (messages, bytes in/out)
- Partition metrics (under-replicated, partition count)
- Consumer metrics (consumer group lag)

Closes /claim #6036