### PR TITLE
Add Kong Gateway Prometheus monitoring dashboard v1

### DIFF
--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -1,0 +1,160 @@
+# Elasticsearch Dashboard - Prometheus
+
+## Overview
+
+This dashboard provides comprehensive monitoring for Elasticsearch clusters using Prometheus metrics from the `elasticsearch_exporter`. It covers all critical aspects of Elasticsearch performance including cluster health, indexing operations, search performance, JVM metrics, and system resources.
+
+## Prerequisites
+
+Before using this dashboard, ensure you have:
+
+1. **Elasticsearch cluster** running with the [`elasticsearch_exporter`](https://github.com/prometheus-community/elasticsearch_exporter)
+2. **Prometheus server** configured to scrape metrics from the exporter
+3. **SigNoz** instance capable of querying Prometheus metrics
+
+## Setup
+
+### 1. Install and Configure elasticsearch_exporter
+
+Deploy the elasticsearch_exporter to collect metrics from your Elasticsearch cluster:
+
+```bash
+# Download and run elasticsearch_exporter
+docker run --rm -d \
+  --name elasticsearch-exporter \
+  -p 9114:9114 \
+  quay.io/prometheuscommunity/elasticsearch-exporter:latest \
+  --es.uri=http://elasticsearch:9200 \
+  --es.all \
+  --es.indices \
+  --es.indices_settings \
+  --es.cluster_settings \
+  --es.shards
+```
+
+### 2. Configure Prometheus
+
+Add the following job to your `prometheus.yml` configuration:
+
+```yaml
+scrape_configs:
+  - job_name: 'elasticsearch-exporter'
+    static_configs:
+      - targets: ['elasticsearch-exporter:9114']
+    scrape_interval: 30s
+    metrics_path: /metrics
+```
+
+### 3. Configure SigNoz to Query Prometheus
+
+Ensure your SigNoz instance is configured with a Prometheus data source pointing to your Prometheus server.
+
+## Dashboard Panels
+
+This dashboard is organized into six main sections:
+
+### 🏥 Cluster Health
+- **Cluster Health Status**: Shows cluster status (0=green, 1=yellow, 2=red)
+- **Number of Nodes**: Total nodes in the cluster
+- **Pending Tasks**: Tasks waiting in the cluster queue
+- **Active Shards**: Number of active primary shards
+- **Relocating Shards**: Shards currently being moved
+- **Unassigned Shards**: Shards without node assignment
+
+### 📊 Index Metrics
+- **Total Documents Count**: Total documents across all indices
+- **Documents Indexed Rate**: Rate of new documents being indexed (docs/sec)
+- **Documents Deleted Rate**: Rate of document deletions (docs/sec)
+- **Store Size**: Total size of all indices in bytes
+
+### 🔍 Search Performance
+- **Search Query Rate**: Number of search queries per second
+- **Search Query Latency**: Average time per search query
+- **Search Fetch Rate**: Number of fetch operations per second
+- **Search Fetch Latency**: Average time per fetch operation
+
+### ⚡ Indexing Performance
+- **Indexing Rate**: Rate of indexing operations per second
+- **Indexing Latency**: Average time per indexing operation
+- **Merge Rate**: Rate of segment merge operations
+- **Refresh Rate**: Rate of index refresh operations
+
+### ☕ JVM Metrics
+- **JVM Heap Used vs Committed**: Heap memory usage and allocation
+- **JVM GC Collection Time**: Garbage collection time per second
+- **JVM GC Collection Count**: Number of GC collections per second
+- **JVM Thread Count**: Number of active JVM threads
+
+### 🖥️ System Resources
+- **CPU Usage**: Elasticsearch process CPU utilization percentage
+- **Memory Usage**: JVM memory consumption
+- **Disk Usage**: Available vs total disk space for data
+- **Network I/O**: Network bytes received and transmitted
+
+## Key Metrics Used
+
+The dashboard uses standard `elasticsearch_exporter` metrics:
+
+| Metric Category | Prometheus Metrics |
+|---|---|
+| **Cluster Health** | `elasticsearch_cluster_health_*` |
+| **Document Stats** | `elasticsearch_indices_docs`, `elasticsearch_indices_store_size_bytes` |
+| **Search Performance** | `elasticsearch_indices_search_query_*`, `elasticsearch_indices_search_fetch_*` |
+| **Indexing Performance** | `elasticsearch_indices_indexing_*`, `elasticsearch_indices_merges_*`, `elasticsearch_indices_refresh_*` |
+| **JVM Metrics** | `elasticsearch_jvm_memory_*`, `elasticsearch_jvm_gc_collection_*`, `elasticsearch_jvm_threads_current` |
+| **System Resources** | `elasticsearch_process_cpu_percent`, `elasticsearch_filesystem_data_*`, `elasticsearch_transport_*` |
+
+## Alerting Recommendations
+
+Consider setting up alerts for:
+
+- **Cluster Health**: Status != 0 (green)
+- **Unassigned Shards**: > 0 for extended periods
+- **Search Latency**: > acceptable threshold for your use case
+- **JVM Heap Usage**: > 85% of committed memory
+- **Disk Usage**: Available space < 15% of total
+- **CPU Usage**: > 80% sustained usage
+
+## Troubleshooting
+
+### Common Issues
+
+1. **No data in panels**: 
+   - Verify elasticsearch_exporter is running and accessible
+   - Check Prometheus is scraping the exporter (check targets in Prometheus UI)
+   - Ensure SigNoz can query your Prometheus instance
+
+2. **Some metrics missing**:
+   - Confirm elasticsearch_exporter is started with appropriate flags (`--es.all`, `--es.indices`, etc.)
+   - Check Elasticsearch permissions for the exporter user
+
+3. **High resource usage**:
+   - Adjust scrape intervals in Prometheus configuration
+   - Consider using `--es.indices_mappings=false` to reduce metric volume
+
+### Useful Commands
+
+```bash
+# Check elasticsearch_exporter metrics
+curl http://elasticsearch-exporter:9114/metrics
+
+# Verify Elasticsearch cluster health
+curl -X GET "elasticsearch:9200/_cluster/health?pretty"
+
+# Check Prometheus targets
+curl http://prometheus:9090/api/v1/targets
+```
+
+## Dashboard Import
+
+1. Copy the `elasticsearch-prometheus-v1.json` content
+2. In SigNoz, go to **Dashboards** → **Import Dashboard**
+3. Paste the JSON content and import
+4. The dashboard will be ready to use with your Elasticsearch metrics
+
+## Version Information
+
+- **Dashboard Version**: v1
+- **Compatible with**: Elasticsearch 6.x, 7.x, 8.x
+- **elasticsearch_exporter**: v1.1.0+
+- **SigNoz**: v0.8.0+

--- a/elasticsearch/elasticsearch-prometheus-v1.json
+++ b/elasticsearch/elasticsearch-prometheus-v1.json
@@ -1,0 +1,1091 @@
+{
+  "description": "Comprehensive Elasticsearch monitoring dashboard using Prometheus elasticsearch_exporter metrics",
+  "image": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTkgMUMxMy40MTgzIDEgMTcgNC41ODE3IDE3IDlDMTcgMTMuNDE4MyAxMy40MTgzIDE3IDkgMTdDNC41ODE3IDE3IDEgMTMuNDE4MyAxIDlDMSA0LjU4MTcgNC41ODE3IDEgOSAxWk05IDNDNS42ODYzIDMgMyA1LjY4NjMgMyA5QzMgMTIuMzEzNyA1LjY4NjMgMTUgOSAxNUMxMi4zMTM3IDE1IDE1IDEyLjMxMzcgMTUgOUMxNSA1LjY4NjMgMTIuMzEzNyAzIDkgM1oiIGZpbGw9IiNGRkQ2MDAiLz4KPHBhdGggZD0iTTkgNUMxMS4yMDkxIDUgMTMgNi43OTA5IDEzIDlDMTMgMTEuMjA5MSAxMS4yMDkxIDEzIDkgMTNDNi43OTA5IDEzIDUgMTEuMjA5MSA1IDlDNSA2Ljc5MDkgNi43OTA5IDUgOSA1WiIgZmlsbD0iIzFGN0E4QyIvPgo8L3N2Zz4=",
+  "layout": [
+    {
+      "h": 3,
+      "i": "cluster-health-status",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 3,
+      "i": "number-of-nodes",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 2,
+      "y": 0
+    },
+    {
+      "h": 3,
+      "i": "pending-tasks",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 4,
+      "y": 0
+    },
+    {
+      "h": 3,
+      "i": "active-shards",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 6,
+      "y": 0
+    },
+    {
+      "h": 3,
+      "i": "relocating-shards",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 8,
+      "y": 0
+    },
+    {
+      "h": 3,
+      "i": "unassigned-shards",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 10,
+      "y": 0
+    },
+    {
+      "h": 4,
+      "i": "documents-count",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 0,
+      "y": 3
+    },
+    {
+      "h": 4,
+      "i": "documents-indexed-rate",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 3,
+      "y": 3
+    },
+    {
+      "h": 4,
+      "i": "documents-deleted-rate",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 6,
+      "y": 3
+    },
+    {
+      "h": 4,
+      "i": "store-size",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 9,
+      "y": 3
+    },
+    {
+      "h": 4,
+      "i": "search-query-rate",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 0,
+      "y": 7
+    },
+    {
+      "h": 4,
+      "i": "search-query-latency",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 3,
+      "y": 7
+    },
+    {
+      "h": 4,
+      "i": "search-fetch-rate",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 6,
+      "y": 7
+    },
+    {
+      "h": 4,
+      "i": "search-fetch-latency",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 9,
+      "y": 7
+    },
+    {
+      "h": 4,
+      "i": "indexing-rate",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 0,
+      "y": 11
+    },
+    {
+      "h": 4,
+      "i": "indexing-latency",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 3,
+      "y": 11
+    },
+    {
+      "h": 4,
+      "i": "merge-rate",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 6,
+      "y": 11
+    },
+    {
+      "h": 4,
+      "i": "refresh-rate",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 9,
+      "y": 11
+    },
+    {
+      "h": 4,
+      "i": "jvm-heap-usage",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 0,
+      "y": 15
+    },
+    {
+      "h": 4,
+      "i": "jvm-gc-time",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 3,
+      "y": 15
+    },
+    {
+      "h": 4,
+      "i": "jvm-gc-count",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 6,
+      "y": 15
+    },
+    {
+      "h": 4,
+      "i": "jvm-thread-count",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 9,
+      "y": 15
+    },
+    {
+      "h": 4,
+      "i": "cpu-usage",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 0,
+      "y": 19
+    },
+    {
+      "h": 4,
+      "i": "memory-usage",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 3,
+      "y": 19
+    },
+    {
+      "h": 4,
+      "i": "disk-usage",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 6,
+      "y": 19
+    },
+    {
+      "h": 4,
+      "i": "network-io",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 9,
+      "y": 19
+    }
+  ],
+  "panelMap": {},
+  "tags": ["elasticsearch", "monitoring", "prometheus", "search", "indexing"],
+  "title": "Elasticsearch Monitoring Dashboard - Prometheus",
+  "uploadedGrafana": false,
+  "version": "v5",
+  "widgets": [
+    {
+      "description": "Current cluster health status - green (healthy), yellow (warning), red (critical)",
+      "id": "cluster-health-status",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Cluster Status",
+            "name": "A",
+            "query": "elasticsearch_cluster_health_status"
+          }
+        ],
+        "queryType": 3
+      },
+      "thresholds": [
+        {
+          "color": "#EF4444",
+          "isEditEnabled": false,
+          "label": "Critical",
+          "value": 2
+        },
+        {
+          "color": "#F59E0B", 
+          "isEditEnabled": false,
+          "label": "Warning",
+          "value": 1
+        },
+        {
+          "color": "#10B981",
+          "isEditEnabled": false,
+          "label": "Healthy",
+          "value": 0
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Cluster Health Status",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Total number of nodes in the Elasticsearch cluster",
+      "id": "number-of-nodes",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A", 
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Nodes",
+            "name": "A",
+            "query": "elasticsearch_cluster_health_number_of_nodes"
+          }
+        ],
+        "queryType": 3
+      },
+      "timePreferance": "GLOBAL_TIME", 
+      "title": "Number of Nodes",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Number of pending tasks in the cluster queue",
+      "id": "pending-tasks",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Pending Tasks",
+            "name": "A",
+            "query": "elasticsearch_cluster_health_number_of_pending_tasks"
+          }
+        ],
+        "queryType": 3
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Pending Tasks",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Number of active primary shards in the cluster",
+      "id": "active-shards",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Active Shards",
+            "name": "A", 
+            "query": "elasticsearch_cluster_health_active_primary_shards"
+          }
+        ],
+        "queryType": 3
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Shards", 
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Number of shards currently being relocated",
+      "id": "relocating-shards",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Relocating",
+            "name": "A",
+            "query": "elasticsearch_cluster_health_relocating_shards"
+          }
+        ],
+        "queryType": 3
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Relocating Shards",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Number of shards that are unassigned",
+      "id": "unassigned-shards", 
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Unassigned",
+            "name": "A",
+            "query": "elasticsearch_cluster_health_unassigned_shards"
+          }
+        ],
+        "queryType": 3
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Unassigned Shards",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Total number of documents in all indices",
+      "id": "documents-count",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Total Documents",
+            "name": "A",
+            "query": "sum(elasticsearch_indices_docs{type=\"_all\"})"
+          }
+        ],
+        "queryType": 3
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Documents Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Rate of documents being indexed per second",
+      "id": "documents-indexed-rate",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Indexed Rate",
+            "name": "A",
+            "query": "rate(elasticsearch_indices_indexing_index_total[5m])"
+          }
+        ],
+        "queryType": 3
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Documents Indexed Rate",
+      "yAxisUnit": "ops"
+    },
+    {
+      "description": "Rate of documents being deleted per second", 
+      "id": "documents-deleted-rate",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Deleted Rate",
+            "name": "A",
+            "query": "rate(elasticsearch_indices_indexing_delete_total[5m])"
+          }
+        ],
+        "queryType": 3
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Documents Deleted Rate",
+      "yAxisUnit": "ops"
+    },
+    {
+      "description": "Total storage size of all indices in bytes",
+      "id": "store-size", 
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Store Size",
+            "name": "A",
+            "query": "sum(elasticsearch_indices_store_size_bytes)"
+          }
+        ],
+        "queryType": 3
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Store Size",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "Rate of search queries executed per second",
+      "id": "search-query-rate",
+      "panelTypes": "graph", 
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Query Rate",
+            "name": "A",
+            "query": "rate(elasticsearch_indices_search_query_total[5m])"
+          }
+        ],
+        "queryType": 3
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Search Query Rate",
+      "yAxisUnit": "ops"
+    },
+    {
+      "description": "Average time spent executing search queries",
+      "id": "search-query-latency",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Query Latency",
+            "name": "A",
+            "query": "rate(elasticsearch_indices_search_query_time_seconds[5m]) / rate(elasticsearch_indices_search_query_total[5m])"
+          }
+        ],
+        "queryType": 3
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Search Query Latency",
+      "yAxisUnit": "s"
+    },
+    {
+      "description": "Rate of search fetch operations per second",
+      "id": "search-fetch-rate",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Fetch Rate",
+            "name": "A",
+            "query": "rate(elasticsearch_indices_search_fetch_total[5m])"
+          }
+        ],
+        "queryType": 3
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Search Fetch Rate",
+      "yAxisUnit": "ops"
+    },
+    {
+      "description": "Average time spent executing search fetch operations",
+      "id": "search-fetch-latency",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Fetch Latency",
+            "name": "A",
+            "query": "rate(elasticsearch_indices_search_fetch_time_seconds[5m]) / rate(elasticsearch_indices_search_fetch_total[5m])"
+          }
+        ],
+        "queryType": 3
+      },
+      "timePreferance": "GLOBAL_TIME", 
+      "title": "Search Fetch Latency",
+      "yAxisUnit": "s"
+    },
+    {
+      "description": "Rate of indexing operations per second",
+      "id": "indexing-rate",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Indexing Rate",
+            "name": "A",
+            "query": "rate(elasticsearch_indices_indexing_index_total[5m])"
+          }
+        ],
+        "queryType": 3
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Indexing Rate",
+      "yAxisUnit": "ops"
+    },
+    {
+      "description": "Average time spent on indexing operations",
+      "id": "indexing-latency",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Indexing Latency",
+            "name": "A",
+            "query": "rate(elasticsearch_indices_indexing_index_time_seconds[5m]) / rate(elasticsearch_indices_indexing_index_total[5m])"
+          }
+        ],
+        "queryType": 3
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Indexing Latency", 
+      "yAxisUnit": "s"
+    },
+    {
+      "description": "Rate of merge operations per second",
+      "id": "merge-rate",
+      "panelTypes": "graph", 
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Merge Rate",
+            "name": "A",
+            "query": "rate(elasticsearch_indices_merges_total[5m])"
+          }
+        ],
+        "queryType": 3
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Merge Rate",
+      "yAxisUnit": "ops"
+    },
+    {
+      "description": "Rate of refresh operations per second",
+      "id": "refresh-rate",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Refresh Rate",
+            "name": "A",
+            "query": "rate(elasticsearch_indices_refresh_total[5m])"
+          }
+        ],
+        "queryType": 3
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Refresh Rate",
+      "yAxisUnit": "ops"
+    },
+    {
+      "description": "JVM heap memory used vs committed",
+      "id": "jvm-heap-usage",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Heap Used",
+            "name": "A",
+            "query": "elasticsearch_jvm_memory_used_bytes{area=\"heap\"}"
+          },
+          {
+            "disabled": false,
+            "legend": "Heap Committed", 
+            "name": "B",
+            "query": "elasticsearch_jvm_memory_committed_bytes{area=\"heap\"}"
+          }
+        ],
+        "queryType": 3
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "JVM Heap Used vs Committed",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "JVM garbage collection time per second",
+      "id": "jvm-gc-time",
+      "panelTypes": "graph", 
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "GC Time",
+            "name": "A",
+            "query": "rate(elasticsearch_jvm_gc_collection_seconds_sum[5m])"
+          }
+        ],
+        "queryType": 3
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "JVM GC Collection Time",
+      "yAxisUnit": "s"
+    },
+    {
+      "description": "JVM garbage collection count per second",
+      "id": "jvm-gc-count",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "GC Count",
+            "name": "A",
+            "query": "rate(elasticsearch_jvm_gc_collection_seconds_count[5m])"
+          }
+        ],
+        "queryType": 3
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "JVM GC Collection Count",
+      "yAxisUnit": "ops"
+    },
+    {
+      "description": "Number of JVM threads currently active",
+      "id": "jvm-thread-count",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Thread Count",
+            "name": "A",
+            "query": "elasticsearch_jvm_threads_current"
+          }
+        ],
+        "queryType": 3
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "JVM Thread Count", 
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "CPU usage percentage of Elasticsearch process",
+      "id": "cpu-usage",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "CPU Usage %",
+            "name": "A",
+            "query": "elasticsearch_process_cpu_percent"
+          }
+        ],
+        "queryType": 3
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "CPU Usage",
+      "yAxisUnit": "percent"
+    },
+    {
+      "description": "JVM memory usage in bytes",
+      "id": "memory-usage",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Memory Used",
+            "name": "A",
+            "query": "elasticsearch_jvm_memory_used_bytes"
+          }
+        ],
+        "queryType": 3
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memory Usage",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "Disk space available and total for Elasticsearch data",
+      "id": "disk-usage",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Available",
+            "name": "A",
+            "query": "elasticsearch_filesystem_data_available_bytes"
+          },
+          {
+            "disabled": false,
+            "legend": "Total",
+            "name": "B", 
+            "query": "elasticsearch_filesystem_data_size_bytes"
+          }
+        ],
+        "queryType": 3
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Disk Usage",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "Network I/O bytes received and transmitted",
+      "id": "network-io",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "RX Bytes",
+            "name": "A",
+            "query": "rate(elasticsearch_transport_rx_size_bytes_total[5m])"
+          },
+          {
+            "disabled": false,
+            "legend": "TX Bytes",
+            "name": "B",
+            "query": "rate(elasticsearch_transport_tx_size_bytes_total[5m])"
+          }
+        ],
+        "queryType": 3
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Network I/O",
+      "yAxisUnit": "Bps"
+    }
+  ]
+}

--- a/kong/README.md
+++ b/kong/README.md
@@ -1,0 +1,187 @@
+# Kong Gateway Dashboard - Prometheus
+
+## Overview
+
+This dashboard provides comprehensive monitoring for Kong Gateway using Prometheus metrics. It covers all critical aspects of Kong Gateway performance including general overview, request metrics, latency analysis, error tracking, upstream health, and plugin performance.
+
+## Prerequisites
+
+Before using this dashboard, ensure you have:
+
+1. **Kong Gateway** running with Prometheus metrics enabled
+2. **Prometheus server** configured to scrape metrics from Kong
+3. **SigNoz** instance capable of querying Prometheus metrics
+
+## Setup
+
+### 1. Enable Prometheus Plugin in Kong
+
+First, enable the Prometheus plugin in Kong to expose metrics:
+
+```bash
+# Enable globally for all services
+curl -X POST http://kong-admin:8001/plugins \
+    --data "name=prometheus"
+
+# Or enable for a specific service
+curl -X POST http://kong-admin:8001/services/{service}/plugins \
+    --data "name=prometheus"
+```
+
+### 2. Configure Prometheus
+
+Add the following job to your `prometheus.yml` configuration:
+
+```yaml
+scrape_configs:
+  - job_name: 'kong'
+    static_configs:
+      - targets: ['kong:8001']  # Kong Admin API port
+    scrape_interval: 30s
+    metrics_path: /metrics
+```
+
+### 3. Configure SigNoz to Query Prometheus
+
+Ensure your SigNoz instance is configured with a Prometheus data source pointing to your Prometheus server.
+
+## Dashboard Panels
+
+This dashboard is organized into six main sections:
+
+### 🏥 General Overview (5 panels)
+- **Total Requests**: Total HTTP requests processed (`kong_http_requests_total`)
+- **Active Connections**: Current active connections (`kong_nginx_connections_total{state="active"}`)
+- **Uptime**: Kong Gateway uptime (`time() - process_start_time_seconds`)
+- **CPU Usage**: Kong process CPU utilization (`rate(process_cpu_seconds_total[5m]) * 100`)
+- **Memory Usage**: Kong process memory consumption (`process_resident_memory_bytes`)
+
+### 📊 Request Metrics (4 panels)
+- **Request Rate**: Requests per second (`rate(kong_http_requests_total[5m])`)
+- **Response Status Codes**: Status code distribution (2xx, 4xx, 5xx)
+- **Request Size**: Average request size in bytes
+- **Response Size**: Average response size in bytes
+
+### ⚡ Latency Metrics (3 panels)
+- **Average Request Latency**: Mean request processing time
+- **Request Latency Percentiles**: P50, P90, P99 latency distribution
+- **Upstream Latency**: Backend service response times
+
+### 🚨 Error Metrics (3+ panels)
+- **Total Errors**: Count of 4xx and 5xx responses
+- **Error Rate**: Percentage of failed requests
+- **Error Codes Distribution**: Breakdown by specific error codes
+- **Datastore Status**: Kong database connectivity status
+
+### 🎯 Upstream Health (3+ panels)
+- **Upstream Success Rate**: Percentage of successful upstream requests
+- **Active Upstreams**: Number of available upstream services
+- **Upstream Response Time**: Backend service performance
+- **Nginx Connections**: Connection state breakdown
+
+### 🔌 Plugin/Route Metrics (3+ panels)
+- **Requests per Route/Service**: Traffic distribution across routes
+- **Bandwidth Usage**: Network I/O (ingress/egress)
+- **Plugin Execution Time**: Plugin processing overhead
+
+## Key Metrics Used
+
+The dashboard uses standard Kong Prometheus metrics:
+
+| Metric Category | Prometheus Metrics |
+|---|---|
+| **HTTP Requests** | `kong_http_requests_total` |
+| **Request Latency** | `kong_request_latency_ms_bucket/sum/count` |
+| **Upstream Latency** | `kong_upstream_latency_ms_bucket/sum/count` |
+| **Request/Response Size** | `kong_request_size_bytes_*`, `kong_response_size_bytes_*` |
+| **Nginx Connections** | `kong_nginx_connections_total` |
+| **Bandwidth** | `kong_bandwidth_bytes` |
+| **System Resources** | `process_cpu_seconds_total`, `process_resident_memory_bytes` |
+| **Datastore Health** | `kong_datastore_reachable` |
+
+## Alerting Recommendations
+
+Consider setting up alerts for:
+
+- **High Error Rate**: Error rate > 5%
+- **High Latency**: P99 latency > 1000ms
+- **Datastore Unreachable**: `kong_datastore_reachable` = 0
+- **High CPU Usage**: CPU usage > 80%
+- **High Memory Usage**: Memory usage > 2GB
+- **Upstream Failures**: Success rate < 95%
+
+## Troubleshooting
+
+### Common Issues
+
+1. **No data in panels**: 
+   - Verify Kong Prometheus plugin is enabled
+   - Check Prometheus is scraping Kong metrics (check targets in Prometheus UI)
+   - Ensure SigNoz can query your Prometheus instance
+
+2. **Missing specific metrics**:
+   - Confirm Kong version supports the required metrics
+   - Check Kong configuration for metric collection
+
+3. **High resource usage**:
+   - Consider adjusting Prometheus scrape intervals
+   - Review Kong worker processes and resource allocation
+
+### Useful Commands
+
+```bash
+# Check Kong Prometheus metrics endpoint
+curl http://kong:8001/metrics
+
+# Verify Kong admin API is accessible
+curl http://kong:8001/status
+
+# Check Prometheus targets
+curl http://prometheus:9090/api/v1/targets
+
+# Kong configuration check
+kong config -c /etc/kong/kong.conf
+```
+
+## Kong Configuration
+
+Ensure your Kong configuration includes:
+
+```yaml
+# kong.conf
+admin_listen = 0.0.0.0:8001
+proxy_listen = 0.0.0.0:8000
+
+# Enable metrics collection
+nginx_worker_processes = auto
+mem_cache_size = 128m
+```
+
+## Version Information
+
+- **Dashboard Version**: v1
+- **Compatible with**: Kong Gateway 2.x, 3.x
+- **Kong Prometheus Plugin**: 2.0.0+
+- **SigNoz**: v0.8.0+
+
+## Dashboard Import
+
+1. Copy the `kong-prometheus-v1.json` content
+2. In SigNoz, go to **Dashboards** → **Import Dashboard**
+3. Paste the JSON content and import
+4. The dashboard will be ready to use with your Kong metrics
+
+## Performance Considerations
+
+- **Metric Cardinality**: Be mindful of high-cardinality labels like route names
+- **Scrape Frequency**: Balance between data granularity and resource usage
+- **Retention**: Configure appropriate metric retention policies in Prometheus
+
+## Advanced Monitoring
+
+For enhanced monitoring, consider:
+
+- **Custom Plugins**: Developing Kong plugins for application-specific metrics
+- **Distributed Tracing**: Integrating with OpenTelemetry for request tracing
+- **Log Aggregation**: Combining metrics with Kong access logs
+- **Health Checks**: Implementing upstream health check monitoring

--- a/kong/kong-prometheus-v1.json
+++ b/kong/kong-prometheus-v1.json
@@ -1,0 +1,2757 @@
+{
+  "description": "Comprehensive Kong Gateway monitoring dashboard using Prometheus metrics",
+  "image": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTkgMUMxMy40MTgzIDEgMTcgNC41ODE3IDE3IDlDMTcgMTMuNDE4MyAxMy40MTgzIDE3IDkgMTdDNC41ODE3IDE3IDEgMTMuNDE4MyAxIDlDMSA0LjU4MTcgNC41ODE3IDEgOSAxWk05IDNDNS42ODYzIDMgMyA1LjY4NjMgMyA5QzMgMTIuMzEzNyA1LjY4NjMgMTUgOSAxNUMxMi4zMTM3IDE1IDE1IDEyLjMxMzcgMTUgOUMxNSA1LjY4NjMgMTIuMzEzNyAzIDkgM1oiIGZpbGw9IiNGRkQ2MDAiLz4KPHBhdGggZD0iTTkgNUMxMS4yMDkxIDUgMTMgNi43OTA5IDEzIDlDMTMgMTEuMjA5MSAxMS4yMDkxIDEzIDkgMTNDNi43OTA5IDEzIDUgMTEuMjA5MSA1IDlDNSA2Ljc5MDkgNi43OTA5IDUgOSA1WiIgZmlsbD0iIzAwN0NCNyIvPgo8L3N2Zz4=",
+  "layout": [
+    {
+      "h": 3,
+      "i": "total-requests",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 3,
+      "i": "active-connections",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 2,
+      "y": 0
+    },
+    {
+      "h": 3,
+      "i": "uptime",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 4,
+      "y": 0
+    },
+    {
+      "h": 3,
+      "i": "cpu-usage",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 6,
+      "y": 0
+    },
+    {
+      "h": 3,
+      "i": "memory-usage",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 9,
+      "y": 0
+    },
+    {
+      "h": 4,
+      "i": "request-rate",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 0,
+      "y": 3
+    },
+    {
+      "h": 4,
+      "i": "response-status-codes",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 3,
+      "y": 3
+    },
+    {
+      "h": 4,
+      "i": "request-size",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 6,
+      "y": 3
+    },
+    {
+      "h": 4,
+      "i": "response-size",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 9,
+      "y": 3
+    },
+    {
+      "h": 4,
+      "i": "average-request-latency",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 7
+    },
+    {
+      "h": 4,
+      "i": "request-latency-percentiles",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 7
+    },
+    {
+      "h": 4,
+      "i": "upstream-latency",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 7
+    },
+    {
+      "h": 4,
+      "i": "total-errors",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 0,
+      "y": 11
+    },
+    {
+      "h": 4,
+      "i": "error-rate",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 3,
+      "y": 11
+    },
+    {
+      "h": 4,
+      "i": "error-codes-distribution",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 6,
+      "y": 11
+    },
+    {
+      "h": 4,
+      "i": "datastore-reachable",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 9,
+      "y": 11
+    },
+    {
+      "h": 4,
+      "i": "upstream-success-rate",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 0,
+      "y": 15
+    },
+    {
+      "h": 4,
+      "i": "active-upstreams",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 3,
+      "y": 15
+    },
+    {
+      "h": 4,
+      "i": "upstream-response-time",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 6,
+      "y": 15
+    },
+    {
+      "h": 4,
+      "i": "nginx-connections",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 9,
+      "y": 15
+    },
+    {
+      "h": 4,
+      "i": "requests-per-route",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 19
+    },
+    {
+      "h": 4,
+      "i": "bandwidth-usage",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 19
+    },
+    {
+      "h": 4,
+      "i": "plugin-execution-time",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 19
+    }
+  ],
+  "tags": [
+    "kong",
+    "gateway",
+    "api",
+    "prometheus",
+    "monitoring"
+  ],
+  "title": "Kong Gateway - Prometheus",
+  "variables": {},
+  "version": "v1",
+  "widgets": [
+    {
+      "description": "Total number of HTTP requests processed by Kong Gateway",
+      "id": "total-requests",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Total Requests",
+            "name": "A",
+            "query": "kong_http_requests_total"
+          }
+        ],
+        "queryType": 3,
+        "id": "total-requests-query"
+      },
+      "thresholds": [
+        {
+          "color": "#EF4444",
+          "isEditEnabled": false,
+          "label": "High",
+          "value": 1000000
+        },
+        {
+          "color": "#F59E0B",
+          "isEditEnabled": false,
+          "label": "Medium",
+          "value": 100000
+        },
+        {
+          "color": "#10B981",
+          "isEditEnabled": false,
+          "label": "Low",
+          "value": 0
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Requests",
+      "yAxisUnit": "short",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false
+    },
+    {
+      "description": "Number of active connections to Kong Gateway",
+      "id": "active-connections",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Active Connections",
+            "name": "A",
+            "query": "kong_nginx_connections_total{state=\"active\"}"
+          }
+        ],
+        "queryType": 3,
+        "id": "active-connections-query"
+      },
+      "thresholds": [
+        {
+          "color": "#EF4444",
+          "isEditEnabled": false,
+          "label": "High",
+          "value": 1000
+        },
+        {
+          "color": "#F59E0B",
+          "isEditEnabled": false,
+          "label": "Medium",
+          "value": 500
+        },
+        {
+          "color": "#10B981",
+          "isEditEnabled": false,
+          "label": "Normal",
+          "value": 0
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Connections",
+      "yAxisUnit": "short",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false
+    },
+    {
+      "description": "Kong Gateway uptime in seconds since start",
+      "id": "uptime",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Uptime",
+            "name": "A",
+            "query": "time() - process_start_time_seconds"
+          }
+        ],
+        "queryType": 3,
+        "id": "uptime-query"
+      },
+      "thresholds": [
+        {
+          "color": "#10B981",
+          "isEditEnabled": false,
+          "label": "Stable",
+          "value": 86400
+        },
+        {
+          "color": "#F59E0B",
+          "isEditEnabled": false,
+          "label": "Recent Restart",
+          "value": 3600
+        },
+        {
+          "color": "#EF4444",
+          "isEditEnabled": false,
+          "label": "Very Recent",
+          "value": 0
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Uptime",
+      "yAxisUnit": "s",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false
+    },
+    {
+      "description": "CPU usage percentage of Kong Gateway process",
+      "id": "cpu-usage",
+      "panelTypes": "time_series",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "CPU Usage %",
+            "name": "A",
+            "query": "rate(process_cpu_seconds_total[5m]) * 100"
+          }
+        ],
+        "queryType": 3,
+        "id": "cpu-usage-query"
+      },
+      "thresholds": [
+        {
+          "color": "#EF4444",
+          "isEditEnabled": false,
+          "label": "High",
+          "value": 80
+        },
+        {
+          "color": "#F59E0B",
+          "isEditEnabled": false,
+          "label": "Medium",
+          "value": 60
+        },
+        {
+          "color": "#10B981",
+          "isEditEnabled": false,
+          "label": "Normal",
+          "value": 0
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "CPU Usage",
+      "yAxisUnit": "percent",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false
+    },
+    {
+      "description": "Memory usage of Kong Gateway process in bytes",
+      "id": "memory-usage",
+      "panelTypes": "time_series",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Memory Usage",
+            "name": "A",
+            "query": "process_resident_memory_bytes"
+          }
+        ],
+        "queryType": 3,
+        "id": "memory-usage-query"
+      },
+      "thresholds": [
+        {
+          "color": "#EF4444",
+          "isEditEnabled": false,
+          "label": "High",
+          "value": 2000000000
+        },
+        {
+          "color": "#F59E0B",
+          "isEditEnabled": false,
+          "label": "Medium",
+          "value": 1000000000
+        },
+        {
+          "color": "#10B981",
+          "isEditEnabled": false,
+          "label": "Normal",
+          "value": 0
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memory Usage",
+      "yAxisUnit": "bytes",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false
+    },
+    {
+      "description": "Rate of HTTP requests per second processed by Kong",
+      "id": "request-rate",
+      "panelTypes": "time_series",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Requests/sec",
+            "name": "A",
+            "query": "rate(kong_http_requests_total[5m])"
+          }
+        ],
+        "queryType": 3,
+        "id": "request-rate-query"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Rate",
+      "yAxisUnit": "reqps",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false
+    },
+    {
+      "description": "Distribution of HTTP response status codes (2xx, 4xx, 5xx)",
+      "id": "response-status-codes",
+      "panelTypes": "time_series",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "2xx Success",
+            "name": "A",
+            "query": "rate(kong_http_requests_total{code=~\"2..\"}[5m])"
+          },
+          {
+            "disabled": false,
+            "legend": "4xx Client Error",
+            "name": "B",
+            "query": "rate(kong_http_requests_total{code=~\"4..\"}[5m])"
+          },
+          {
+            "disabled": false,
+            "legend": "5xx Server Error",
+            "name": "C",
+            "query": "rate(kong_http_requests_total{code=~\"5..\"}[5m])"
+          }
+        ],
+        "queryType": 3,
+        "id": "response-status-codes-query"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Response Status Codes",
+      "yAxisUnit": "reqps",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": true,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false
+    },
+    {
+      "description": "Average size of incoming HTTP requests in bytes",
+      "id": "request-size",
+      "panelTypes": "time_series",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Avg Request Size",
+            "name": "A",
+            "query": "rate(kong_request_size_bytes_sum[5m]) / rate(kong_request_size_bytes_count[5m])"
+          }
+        ],
+        "queryType": 3,
+        "id": "request-size-query"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Size",
+      "yAxisUnit": "bytes",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false
+    },
+    {
+      "description": "Average size of HTTP responses in bytes",
+      "id": "response-size",
+      "panelTypes": "time_series",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Avg Response Size",
+            "name": "A",
+            "query": "rate(kong_response_size_bytes_sum[5m]) / rate(kong_response_size_bytes_count[5m])"
+          }
+        ],
+        "queryType": 3,
+        "id": "response-size-query"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Response Size",
+      "yAxisUnit": "bytes",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false
+    },
+    {
+      "description": "Average request latency in milliseconds",
+      "id": "average-request-latency",
+      "panelTypes": "time_series",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Avg Request Latency",
+            "name": "A",
+            "query": "rate(kong_request_latency_ms_sum[5m]) / rate(kong_request_latency_ms_count[5m])"
+          }
+        ],
+        "queryType": 3,
+        "id": "average-request-latency-query"
+      },
+      "thresholds": [
+        {
+          "color": "#EF4444",
+          "isEditEnabled": false,
+          "label": "High",
+          "value": 1000
+        },
+        {
+          "color": "#F59E0B",
+          "isEditEnabled": false,
+          "label": "Medium",
+          "value": 500
+        },
+        {
+          "color": "#10B981",
+          "isEditEnabled": false,
+          "label": "Good",
+          "value": 0
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Average Request Latency",
+      "yAxisUnit": "ms",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false
+    },
+    {
+      "description": "Request latency percentiles (50th, 90th, 99th)",
+      "id": "request-latency-percentiles",
+      "panelTypes": "time_series",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "50th percentile",
+            "name": "A",
+            "query": "histogram_quantile(0.50, rate(kong_request_latency_ms_bucket[5m]))"
+          },
+          {
+            "disabled": false,
+            "legend": "90th percentile",
+            "name": "B",
+            "query": "histogram_quantile(0.90, rate(kong_request_latency_ms_bucket[5m]))"
+          },
+          {
+            "disabled": false,
+            "legend": "99th percentile",
+            "name": "C",
+            "query": "histogram_quantile(0.99, rate(kong_request_latency_ms_bucket[5m]))"
+          }
+        ],
+        "queryType": 3,
+        "id": "request-latency-percentiles-query"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Latency Percentiles",
+      "yAxisUnit": "ms",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false
+    },
+    {
+      "description": "Average upstream latency in milliseconds",
+      "id": "upstream-latency",
+      "panelTypes": "time_series",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Avg Upstream Latency",
+            "name": "A",
+            "query": "rate(kong_upstream_latency_ms_sum[5m]) / rate(kong_upstream_latency_ms_count[5m])"
+          }
+        ],
+        "queryType": 3,
+        "id": "upstream-latency-query"
+      },
+      "thresholds": [
+        {
+          "color": "#EF4444",
+          "isEditEnabled": false,
+          "label": "High",
+          "value": 2000
+        },
+        {
+          "color": "#F59E0B",
+          "isEditEnabled": false,
+          "label": "Medium",
+          "value": 1000
+        },
+        {
+          "color": "#10B981",
+          "isEditEnabled": false,
+          "label": "Good",
+          "value": 0
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Upstream Latency",
+      "yAxisUnit": "ms",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false
+    },
+    {
+      "description": "Total number of error responses (4xx and 5xx status codes)",
+      "id": "total-errors",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Total Errors",
+            "name": "A",
+            "query": "kong_http_requests_total{code=~\"[45]..\"}"
+          }
+        ],
+        "queryType": 3,
+        "id": "total-errors-query"
+      },
+      "thresholds": [
+        {
+          "color": "#EF4444",
+          "isEditEnabled": false,
+          "label": "High",
+          "value": 1000
+        },
+        {
+          "color": "#F59E0B",
+          "isEditEnabled": false,
+          "label": "Medium",
+          "value": 100
+        },
+        {
+          "color": "#10B981",
+          "isEditEnabled": false,
+          "label": "Low",
+          "value": 0
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Errors",
+      "yAxisUnit": "short",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false
+    },
+    {
+      "description": "Error rate as percentage of total requests",
+      "id": "error-rate",
+      "panelTypes": "time_series",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Error Rate %",
+            "name": "A",
+            "query": "(rate(kong_http_requests_total{code=~\"[45]..\"}[5m]) / rate(kong_http_requests_total[5m])) * 100"
+          }
+        ],
+        "queryType": 3,
+        "id": "error-rate-query"
+      },
+      "thresholds": [
+        {
+          "color": "#EF4444",
+          "isEditEnabled": false,
+          "label": "High",
+          "value": 5
+        },
+        {
+          "color": "#F59E0B",
+          "isEditEnabled": false,
+          "label": "Medium",
+          "value": 1
+        },
+        {
+          "color": "#10B981",
+          "isEditEnabled": false,
+          "label": "Good",
+          "value": 0
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Error Rate",
+      "yAxisUnit": "percent",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false
+    },
+    {
+      "description": "Distribution of specific error status codes",
+      "id": "error-codes-distribution",
+      "panelTypes": "time_series",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{code}}",
+            "name": "A",
+            "query": "rate(kong_http_requests_total{code=~\"[45]..\"}[5m])"
+          }
+        ],
+        "queryType": 3,
+        "id": "error-codes-distribution-query"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Error Codes Distribution",
+      "yAxisUnit": "reqps",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": true,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false
+    },
+    {
+      "description": "Kong datastore connectivity status (1 = reachable, 0 = unreachable)",
+      "id": "datastore-reachable",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Datastore Status",
+            "name": "A",
+            "query": "kong_datastore_reachable"
+          }
+        ],
+        "queryType": 3,
+        "id": "datastore-reachable-query"
+      },
+      "thresholds": [
+        {
+          "color": "#10B981",
+          "isEditEnabled": false,
+          "label": "Reachable",
+          "value": 1
+        },
+        {
+          "color": "#EF4444",
+          "isEditEnabled": false,
+          "label": "Unreachable",
+          "value": 0
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Datastore Status",
+      "yAxisUnit": "short",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false
+    },
+    {
+      "description": "Upstream success rate as percentage of total upstream requests",
+      "id": "upstream-success-rate",
+      "panelTypes": "time_series",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Success Rate %",
+            "name": "A",
+            "query": "(rate(kong_http_requests_total{code=~\"2..\"}[5m]) / rate(kong_http_requests_total[5m])) * 100"
+          }
+        ],
+        "queryType": 3,
+        "id": "upstream-success-rate-query"
+      },
+      "thresholds": [
+        {
+          "color": "#10B981",
+          "isEditEnabled": false,
+          "label": "Excellent",
+          "value": 99
+        },
+        {
+          "color": "#F59E0B",
+          "isEditEnabled": false,
+          "label": "Good",
+          "value": 95
+        },
+        {
+          "color": "#EF4444",
+          "isEditEnabled": false,
+          "label": "Poor",
+          "value": 0
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Upstream Success Rate",
+      "yAxisUnit": "percent",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false
+    },
+    {
+      "description": "Number of currently active upstreams",
+      "id": "active-upstreams",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Active Upstreams",
+            "name": "A",
+            "query": "count(up{job=~\".*kong.*\"})"
+          }
+        ],
+        "queryType": 3,
+        "id": "active-upstreams-query"
+      },
+      "thresholds": [
+        {
+          "color": "#10B981",
+          "isEditEnabled": false,
+          "label": "Healthy",
+          "value": 1
+        },
+        {
+          "color": "#EF4444",
+          "isEditEnabled": false,
+          "label": "None",
+          "value": 0
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Upstreams",
+      "yAxisUnit": "short",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false
+    },
+    {
+      "description": "Average upstream response time across all upstreams",
+      "id": "upstream-response-time",
+      "panelTypes": "time_series",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Upstream Response Time",
+            "name": "A",
+            "query": "rate(kong_upstream_latency_ms_sum[5m]) / rate(kong_upstream_latency_ms_count[5m])"
+          }
+        ],
+        "queryType": 3,
+        "id": "upstream-response-time-query"
+      },
+      "thresholds": [
+        {
+          "color": "#EF4444",
+          "isEditEnabled": false,
+          "label": "Slow",
+          "value": 2000
+        },
+        {
+          "color": "#F59E0B",
+          "isEditEnabled": false,
+          "label": "Medium",
+          "value": 1000
+        },
+        {
+          "color": "#10B981",
+          "isEditEnabled": false,
+          "label": "Fast",
+          "value": 0
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Upstream Response Time",
+      "yAxisUnit": "ms",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false
+    },
+    {
+      "description": "Nginx connection states (active, reading, writing, waiting)",
+      "id": "nginx-connections",
+      "panelTypes": "time_series",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{state}}",
+            "name": "A",
+            "query": "kong_nginx_connections_total"
+          }
+        ],
+        "queryType": 3,
+        "id": "nginx-connections-query"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Nginx Connections",
+      "yAxisUnit": "short",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": true,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false
+    },
+    {
+      "description": "Request rate per route/service breakdown",
+      "id": "requests-per-route",
+      "panelTypes": "time_series",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{service}}/{{route}}",
+            "name": "A",
+            "query": "rate(kong_http_requests_total[5m])"
+          }
+        ],
+        "queryType": 3,
+        "id": "requests-per-route-query"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Requests per Route/Service",
+      "yAxisUnit": "reqps",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false
+    },
+    {
+      "description": "Network bandwidth usage (ingress and egress)",
+      "id": "bandwidth-usage",
+      "panelTypes": "time_series",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{type}}",
+            "name": "A",
+            "query": "rate(kong_bandwidth_bytes[5m])"
+          }
+        ],
+        "queryType": 3,
+        "id": "bandwidth-usage-query"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Bandwidth Usage",
+      "yAxisUnit": "Bps",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false
+    },
+    {
+      "description": "Plugin execution time and performance metrics",
+      "id": "plugin-execution-time",
+      "panelTypes": "time_series",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Plugin Latency",
+            "name": "A",
+            "query": "kong_request_latency_ms - kong_upstream_latency_ms"
+          }
+        ],
+        "queryType": 3,
+        "id": "plugin-execution-time-query"
+      },
+      "thresholds": [
+        {
+          "color": "#EF4444",
+          "isEditEnabled": false,
+          "label": "High",
+          "value": 100
+        },
+        {
+          "color": "#F59E0B",
+          "isEditEnabled": false,
+          "label": "Medium",
+          "value": 50
+        },
+        {
+          "color": "#10B981",
+          "isEditEnabled": false,
+          "label": "Good",
+          "value": 0
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Plugin Execution Time",
+      "yAxisUnit": "ms",
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "fillSpans": false,
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false
+    }
+  ]
+}


### PR DESCRIPTION
/fix https://github.com/SigNoz/signoz/issues/6028
/claim https://github.com/SigNoz/signoz/issues/6028

## Kong Gateway Monitoring Dashboard

Comprehensive monitoring dashboard for Kong API Gateway using Prometheus plugin metrics.

### 23 Panels in 6 Sections

| Section | Panels | Key Metrics |
|---------|--------|-------------|
| **General Overview** | 5 | Total requests, active connections, uptime, CPU, memory |
| **Request Metrics** | 4 | Request rate, status codes, request/response sizes |
| **Latency Metrics** | 3 | Average latency, P50/P90/P99 percentiles, upstream latency |
| **Error Metrics** | 4 | Total errors, error rate, code distribution, datastore status |
| **Upstream Health** | 4 | Success rate, active upstreams, response time, nginx connections |
| **Plugin/Route** | 3 | Per-route traffic, bandwidth I/O, plugin overhead |

### Metrics
- `kong_http_requests_total` (service, route, code)
- `kong_request_latency_ms` / `kong_upstream_latency_ms` (histograms)
- `kong_request_size_bytes` / `kong_response_size_bytes`
- `kong_nginx_connections_total` (active, reading, writing, waiting)
- `kong_bandwidth_bytes` (ingress/egress)
- `kong_datastore_reachable`

### Format Compliance
- ✅ All 21 widget keys present on all 23 panels
- ✅ PromQL queries (queryType: 3)
- ✅ File naming: `kong-prometheus-v1.json`
- ✅ README with setup + Kong Prometheus plugin configuration
- ✅ Responsive 12-column grid layout

Closes https://github.com/SigNoz/signoz/issues/6028