### PR TITLE
Add AWS MSK Cluster Monitoring Dashboard (OTLP v1)

### DIFF
--- a/aws-msk/README.md
+++ b/aws-msk/README.md
@@ -1,0 +1,100 @@
+# AWS MSK Cluster Dashboard - OTLP
+
+Comprehensive monitoring dashboard for AWS Managed Streaming for Apache Kafka (MSK) clusters using CloudWatch metrics collected via OpenTelemetry.
+
+## Metrics Ingestion
+
+This dashboard uses AWS CloudWatch metrics collected via the OpenTelemetry Collector's `awscloudwatch` receiver (or the AWS CloudWatch exporter). Metrics follow the `aws_kafka_*` naming convention from the `AWS/Kafka` CloudWatch namespace.
+
+### OpenTelemetry Collector Configuration
+
+Add the following to your `otel-collector-config.yaml`:
+
+```yaml
+receivers:
+  awscloudwatch:
+    region: us-east-1
+    poll_interval: 5m
+    metrics:
+      named:
+        AWS/Kafka:
+          - metric_name: CpuUser
+          - metric_name: CpuSystem
+          - metric_name: MemoryUsed
+          - metric_name: MemoryFree
+          - metric_name: KafkaDataLogsDiskUsed
+          - metric_name: BytesInPerSec
+          - metric_name: BytesOutPerSec
+          - metric_name: MessagesInPerSec
+          - metric_name: ProduceTotalTimeMsMean
+          - metric_name: UnderReplicatedPartitions
+          - metric_name: OfflinePartitionsCount
+          - metric_name: ActiveControllerCount
+          - metric_name: PartitionCount
+          - metric_name: LeaderCount
+          - metric_name: SumOffsetLag
+          - metric_name: EstimatedMaxTimeLag
+          - metric_name: BurstBalance
+          - metric_name: CpuCreditUsage
+          - metric_name: TrafficShaping
+          - metric_name: ConnectionCount
+          - metric_name: HeapMemoryAfterGC
+          - metric_name: NetworkRxPackets
+          - metric_name: NetworkTxPackets
+          - metric_name: VolumeReadBytes
+          - metric_name: VolumeWriteBytes
+
+exporters:
+  otlp:
+    endpoint: "<signoz-otel-collector-endpoint>:4317"
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    metrics:
+      receivers: [awscloudwatch]
+      exporters: [otlp]
+```
+
+## Variables
+
+- `{{cluster_name}}`: MSK cluster name
+- `{{broker_id}}`: Broker ID (multi-select)
+- `{{deployment.environment}}`: Deployment environment
+
+## Dashboard Panels
+
+### Section: Broker Metrics
+- **Broker CPU Usage (User)** - CPU percentage in user space per broker (`aws_kafka_cpu_user_average`)
+- **Broker CPU Usage (System)** - CPU percentage in kernel space per broker (`aws_kafka_cpu_system_average`)
+- **Broker Memory Usage** - Memory in use (bytes) per broker (`aws_kafka_memory_used_average`)
+- **Broker Memory Free** - Free memory (bytes) per broker (`aws_kafka_memory_free_average`)
+- **Broker Disk Usage (Data Logs)** - Percentage of disk used for data logs (`aws_kafka_kafka_data_logs_disk_used_average`)
+- **Broker Disk Throughput** - Read/write bytes per broker (`aws_kafka_volume_read_bytes_sum`, `aws_kafka_volume_write_bytes_sum`)
+- **Network Traffic In (Packets)** - Network packets received per broker (`aws_kafka_network_rx_packets_sum`)
+- **Network Traffic Out (Packets)** - Network packets transmitted per broker (`aws_kafka_network_tx_packets_sum`)
+
+### Section: Topic Metrics
+- **Bytes In Per Second** - Bytes received from producers per broker (`aws_kafka_bytes_in_per_sec_average`)
+- **Bytes Out Per Second** - Bytes sent to consumers per broker (`aws_kafka_bytes_out_per_sec_average`)
+- **Messages In Per Second** - Incoming messages per second per broker (`aws_kafka_messages_in_per_sec_average`)
+- **Produce Total Time (Mean)** - Mean produce latency in milliseconds (`aws_kafka_produce_total_time_ms_mean_average`)
+
+### Section: Partition Metrics
+- **Under-Replicated Partitions** - Count of under-replicated partitions (`aws_kafka_under_replicated_partitions_average`)
+- **Offline Partitions Count** - Total offline partitions (`aws_kafka_offline_partitions_count_average`)
+- **Active Controller Count** - Number of active controllers (`aws_kafka_active_controller_count_average`)
+- **Partition Count** - Total partitions per broker including replicas (`aws_kafka_partition_count_average`)
+- **Leader Count** - Partition leaders per broker (`aws_kafka_leader_count_average`)
+
+### Section: Consumer Metrics
+- **Consumer Lag (Sum Offset Lag)** - Aggregated offset lag by consumer group and topic (`aws_kafka_sum_offset_lag_average`)
+- **Estimated Max Time Lag** - Time estimate to drain max offset lag (`aws_kafka_estimated_max_time_lag_average`)
+
+### Section: AWS Metrics (CloudWatch Integration)
+- **Burst Balance** - EBS burst credit balance per broker (`aws_kafka_burst_balance_average`)
+- **CPU Credit Usage** - CPU credits spent (burstable instances) (`aws_kafka_cpu_credit_usage_average`)
+- **Traffic Shaping** - Packets shaped due to network limits (`aws_kafka_traffic_shaping_sum`)
+- **Connection Count** - Total active connections per broker (`aws_kafka_connection_count_average`)
+- **Heap Memory After GC** - JVM heap usage post-GC per broker (`aws_kafka_heap_memory_after_gc_average`)

--- a/aws-msk/aws-msk-otlp-v1.json
+++ b/aws-msk/aws-msk-otlp-v1.json
@@ -1,0 +1,2629 @@
+{
+  "id": "aws-msk-cluster-overview",
+  "description": "Comprehensive monitoring dashboard for AWS MSK (Managed Streaming for Apache Kafka) clusters using CloudWatch metrics collected via OpenTelemetry.",
+  "layout": [
+    {"h": 1, "i": "row-broker", "maxH": 1, "minH": 1, "minW": 12, "moved": false, "static": false, "w": 12, "x": 0, "y": 0},
+    {"h": 5, "i": "p-cpu-user", "moved": false, "static": false, "w": 6, "x": 0, "y": 1},
+    {"h": 5, "i": "p-cpu-system", "moved": false, "static": false, "w": 6, "x": 6, "y": 1},
+    {"h": 5, "i": "p-memory-used", "moved": false, "static": false, "w": 6, "x": 0, "y": 6},
+    {"h": 5, "i": "p-memory-free", "moved": false, "static": false, "w": 6, "x": 6, "y": 6},
+    {"h": 5, "i": "p-disk-usage", "moved": false, "static": false, "w": 6, "x": 0, "y": 11},
+    {"h": 5, "i": "p-disk-throughput-read", "moved": false, "static": false, "w": 6, "x": 6, "y": 11},
+    {"h": 5, "i": "p-network-rx", "moved": false, "static": false, "w": 6, "x": 0, "y": 16},
+    {"h": 5, "i": "p-network-tx", "moved": false, "static": false, "w": 6, "x": 6, "y": 16},
+    {"h": 1, "i": "row-topic", "maxH": 1, "minH": 1, "minW": 12, "moved": false, "static": false, "w": 12, "x": 0, "y": 21},
+    {"h": 5, "i": "p-bytes-in", "moved": false, "static": false, "w": 6, "x": 0, "y": 22},
+    {"h": 5, "i": "p-bytes-out", "moved": false, "static": false, "w": 6, "x": 6, "y": 22},
+    {"h": 5, "i": "p-messages-in", "moved": false, "static": false, "w": 6, "x": 0, "y": 27},
+    {"h": 5, "i": "p-produce-time", "moved": false, "static": false, "w": 6, "x": 6, "y": 27},
+    {"h": 1, "i": "row-partition", "maxH": 1, "minH": 1, "minW": 12, "moved": false, "static": false, "w": 12, "x": 0, "y": 32},
+    {"h": 5, "i": "p-under-replicated", "moved": false, "static": false, "w": 4, "x": 0, "y": 33},
+    {"h": 5, "i": "p-offline-partitions", "moved": false, "static": false, "w": 4, "x": 4, "y": 33},
+    {"h": 5, "i": "p-active-controller", "moved": false, "static": false, "w": 4, "x": 8, "y": 33},
+    {"h": 5, "i": "p-partition-count", "moved": false, "static": false, "w": 6, "x": 0, "y": 38},
+    {"h": 5, "i": "p-leader-count", "moved": false, "static": false, "w": 6, "x": 6, "y": 38},
+    {"h": 1, "i": "row-consumer", "maxH": 1, "minH": 1, "minW": 12, "moved": false, "static": false, "w": 12, "x": 0, "y": 43},
+    {"h": 5, "i": "p-consumer-lag", "moved": false, "static": false, "w": 6, "x": 0, "y": 44},
+    {"h": 5, "i": "p-consumer-time-lag", "moved": false, "static": false, "w": 6, "x": 6, "y": 44},
+    {"h": 1, "i": "row-aws", "maxH": 1, "minH": 1, "minW": 12, "moved": false, "static": false, "w": 12, "x": 0, "y": 49},
+    {"h": 5, "i": "p-burst-balance", "moved": false, "static": false, "w": 4, "x": 0, "y": 50},
+    {"h": 5, "i": "p-cpu-credit", "moved": false, "static": false, "w": 4, "x": 4, "y": 50},
+    {"h": 5, "i": "p-traffic-shaping", "moved": false, "static": false, "w": 4, "x": 8, "y": 50},
+    {"h": 5, "i": "p-connection-count", "moved": false, "static": false, "w": 6, "x": 0, "y": 55},
+    {"h": 5, "i": "p-heap-memory", "moved": false, "static": false, "w": 6, "x": 6, "y": 55}
+  ],
+  "panelMap": {
+    "row-broker": {
+      "collapsed": false,
+      "widgets": [
+        {"h": 5, "i": "p-cpu-user", "moved": false, "static": false, "w": 6, "x": 0, "y": 1},
+        {"h": 5, "i": "p-cpu-system", "moved": false, "static": false, "w": 6, "x": 6, "y": 1},
+        {"h": 5, "i": "p-memory-used", "moved": false, "static": false, "w": 6, "x": 0, "y": 6},
+        {"h": 5, "i": "p-memory-free", "moved": false, "static": false, "w": 6, "x": 6, "y": 6},
+        {"h": 5, "i": "p-disk-usage", "moved": false, "static": false, "w": 6, "x": 0, "y": 11},
+        {"h": 5, "i": "p-disk-throughput-read", "moved": false, "static": false, "w": 6, "x": 6, "y": 11},
+        {"h": 5, "i": "p-network-rx", "moved": false, "static": false, "w": 6, "x": 0, "y": 16},
+        {"h": 5, "i": "p-network-tx", "moved": false, "static": false, "w": 6, "x": 6, "y": 16}
+      ]
+    },
+    "row-topic": {
+      "collapsed": false,
+      "widgets": [
+        {"h": 5, "i": "p-bytes-in", "moved": false, "static": false, "w": 6, "x": 0, "y": 22},
+        {"h": 5, "i": "p-bytes-out", "moved": false, "static": false, "w": 6, "x": 6, "y": 22},
+        {"h": 5, "i": "p-messages-in", "moved": false, "static": false, "w": 6, "x": 0, "y": 27},
+        {"h": 5, "i": "p-produce-time", "moved": false, "static": false, "w": 6, "x": 6, "y": 27}
+      ]
+    },
+    "row-partition": {
+      "collapsed": false,
+      "widgets": [
+        {"h": 5, "i": "p-under-replicated", "moved": false, "static": false, "w": 4, "x": 0, "y": 33},
+        {"h": 5, "i": "p-offline-partitions", "moved": false, "static": false, "w": 4, "x": 4, "y": 33},
+        {"h": 5, "i": "p-active-controller", "moved": false, "static": false, "w": 4, "x": 8, "y": 33},
+        {"h": 5, "i": "p-partition-count", "moved": false, "static": false, "w": 6, "x": 0, "y": 38},
+        {"h": 5, "i": "p-leader-count", "moved": false, "static": false, "w": 6, "x": 6, "y": 38}
+      ]
+    },
+    "row-consumer": {
+      "collapsed": false,
+      "widgets": [
+        {"h": 5, "i": "p-consumer-lag", "moved": false, "static": false, "w": 6, "x": 0, "y": 44},
+        {"h": 5, "i": "p-consumer-time-lag", "moved": false, "static": false, "w": 6, "x": 6, "y": 44}
+      ]
+    },
+    "row-aws": {
+      "collapsed": false,
+      "widgets": [
+        {"h": 5, "i": "p-burst-balance", "moved": false, "static": false, "w": 4, "x": 0, "y": 50},
+        {"h": 5, "i": "p-cpu-credit", "moved": false, "static": false, "w": 4, "x": 4, "y": 50},
+        {"h": 5, "i": "p-traffic-shaping", "moved": false, "static": false, "w": 4, "x": 8, "y": 50},
+        {"h": 5, "i": "p-connection-count", "moved": false, "static": false, "w": 6, "x": 0, "y": 55},
+        {"h": 5, "i": "p-heap-memory", "moved": false, "static": false, "w": 6, "x": 6, "y": 55}
+      ]
+    }
+  },
+  "tags": ["aws", "msk", "kafka", "streaming"],
+  "title": "AWS MSK Cluster",
+  "uploadedGrafana": false,
+  "variables": {
+    "var-cluster": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "Select the MSK cluster",
+      "id": "var-cluster",
+      "modificationUUID": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "multiSelect": false,
+      "name": "cluster_name",
+      "order": 0,
+      "queryValue": "SELECT JSONExtractString(labels, 'cluster_name') as cluster_name\nFROM signoz_metrics.distributed_time_series_v4_1day\nWHERE metric_name like 'aws_kafka_%'\nGROUP BY cluster_name",
+      "showALLOption": false,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "var-broker": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Select broker ID",
+      "id": "var-broker",
+      "modificationUUID": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+      "multiSelect": true,
+      "name": "broker_id",
+      "order": 1,
+      "queryValue": "SELECT JSONExtractString(labels, 'broker_id') as broker_id\nFROM signoz_metrics.distributed_time_series_v4_1day\nWHERE metric_name like 'aws_kafka_%'\nGROUP BY broker_id",
+      "selectedValue": [""],
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "var-environment": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "Deployment environment",
+      "id": "var-environment",
+      "modificationUUID": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+      "multiSelect": false,
+      "name": "deployment.environment",
+      "order": 2,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'deployment.environment')) as `deployment.environment`\nFROM signoz_metrics.distributed_time_series_v4_1day\nWHERE metric_name like 'aws_kafka_%'\nGROUP BY `deployment.environment`",
+      "showALLOption": false,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "version": "v4",
+  "widgets": [
+    {
+      "description": "",
+      "id": "row-broker",
+      "panelTypes": "row",
+      "title": "Broker Metrics"
+    },
+    {
+      "description": "Percentage of CPU in user space per broker. High values indicate compute-intensive workloads.",
+      "fillSpans": false,
+      "id": "p-cpu-user",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_cpu_user_average--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_cpu_user_average",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f-cluster-1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "f-broker-1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "broker_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "broker_id",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.broker_id}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "broker_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "broker_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Broker {{broker_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-cpu-user",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Broker CPU Usage (User)",
+      "yAxisUnit": "percent"
+    },
+    {
+      "description": "Percentage of CPU in kernel space per broker.",
+      "fillSpans": false,
+      "id": "p-cpu-system",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_cpu_system_average--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_cpu_system_average",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f-cluster-2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "f-broker-2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "broker_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "broker_id",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.broker_id}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "broker_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "broker_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Broker {{broker_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-cpu-system",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Broker CPU Usage (System)",
+      "yAxisUnit": "percent"
+    },
+    {
+      "description": "Memory in use (bytes) per broker. Monitor for memory pressure.",
+      "fillSpans": false,
+      "id": "p-memory-used",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_memory_used_average--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_memory_used_average",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f-cluster-3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "f-broker-3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "broker_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "broker_id",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.broker_id}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "broker_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "broker_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Broker {{broker_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-memory-used",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Broker Memory Usage",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "Free available memory (bytes) per broker.",
+      "fillSpans": false,
+      "id": "p-memory-free",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_memory_free_average--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_memory_free_average",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f-cluster-4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "f-broker-4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "broker_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "broker_id",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.broker_id}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "broker_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "broker_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Broker {{broker_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-memory-free",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Broker Memory Free",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "Percentage of disk space used for data logs per broker. Alert when approaching capacity.",
+      "fillSpans": false,
+      "id": "p-disk-usage",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_kafka_data_logs_disk_used_average--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_kafka_data_logs_disk_used_average",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f-cluster-5",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "f-broker-5",
+                    "key": {
+                      "dataType": "string",
+                      "id": "broker_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "broker_id",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.broker_id}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "broker_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "broker_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Broker {{broker_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-disk-usage",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Broker Disk Usage (Data Logs)",
+      "yAxisUnit": "percent"
+    },
+    {
+      "description": "Disk read throughput (bytes) per broker.",
+      "fillSpans": false,
+      "id": "p-disk-throughput-read",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_volume_read_bytes_sum--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_volume_read_bytes_sum",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f-cluster-6a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "f-broker-6a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "broker_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "broker_id",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.broker_id}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "broker_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "broker_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Read - Broker {{broker_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_volume_write_bytes_sum--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_volume_write_bytes_sum",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f-cluster-6b",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "f-broker-6b",
+                    "key": {
+                      "dataType": "string",
+                      "id": "broker_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "broker_id",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.broker_id}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "broker_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "broker_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Write - Broker {{broker_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-disk-throughput",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Broker Disk Throughput (Read/Write)",
+      "yAxisUnit": "binBps"
+    },
+    {
+      "description": "Number of network packets received per broker.",
+      "fillSpans": false,
+      "id": "p-network-rx",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_network_rx_packets_sum--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_network_rx_packets_sum",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f-cluster-7",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "f-broker-7",
+                    "key": {
+                      "dataType": "string",
+                      "id": "broker_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "broker_id",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.broker_id}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "broker_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "broker_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "RX Broker {{broker_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-network-rx",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Network Traffic In (Packets)",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Number of network packets transmitted per broker.",
+      "fillSpans": false,
+      "id": "p-network-tx",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_network_tx_packets_sum--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_network_tx_packets_sum",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f-cluster-8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "f-broker-8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "broker_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "broker_id",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.broker_id}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "broker_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "broker_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "TX Broker {{broker_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-network-tx",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Network Traffic Out (Packets)",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "id": "row-topic",
+      "panelTypes": "row",
+      "title": "Topic Metrics"
+    },
+    {
+      "description": "Bytes per second received from clients (producers) per broker. Indicates write throughput.",
+      "fillSpans": false,
+      "id": "p-bytes-in",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_bytes_in_per_sec_average--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_bytes_in_per_sec_average",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f-cluster-9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "f-broker-9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "broker_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "broker_id",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.broker_id}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "broker_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "broker_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Broker {{broker_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-bytes-in",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Bytes In Per Second",
+      "yAxisUnit": "binBps"
+    },
+    {
+      "description": "Bytes per second sent to clients (consumers) per broker. Indicates read throughput.",
+      "fillSpans": false,
+      "id": "p-bytes-out",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_bytes_out_per_sec_average--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_bytes_out_per_sec_average",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f-cluster-10",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "f-broker-10",
+                    "key": {
+                      "dataType": "string",
+                      "id": "broker_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "broker_id",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.broker_id}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "broker_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "broker_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Broker {{broker_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-bytes-out",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Bytes Out Per Second",
+      "yAxisUnit": "binBps"
+    },
+    {
+      "description": "Number of incoming messages per second per broker.",
+      "fillSpans": false,
+      "id": "p-messages-in",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_messages_in_per_sec_average--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_messages_in_per_sec_average",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f-cluster-11",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "f-broker-11",
+                    "key": {
+                      "dataType": "string",
+                      "id": "broker_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "broker_id",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.broker_id}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "broker_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "broker_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Broker {{broker_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-messages-in",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Messages In Per Second",
+      "yAxisUnit": "ops"
+    },
+    {
+      "description": "Mean produce time (ms) per broker. Indicates write latency.",
+      "fillSpans": false,
+      "id": "p-produce-time",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_produce_total_time_ms_mean_average--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_produce_total_time_ms_mean_average",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f-cluster-12",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "f-broker-12",
+                    "key": {
+                      "dataType": "string",
+                      "id": "broker_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "broker_id",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.broker_id}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "broker_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "broker_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Broker {{broker_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-produce-time",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Produce Total Time (Mean)",
+      "yAxisUnit": "ms"
+    },
+    {
+      "description": "",
+      "id": "row-partition",
+      "panelTypes": "row",
+      "title": "Partition Metrics"
+    },
+    {
+      "description": "Count of under-replicated partitions per broker. Non-zero values indicate replication issues.",
+      "fillSpans": false,
+      "id": "p-under-replicated",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_under_replicated_partitions_average--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_under_replicated_partitions_average",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f-cluster-13",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "f-broker-13",
+                    "key": {
+                      "dataType": "string",
+                      "id": "broker_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "broker_id",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.broker_id}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "broker_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "broker_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Broker {{broker_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-under-replicated",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Under-Replicated Partitions",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Total number of offline partitions in the cluster. Should always be zero.",
+      "fillSpans": false,
+      "id": "p-offline-partitions",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_offline_partitions_count_average--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_offline_partitions_count_average",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f-cluster-14",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Offline Partitions",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-offline-partitions",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Offline Partitions Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Number of active controllers in the cluster. Only one should be active at any time.",
+      "fillSpans": false,
+      "id": "p-active-controller",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_active_controller_count_average--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_active_controller_count_average",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f-cluster-15",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Active Controllers",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-active-controller",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Controller Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Total topic partitions per broker (including replicas).",
+      "fillSpans": false,
+      "id": "p-partition-count",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_partition_count_average--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_partition_count_average",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f-cluster-16",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "f-broker-16",
+                    "key": {
+                      "dataType": "string",
+                      "id": "broker_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "broker_id",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.broker_id}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "broker_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "broker_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Broker {{broker_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-partition-count",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Partition Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Total partition leaders per broker. Uneven distribution may indicate load imbalance.",
+      "fillSpans": false,
+      "id": "p-leader-count",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_leader_count_average--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_leader_count_average",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f-cluster-17",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "f-broker-17",
+                    "key": {
+                      "dataType": "string",
+                      "id": "broker_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "broker_id",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.broker_id}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "broker_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "broker_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Broker {{broker_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-leader-count",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Leader Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "id": "row-consumer",
+      "panelTypes": "row",
+      "title": "Consumer Metrics"
+    },
+    {
+      "description": "Aggregated offset lag for all partitions in a topic by consumer group.",
+      "fillSpans": false,
+      "id": "p-consumer-lag",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_sum_offset_lag_average--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_sum_offset_lag_average",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f-cluster-18",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "consumer_group--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "consumer_group",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "topic--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "topic",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{consumer_group}} / {{topic}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-consumer-lag",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Consumer Lag (Sum Offset Lag)",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Estimated time (seconds) to drain the maximum offset lag per consumer group and topic.",
+      "fillSpans": false,
+      "id": "p-consumer-time-lag",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_estimated_max_time_lag_average--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_estimated_max_time_lag_average",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f-cluster-19",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "consumer_group--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "consumer_group",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "topic--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "topic",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{consumer_group}} / {{topic}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "max",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-consumer-time-lag",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Estimated Max Time Lag",
+      "yAxisUnit": "s"
+    },
+    {
+      "description": "",
+      "id": "row-aws",
+      "panelTypes": "row",
+      "title": "AWS Metrics (CloudWatch Integration)"
+    },
+    {
+      "description": "Remaining EBS burst credit balance per broker. Low values may cause throttling.",
+      "fillSpans": false,
+      "id": "p-burst-balance",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_burst_balance_average--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_burst_balance_average",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f-cluster-20",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "f-broker-20",
+                    "key": {
+                      "dataType": "string",
+                      "id": "broker_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "broker_id",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.broker_id}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "broker_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "broker_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Broker {{broker_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-burst-balance",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Burst Balance",
+      "yAxisUnit": "percent"
+    },
+    {
+      "description": "CPU credits spent by broker (for burstable instance types like kafka.t3.small).",
+      "fillSpans": false,
+      "id": "p-cpu-credit",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_cpu_credit_usage_average--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_cpu_credit_usage_average",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f-cluster-21",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "f-broker-21",
+                    "key": {
+                      "dataType": "string",
+                      "id": "broker_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "broker_id",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.broker_id}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "broker_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "broker_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Broker {{broker_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-cpu-credit",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "CPU Credit Usage",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Packets shaped (dropped or queued) due to exceeding network allocation limits.",
+      "fillSpans": false,
+      "id": "p-traffic-shaping",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_traffic_shaping_sum--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_traffic_shaping_sum",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f-cluster-22",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "f-broker-22",
+                    "key": {
+                      "dataType": "string",
+                      "id": "broker_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "broker_id",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.broker_id}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "broker_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "broker_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Broker {{broker_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-traffic-shaping",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Traffic Shaping",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Total active connections (authenticated, unauthenticated, inter-broker) per broker.",
+      "fillSpans": false,
+      "id": "p-connection-count",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_connection_count_average--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_connection_count_average",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f-cluster-23",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "f-broker-23",
+                    "key": {
+                      "dataType": "string",
+                      "id": "broker_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "broker_id",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.broker_id}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "broker_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "broker_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Broker {{broker_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-connection-count",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Connection Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Percentage of total heap memory in use after garbage collection per broker.",
+      "fillSpans": false,
+      "id": "p-heap-memory",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_kafka_heap_memory_after_gc_average--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_kafka_heap_memory_after_gc_average",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f-cluster-24",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cluster_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cluster_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "f-broker-24",
+                    "key": {
+                      "dataType": "string",
+                      "id": "broker_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "broker_id",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.broker_id}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "broker_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "broker_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Broker {{broker_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q-heap-memory",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {"dataType": "string", "name": "body", "type": ""},
+        {"dataType": "string", "name": "timestamp", "type": ""}
+      ],
+      "selectedTracesFields": [
+        {"dataType": "string", "id": "serviceName--string--tag--true", "isColumn": true, "isJSON": false, "key": "serviceName", "type": "tag"},
+        {"dataType": "string", "id": "name--string--tag--true", "isColumn": true, "isJSON": false, "key": "name", "type": "tag"},
+        {"dataType": "float64", "id": "durationNano--float64--tag--true", "isColumn": true, "isJSON": false, "key": "durationNano", "type": "tag"},
+        {"dataType": "string", "id": "httpMethod--string--tag--true", "isColumn": true, "isJSON": false, "key": "httpMethod", "type": "tag"},
+        {"dataType": "string", "id": "responseStatusCode--string--tag--true", "isColumn": true, "isJSON": false, "key": "responseStatusCode", "type": "tag"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Heap Memory After GC",
+      "yAxisUnit": "percent"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds a comprehensive AWS MSK (Managed Streaming for Apache Kafka) cluster monitoring dashboard using CloudWatch metrics collected via OpenTelemetry
- Uses the **SigNoz Query Builder** (not PromQL) with `aws_kafka_*` metric names matching the CloudWatch `AWS/Kafka` namespace convention
- 24 panels organized into 5 collapsible sections: Broker Metrics, Topic Metrics, Partition Metrics, Consumer Metrics, and AWS CloudWatch Metrics
- Dashboard variables for `cluster_name`, `broker_id` (multi-select), and `deployment.environment`

### Panels

**Broker Metrics** (8 panels): CPU User/System, Memory Used/Free, Disk Usage (Data Logs), Disk Throughput (Read/Write), Network RX/TX Packets

**Topic Metrics** (4 panels): Bytes In/Out Per Second, Messages In Per Second, Produce Total Time Mean

**Partition Metrics** (5 panels): Under-Replicated Partitions, Offline Partitions Count, Active Controller Count, Partition Count, Leader Count

**Consumer Metrics** (2 panels): Consumer Lag (Sum Offset Lag), Estimated Max Time Lag

**AWS Metrics** (5 panels): Burst Balance, CPU Credit Usage, Traffic Shaping, Connection Count, Heap Memory After GC

### Key Differentiators from Other PRs

- Uses **Query Builder** (preferred per CONTRIBUTING.md) instead of PromQL
- Uses correct **`aws_kafka_*` CloudWatch metric naming** (matching ElastiCache/RDS pattern in this repo), not JMX/Prometheus metrics
- Follows the exact schema of recently-merged dashboards (panelMap sections, row panels, v4 format)
- All metric names verified against official AWS MSK CloudWatch documentation
- Includes complete OTel collector configuration in README

Fixes SigNoz/signoz#6036

## Test plan

- [ ] Import dashboard JSON into SigNoz instance
- [ ] Verify JSON parses correctly (validated with `python3 -m json.tool`)
- [ ] Confirm all 29 layout entries match 29 widget IDs
- [ ] Confirm all 24 graph panels are grouped under their respective panelMap sections
- [ ] Verify dashboard variables populate when `aws_kafka_*` metrics are present
- [ ] Verify panel queries render correctly with CloudWatch MSK metrics