### PR TITLE
Add Kafka Server Monitoring Dashboard

### DIFF
--- a/kafka-server/README.md
+++ b/kafka-server/README.md
@@ -1,0 +1,22 @@
+# Kafka Server Monitoring Dashboard - Prometheus
+
+## Overview
+Monitor Kafka server health, topics, partitions and consumer groups using OTel Kafka metrics receiver.
+
+## Metrics Ingestion
+Use the OpenTelemetry Kafka metrics receiver:
+
+```yaml
+receivers:
+  kafkametrics:
+    brokers:
+      - <kafka-broker>:9092
+    scrapers:
+      - brokers
+      - topics
+      - consumers
+```
+
+## Variables
+- `{{deployment.environment}}`: Deployment environment
+- `{{kafka.cluster.alias}}`: Kafka cluster alias

--- a/kafka-server/kafka-server-prometheus-v1.json
+++ b/kafka-server/kafka-server-prometheus-v1.json
@@ -1,0 +1,593 @@
+{
+  "description": "Monitor Kafka server health, topics, partitions and consumer groups using OTel Kafka metrics receiver",
+  "layout": [
+    {
+      "h": 6,
+      "i": "20888abb-cefa-48cf-af97-a4556bd6dc5e",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 6,
+      "i": "af624df9-e753-4cf5-8b47-03c42487eb3f",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 0
+    },
+    {
+      "h": 6,
+      "i": "8bb40537-613e-4688-9cec-fe002a1b580e",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 0
+    },
+    {
+      "h": 6,
+      "i": "4c2d7b7b-9036-4eb7-8998-ace4cc278411",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 6
+    },
+    {
+      "h": 6,
+      "i": "577b8ee0-07ec-47ec-a822-0c0abfcea99c",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 6
+    },
+    {
+      "h": 6,
+      "i": "3ca644de-0fdd-486b-b31e-7058cf45507f",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 6
+    },
+    {
+      "h": 6,
+      "i": "8fe0cc6b-9fa8-4e83-86b7-a403d94a3ceb",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 12
+    },
+    {
+      "h": 6,
+      "i": "e5a0787f-297d-453a-9836-d79df4d2d97e",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 12
+    },
+    {
+      "h": 6,
+      "i": "64362de7-cf2a-4159-b907-a86404840b74",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 12
+    },
+    {
+      "h": 6,
+      "i": "3b80d969-25c5-4b1b-aecc-6708dad118d4",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 18
+    },
+    {
+      "h": 6,
+      "i": "075d3baf-038b-40d6-a088-6189d07b305f",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 18
+    },
+    {
+      "h": 6,
+      "i": "d888b4a3-9593-436b-8d58-f652bb7c73d6",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 18
+    }
+  ],
+  "name": "",
+  "panelMap": {},
+  "tags": [],
+  "title": "Kafka Server Monitoring",
+  "uploadedGrafana": false,
+  "variables": {
+    "121bf940-c0a6-4e40-9fe7-23f6cc252ee7": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Deployment environment",
+      "id": "121bf940-c0a6-4e40-9fe7-23f6cc252ee7",
+      "modificationUUID": "aaeb85cb-3db3-4c5b-a44e-2077ba680e07",
+      "multiSelect": false,
+      "name": "deployment.environment",
+      "order": 0,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'deployment.environment')) as `deployment.environment`\nFROM signoz_metrics.time_series_v4\nWHERE metric_name LIKE '%kafka%'\nAND (unix_milli >= $__unixMilliStart() AND unix_milli <= $__unixMilliEnd())",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "2c0b2416-f14b-4b98-a78b-f0a82e9593ca": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Kafka cluster alias",
+      "id": "2c0b2416-f14b-4b98-a78b-f0a82e9593ca",
+      "modificationUUID": "ca6b57eb-07e8-4c48-803d-6e1d0bb041d8",
+      "multiSelect": false,
+      "name": "kafka.cluster.alias",
+      "order": 1,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'kafka_cluster_alias')) as `kafka.cluster.alias`\nFROM signoz_metrics.time_series_v4\nWHERE metric_name LIKE '%kafka%'\nAND (unix_milli >= $__unixMilliStart() AND unix_milli <= $__unixMilliEnd())",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "version": "v4",
+  "widgets": [
+    {
+      "description": "Number of brokers per cluster",
+      "fillSpans": false,
+      "id": "20888abb-cefa-48cf-af97-a4556bd6dc5e",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "stat",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8aac341e-796e-4526-ad3e-b097ad0a1ec3",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{kafka_cluster_alias}}",
+            "name": "A",
+            "query": "count(kafka_server_BrokerTopicMetrics_count{deployment_environment=\"$deployment_environment\"}) by (kafka_cluster_alias)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Broker Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Under-replicated partitions per cluster",
+      "fillSpans": false,
+      "id": "af624df9-e753-4cf5-8b47-03c42487eb3f",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "3c7acff3-b484-4009-b43e-574411834244",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{kafka_cluster_alias}}",
+            "name": "A",
+            "query": "sum(kafka_controller_under_replicated_partitions{deployment_environment=\"$deployment_environment\"}) by (kafka_cluster_alias)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Under-Replicated Partitions",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Offline partitions per cluster",
+      "fillSpans": false,
+      "id": "8bb40537-613e-4688-9cec-fe002a1b580e",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f2838794-90be-4bea-808c-6792d4c03487",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{kafka_cluster_alias}}",
+            "name": "A",
+            "query": "sum(kafka_controller_offlinepartitionscount{deployment_environment=\"$deployment_environment\"}) by (kafka_cluster_alias)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Offline Partitions",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Active controller count",
+      "fillSpans": false,
+      "id": "4c2d7b7b-9036-4eb7-8998-ace4cc278411",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "942f1ce1-25db-49cd-85ca-ddef9542ea7e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{kafka_cluster_alias}}",
+            "name": "A",
+            "query": "sum(kafka_controller_activecontrollercount{deployment_environment=\"$deployment_environment\"}) by (kafka_cluster_alias)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Controller Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Messages per topic",
+      "fillSpans": false,
+      "id": "577b8ee0-07ec-47ec-a822-0c0abfcea99c",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "7ad36b7a-3e0b-4292-807c-628f53e49bb2",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{topic}}",
+            "name": "A",
+            "query": "sum(rate(kafka_server_BrokerTopicMetrics_MessagesInPerSec{deployment_environment=\"$deployment_environment\"}[$__rate_interval])) by (topic)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Messages In Per Sec",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Data produced per topic",
+      "fillSpans": false,
+      "id": "3ca644de-0fdd-486b-b31e-7058cf45507f",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "05968f95-5f09-4a2f-8d68-856bfcb04d12",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{topic}}",
+            "name": "A",
+            "query": "sum(rate(kafka_server_BrokerTopicMetrics_BytesInPerSec{deployment_environment=\"$deployment_environment\"}[$__rate_interval])) by (topic)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Bytes In Per Sec",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "Data consumed per topic",
+      "fillSpans": false,
+      "id": "8fe0cc6b-9fa8-4e83-86b7-a403d94a3ceb",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f7707893-636f-417e-b7b9-25a3ab2cd36a",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{topic}}",
+            "name": "A",
+            "query": "sum(rate(kafka_server_BrokerTopicMetrics_BytesOutPerSec{deployment_environment=\"$deployment_environment\"}[$__rate_interval])) by (topic)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Bytes Out Per Sec",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "Network request rate by type",
+      "fillSpans": false,
+      "id": "e5a0787f-297d-453a-9836-d79df4d2d97e",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "198bb0d2-c064-42ed-bc78-70bf71f46707",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{request_type}}",
+            "name": "A",
+            "query": "sum(rate(kafka_network_request_total{deployment_environment=\"$deployment_environment\"}[$__rate_interval])) by (request_type)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Rate",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Consumer group lag",
+      "fillSpans": false,
+      "id": "64362de7-cf2a-4159-b907-a86404840b74",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "2d645a94-2f45-4927-8cdb-a09d44b9744e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{consumergroup}} - {{topic}}",
+            "name": "A",
+            "query": "sum(kafka_consumergroup_lag{deployment_environment=\"$deployment_environment\"}) by (consumergroup, topic)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Consumer Group Lag",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Request latency percentiles",
+      "fillSpans": false,
+      "id": "3b80d969-25c5-4b1b-aecc-6708dad118d4",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "2649d79c-a95a-4600-84c3-659f274f4f5e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "P50 - {{request_type}}",
+            "name": "A",
+            "query": "histogram_quantile(0.50, sum(rate(kafka_network_request_latency_seconds_bucket{deployment_environment=\"$deployment_environment\"}[$__rate_interval])) by (le, request_type))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Latency P50/P99",
+      "yAxisUnit": "seconds"
+    },
+    {
+      "description": "Partitions per cluster",
+      "fillSpans": false,
+      "id": "075d3baf-038b-40d6-a088-6189d07b305f",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0c5312aa-d92a-4891-a01d-e8902a3f53f7",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{kafka_cluster_alias}}",
+            "name": "A",
+            "query": "sum(kafka_server_replicamanager_partitioncount{deployment_environment=\"$deployment_environment\"}) by (kafka_cluster_alias)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Partition Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Producer request rate by topic",
+      "fillSpans": false,
+      "id": "d888b4a3-9593-436b-8d58-f652bb7c73d6",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "4f0de9dd-25f0-4553-816d-ad82fd0b56dd",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{topic}}",
+            "name": "A",
+            "query": "sum(rate(kafka_producer_request_total{deployment_environment=\"$deployment_environment\"}[$__rate_interval])) by (topic)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Producer Request Rate",
+      "yAxisUnit": "none"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds a Kafka Server monitoring dashboard using OTel Kafka metrics receiver with panels for:
- Broker metrics (count, under-replicated, offline partitions)
- Topic metrics (messages, bytes in/out)
- Consumer metrics (consumer group lag)
- Network and request metrics

Closes /claim #6026