### PR TITLE
Add cert-manager Prometheus monitoring dashboard v1

### DIFF
--- a/cert-manager/README.md
+++ b/cert-manager/README.md
@@ -1,0 +1,167 @@
+# cert-manager Monitoring Dashboard
+
+A comprehensive SigNoz dashboard for monitoring cert-manager in Kubernetes environments using Prometheus metrics.
+
+## Overview
+
+This dashboard provides complete visibility into cert-manager operations including certificate lifecycle management, issuance and renewal processes, error monitoring, and resource usage tracking.
+
+## Prerequisites
+
+- cert-manager deployed in your Kubernetes cluster with Prometheus monitoring enabled
+- SigNoz with Prometheus data source configured
+- The following cert-manager Prometheus metrics available:
+  - `certmanager_certificate_ready_status`
+  - `certmanager_certificate_expiration_timestamp_seconds`
+  - `certmanager_certificate_renewal_timestamp_seconds`
+  - `certmanager_http_acme_client_request_count`
+  - `certmanager_controller_sync_call_count`
+  - `process_cpu_seconds_total`
+  - `process_resident_memory_bytes`
+  - `process_start_time_seconds`
+  - `kube_pod_container_status_restarts_total`
+
+## Dashboard Sections
+
+### General Overview (4 panels)
+- **Total Certificates Issued**: Total number of certificates managed by cert-manager
+- **Active Certificates**: Certificates currently in Ready=True state
+- **Certificate Requests**: Count of HTTP ACME client requests
+- **Uptime**: cert-manager process uptime
+
+### Certificate Issuance (3 panels)
+- **Certificates Issued per Issuer**: Breakdown by issuer type (Let's Encrypt, CA, etc.)
+- **Issuance Rate**: Rate of certificate issuance operations
+- **Issuance Success Rate**: Success percentage for certificate issuance
+
+### Certificate Renewal (3 panels)
+- **Certificates Pending Renewal**: Certificates expiring within 30 days
+- **Renewal Success Rate**: Success rate of renewal operations
+- **Renewal Duration**: Time taken for certificate renewals
+
+### Error Metrics (3 panels)
+- **Certificate Issuance Errors**: Failed certificate issuance attempts
+- **Renewal Errors**: Controller sync errors during renewal
+- **API Server Errors**: HTTP 4xx/5xx errors from ACME API calls
+
+### Resource Usage (3 panels)
+- **CPU Usage**: CPU consumption of cert-manager process
+- **Memory Usage**: Memory consumption in bytes
+- **Pod Restarts**: Number of cert-manager pod restarts
+
+### API and Event Metrics (3 panels)
+- **API Request Rate**: Rate of HTTP ACME client requests
+- **Event Processing Rate**: Controller sync call frequency
+- **Failed API Requests**: Rate of failed API requests
+
+## Installation
+
+1. Import the dashboard JSON file (`cert-manager-prometheus-v1.json`) into SigNoz
+2. Ensure your Prometheus data source includes cert-manager metrics
+3. Verify cert-manager is running with monitoring enabled
+
+## Configuration
+
+### Enabling cert-manager Prometheus Metrics
+
+Ensure cert-manager is deployed with monitoring enabled:
+
+```yaml
+# In your cert-manager values.yaml or deployment
+prometheus:
+  enabled: true
+  servicemonitor:
+    enabled: true
+```
+
+### Required RBAC
+
+Make sure your monitoring setup has the necessary permissions to scrape cert-manager metrics:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: cert-manager-metrics
+  namespace: cert-manager
+  labels:
+    app: cert-manager
+spec:
+  selector:
+    app: cert-manager
+  ports:
+  - name: tcp-prometheus-servicemonitor
+    port: 9402
+    protocol: TCP
+    targetPort: 9402
+```
+
+## Metrics Reference
+
+### Core cert-manager Metrics
+
+| Metric | Description | Type |
+|--------|-------------|------|
+| `certmanager_certificate_ready_status` | Certificate ready status (0 or 1) | Gauge |
+| `certmanager_certificate_expiration_timestamp_seconds` | Certificate expiration time | Gauge |
+| `certmanager_certificate_renewal_timestamp_seconds` | Last renewal timestamp | Gauge |
+| `certmanager_http_acme_client_request_count` | ACME client request count | Counter |
+| `certmanager_http_acme_client_request_duration_seconds` | ACME request duration | Histogram |
+| `certmanager_controller_sync_call_count` | Controller sync operations | Counter |
+
+### Process Metrics
+
+| Metric | Description | Type |
+|--------|-------------|------|
+| `process_cpu_seconds_total` | CPU time consumed | Counter |
+| `process_resident_memory_bytes` | Memory usage in bytes | Gauge |
+| `process_start_time_seconds` | Process start time | Gauge |
+
+### Kubernetes Metrics
+
+| Metric | Description | Type |
+|--------|-------------|------|
+| `kube_pod_container_status_restarts_total` | Pod restart count | Counter |
+
+## Alerting Recommendations
+
+Consider setting up alerts for:
+
+1. **Certificate Expiry**: Certificates expiring within 7 days
+2. **Issuance Failures**: High rate of certificate issuance errors
+3. **API Errors**: Persistent ACME API failures
+4. **Memory Usage**: High memory consumption
+5. **Pod Restarts**: Frequent cert-manager restarts
+
+## Troubleshooting
+
+### Common Issues
+
+1. **No data showing**: Verify cert-manager metrics are being scraped by Prometheus
+2. **Missing panels**: Check if all required metrics are available in your environment
+3. **Incorrect values**: Ensure proper label matching in PromQL queries
+
+### Debugging Steps
+
+1. Check cert-manager pod logs:
+   ```bash
+   kubectl logs -n cert-manager deployment/cert-manager
+   ```
+
+2. Verify metrics endpoint:
+   ```bash
+   kubectl port-forward -n cert-manager svc/cert-manager-metrics 9402:9402
+   curl http://localhost:9402/metrics
+   ```
+
+3. Check Prometheus targets:
+   - Ensure cert-manager metrics endpoint is being scraped
+   - Verify ServiceMonitor configuration if using Prometheus Operator
+
+## Contributing
+
+This dashboard is part of the SigNoz community dashboards project. For issues or improvements, please contribute to the [SigNoz dashboards repository](https://github.com/SigNoz/dashboards).
+
+## License
+
+This dashboard is provided under the same license as the SigNoz project.

--- a/cert-manager/cert-manager-prometheus-v1.json
+++ b/cert-manager/cert-manager-prometheus-v1.json
@@ -1,0 +1,2053 @@
+{
+  "description": "Comprehensive cert-manager monitoring dashboard using Prometheus metrics for certificate lifecycle management",
+  "image": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTkgMUMxMy40MTgzIDEgMTcgNC41ODE3IDE3IDlDMTcgMTMuNDE4MyAxMy40MTgzIDE3IDkgMTdDNC41ODE3IDE3IDEgMTMuNDE4MyAxIDlDMSA0LjU4MTcgNC41ODE3IDEgOSAxWk05IDNDNS42ODYzIDMgMyA1LjY4NjMgMyA5QzMgMTIuMzEzNyA1LjY4NjMgMTUgOSAxNUMxMi4zMTM3IDE1IDE1IDEyLjMxMzcgMTUgOUMxNSA1LjY4NjMgMTIuMzEzNyAzIDkgM1oiIGZpbGw9IiMxOEE1NTgiLz4KPHBhdGggZD0iTTkgNUMxMS4yMDkxIDUgMTMgNi43OTA5IDEzIDlDMTMgMTEuMjA5MSAxMS4yMDkxIDEzIDkgMTNDNi43OTA5IDEzIDUgMTEuMjA5MSA1IDlDNSA2Ljc5MDkgNi43OTA5IDUgOSA1WiIgZmlsbD0iIzBBRUJGQiIvPgo8L3N2Zz4=",
+  "layout": [
+    {
+      "h": 3,
+      "i": "total-certificates",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 3,
+      "i": "active-certificates",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 3,
+      "y": 0
+    },
+    {
+      "h": 3,
+      "i": "certificate-requests",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 6,
+      "y": 0
+    },
+    {
+      "h": 3,
+      "i": "cert-manager-uptime",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 9,
+      "y": 0
+    },
+    {
+      "h": 4,
+      "i": "certificates-per-issuer",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 3
+    },
+    {
+      "h": 4,
+      "i": "issuance-rate",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 3
+    },
+    {
+      "h": 4,
+      "i": "issuance-success-rate",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 3
+    },
+    {
+      "h": 4,
+      "i": "certificates-pending-renewal",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 7
+    },
+    {
+      "h": 4,
+      "i": "renewal-success-rate",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 7
+    },
+    {
+      "h": 4,
+      "i": "renewal-duration",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 7
+    },
+    {
+      "h": 4,
+      "i": "certificate-issuance-errors",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 11
+    },
+    {
+      "h": 4,
+      "i": "renewal-errors",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 11
+    },
+    {
+      "h": 4,
+      "i": "api-server-errors",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 11
+    },
+    {
+      "h": 4,
+      "i": "cpu-usage",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 15
+    },
+    {
+      "h": 4,
+      "i": "memory-usage",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 15
+    },
+    {
+      "h": 4,
+      "i": "pod-restarts",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 15
+    },
+    {
+      "h": 4,
+      "i": "api-request-rate",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 19
+    },
+    {
+      "h": 4,
+      "i": "event-processing-rate",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 19
+    },
+    {
+      "h": 4,
+      "i": "failed-api-requests",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 19
+    }
+  ],
+  "panelMap": {},
+  "tags": [
+    "cert-manager",
+    "monitoring",
+    "prometheus",
+    "ssl",
+    "certificates"
+  ],
+  "title": "Cert-Manager Monitoring Dashboard - Prometheus",
+  "uploadedGrafana": false,
+  "version": "v5",
+  "widgets": [
+    {
+      "description": "Total number of certificates issued and managed by cert-manager",
+      "id": "total-certificates",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Total Certificates",
+            "name": "A",
+            "query": "sum(certmanager_certificate_ready_status)"
+          }
+        ],
+        "queryType": 3,
+        "id": "total-certificates-id"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Certificates Issued",
+      "yAxisUnit": "none",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": []
+    },
+    {
+      "description": "Number of certificates currently in Ready=True state",
+      "id": "active-certificates",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Active Certificates",
+            "name": "A",
+            "query": "sum(certmanager_certificate_ready_status{condition=\"True\"})"
+          }
+        ],
+        "queryType": 3,
+        "id": "active-certificates-id"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Certificates",
+      "yAxisUnit": "none",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": []
+    },
+    {
+      "description": "Total HTTP ACME client requests count",
+      "id": "certificate-requests",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Certificate Requests",
+            "name": "A",
+            "query": "sum(certmanager_http_acme_client_request_count)"
+          }
+        ],
+        "queryType": 3,
+        "id": "certificate-requests-id"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Certificate Requests",
+      "yAxisUnit": "none",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": []
+    },
+    {
+      "description": "Uptime of cert-manager controller process in seconds",
+      "id": "cert-manager-uptime",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Uptime",
+            "name": "A",
+            "query": "time() - process_start_time_seconds{job=~\".*cert-manager.*\"}"
+          }
+        ],
+        "queryType": 3,
+        "id": "cert-manager-uptime-id"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Cert-Manager Uptime",
+      "yAxisUnit": "s",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": []
+    },
+    {
+      "description": "Number of certificates issued per issuer type",
+      "id": "certificates-per-issuer",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{issuer_name}}",
+            "name": "A",
+            "query": "sum by (issuer_name) (certmanager_certificate_ready_status)"
+          }
+        ],
+        "queryType": 3,
+        "id": "certificates-per-issuer-id"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Certificates Issued per Issuer",
+      "yAxisUnit": "none",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": []
+    },
+    {
+      "description": "Rate of certificate issuance operations per minute",
+      "id": "issuance-rate",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Issuance Rate",
+            "name": "A",
+            "query": "rate(certmanager_certificate_ready_status[5m])"
+          }
+        ],
+        "queryType": 3,
+        "id": "issuance-rate-id"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Certificate Issuance Rate",
+      "yAxisUnit": "ops",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": []
+    },
+    {
+      "description": "Certificate issuance success ratio (successful/total)",
+      "id": "issuance-success-rate",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Success Rate",
+            "name": "A",
+            "query": "sum(certmanager_certificate_ready_status{condition=\"True\"}) / sum(certmanager_certificate_ready_status) * 100"
+          }
+        ],
+        "queryType": 3,
+        "id": "issuance-success-rate-id"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Certificate Issuance Success Rate",
+      "yAxisUnit": "percent",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": []
+    },
+    {
+      "description": "Certificates approaching expiry requiring renewal (expiring within 30 days)",
+      "id": "certificates-pending-renewal",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Pending Renewal",
+            "name": "A",
+            "query": "count((certmanager_certificate_expiration_timestamp_seconds - time()) < (30 * 24 * 3600))"
+          }
+        ],
+        "queryType": 3,
+        "id": "certificates-pending-renewal-id"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Certificates Pending Renewal",
+      "yAxisUnit": "none",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": []
+    },
+    {
+      "description": "Success rate of certificate renewal operations",
+      "id": "renewal-success-rate",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Renewal Success Rate",
+            "name": "A",
+            "query": "rate(certmanager_certificate_renewal_timestamp_seconds[5m]) * 100"
+          }
+        ],
+        "queryType": 3,
+        "id": "renewal-success-rate-id"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Certificate Renewal Success Rate",
+      "yAxisUnit": "percent",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": []
+    },
+    {
+      "description": "Duration of certificate renewal operations",
+      "id": "renewal-duration",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Renewal Duration",
+            "name": "A",
+            "query": "certmanager_certificate_renewal_timestamp_seconds - certmanager_certificate_expiration_timestamp_seconds"
+          }
+        ],
+        "queryType": 3,
+        "id": "renewal-duration-id"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Certificate Renewal Duration",
+      "yAxisUnit": "s",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": []
+    },
+    {
+      "description": "Errors during certificate issuance process",
+      "id": "certificate-issuance-errors",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Issuance Errors",
+            "name": "A",
+            "query": "sum(certmanager_certificate_ready_status{condition=\"False\"})"
+          }
+        ],
+        "queryType": 3,
+        "id": "certificate-issuance-errors-id"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Certificate Issuance Errors",
+      "yAxisUnit": "none",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": []
+    },
+    {
+      "description": "Errors during certificate renewal process",
+      "id": "renewal-errors",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Renewal Errors",
+            "name": "A",
+            "query": "rate(certmanager_controller_sync_call_count{result=\"error\"}[5m])"
+          }
+        ],
+        "queryType": 3,
+        "id": "renewal-errors-id"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Certificate Renewal Errors",
+      "yAxisUnit": "ops",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": []
+    },
+    {
+      "description": "HTTP 4xx and 5xx errors from ACME API requests",
+      "id": "api-server-errors",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "API Server Errors",
+            "name": "A",
+            "query": "sum(rate(certmanager_http_acme_client_request_count{status=~\"4..|5..\"}[5m]))"
+          }
+        ],
+        "queryType": 3,
+        "id": "api-server-errors-id"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "API Server Errors",
+      "yAxisUnit": "ops",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": []
+    },
+    {
+      "description": "CPU usage of cert-manager process",
+      "id": "cpu-usage",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "CPU Usage",
+            "name": "A",
+            "query": "rate(process_cpu_seconds_total{job=~\".*cert-manager.*\"}[5m]) * 100"
+          }
+        ],
+        "queryType": 3,
+        "id": "cpu-usage-id"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "CPU Usage",
+      "yAxisUnit": "percent",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": []
+    },
+    {
+      "description": "Memory usage of cert-manager process",
+      "id": "memory-usage",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Memory Usage",
+            "name": "A",
+            "query": "process_resident_memory_bytes{job=~\".*cert-manager.*\"}"
+          }
+        ],
+        "queryType": 3,
+        "id": "memory-usage-id"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memory Usage",
+      "yAxisUnit": "bytes",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": []
+    },
+    {
+      "description": "Number of cert-manager pod restarts in Kubernetes",
+      "id": "pod-restarts",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Pod Restarts",
+            "name": "A",
+            "query": "sum(kube_pod_container_status_restarts_total{pod=~\".*cert-manager.*\"})"
+          }
+        ],
+        "queryType": 3,
+        "id": "pod-restarts-id"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Pod Restarts",
+      "yAxisUnit": "none",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": []
+    },
+    {
+      "description": "Rate of HTTP ACME API requests to certificate authorities",
+      "id": "api-request-rate",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "API Request Rate",
+            "name": "A",
+            "query": "sum(rate(certmanager_http_acme_client_request_count[5m]))"
+          }
+        ],
+        "queryType": 3,
+        "id": "api-request-rate-id"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "API Request Rate",
+      "yAxisUnit": "ops",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": []
+    },
+    {
+      "description": "Rate of controller sync events and operations",
+      "id": "event-processing-rate",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Event Processing Rate",
+            "name": "A",
+            "query": "sum(rate(certmanager_controller_sync_call_count[5m]))"
+          }
+        ],
+        "queryType": 3,
+        "id": "event-processing-rate-id"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Event Processing Rate",
+      "yAxisUnit": "ops",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": []
+    },
+    {
+      "description": "Failed API requests to certificate authorities and Kubernetes API",
+      "id": "failed-api-requests",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Failed API Requests",
+            "name": "A",
+            "query": "sum(rate(certmanager_http_acme_client_request_count{status=~\"4..|5..\"}[5m]))"
+          }
+        ],
+        "queryType": 3,
+        "id": "failed-api-requests-id"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Failed API Requests",
+      "yAxisUnit": "ops",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": []
+    }
+  ],
+  "variables": {}
+}


### PR DESCRIPTION
/fix https://github.com/SigNoz/signoz/issues/6023
/claim https://github.com/SigNoz/signoz/issues/6023

## Cert-Manager Monitoring Dashboard

Comprehensive monitoring dashboard for cert-manager using Prometheus metrics.

### 19 Panels in 6 Sections

| Section | Panels | Key Metrics |
|---------|--------|-------------|
| **General Overview** | 4 | Total certs, active certs, requests, uptime |
| **Certificate Issuance** | 3 | Per-issuer breakdown, rate, success rate |
| **Certificate Renewal** | 3 | Pending renewal, success rate, duration |
| **Error Metrics** | 3 | Issuance errors, renewal errors, API errors |
| **Resource Usage** | 3 | CPU, memory, pod restarts |
| **API & Events** | 3 | Request rate, event processing, failed requests |

### Metrics
- `certmanager_certificate_ready_status`
- `certmanager_certificate_expiration_timestamp_seconds`
- `certmanager_certificate_renewal_timestamp_seconds`
- `certmanager_http_acme_client_request_count`
- `certmanager_controller_sync_call_count`
- `process_cpu_seconds_total` / `process_resident_memory_bytes`

### Format Compliance
- ✅ All widget keys present (21 keys per widget)
- ✅ PromQL queries (queryType: 3)
- ✅ File naming: `cert-manager-prometheus-v1.json`
- ✅ README with setup, prerequisites, troubleshooting
- ✅ Layout matches existing dashboards

Closes https://github.com/SigNoz/signoz/issues/6023