### PR TITLE
feat: add Tomcat monitoring dashboard

### DIFF
--- a/tomcat/readme.md
+++ b/tomcat/readme.md
@@ -1,0 +1,65 @@
+# Tomcat Dashboard - OTLP
+
+This dashboard provides monitoring for Apache Tomcat application servers using OpenTelemetry JMX Receiver.
+
+## Metrics Ingestion
+
+Configure the OpenTelemetry JMX Receiver to collect Tomcat metrics. Add the following to your OpenTelemetry Collector configuration:
+
+```yaml
+receivers:
+  jmx:
+    jar_path: /opt/opentelemetry-java-contrib-jmx-metrics.jar
+    endpoint: localhost:7199
+    target_system: tomcat,jvm
+    collection_interval: 60s
+    username: admin
+    password: admin
+```
+
+Ensure the JMX metrics JAR is downloaded from the [OpenTelemetry Java Contrib](https://github.com/open-telemetry/opentelemetry-java-contrib/releases) repository.
+
+### Required Metrics
+
+| Metric Name | Type | Description |
+|---|---|---|
+| `tomcat.threads.current` | Gauge | Current thread count |
+| `tomcat.threads.busy` | Gauge | Busy thread count |
+| `tomcat.threads.max_config` | Gauge | Maximum configured threads |
+| `tomcat.request_count` | Sum | Total request count |
+| `tomcat.error_count` | Sum | Total error count |
+| `tomcat.processing_time` | Sum | Total processing time (ns) |
+| `tomcat.sessions.active` | Gauge | Active session count |
+| `tomcat.sessions.created` | Sum | Total sessions created |
+| `tomcat.sessions.expired` | Sum | Total sessions expired |
+| `tomcat.sessions.rejected` | Sum | Total sessions rejected |
+| `jvm.memory.heap.used` | Gauge | JVM heap memory used (bytes) |
+| `jvm.memory.heap.max` | Gauge | JVM heap memory max (bytes) |
+
+## Variables
+
+| Variable | Description |
+|---|---|
+| `host.name` | List of hosts sending Tomcat metrics |
+
+## Dashboard Panels
+
+### Section 1: Tomcat Thread Pool
+- **Active Threads** — Current number of threads (`tomcat.threads.current`)
+- **Busy Threads** — Number of busy threads (`tomcat.threads.busy`)
+- **Max Threads** — Maximum configured threads (`tomcat.threads.max_config`)
+
+### Section 2: Request Metrics
+- **Request Rate** — Rate of requests per second (`tomcat.request_count`)
+- **Error Rate** — Rate of errors per second (`tomcat.error_count`)
+- **Processing Time Rate** — Rate of processing time (`tomcat.processing_time`, ns)
+
+### Section 3: Session Metrics
+- **Active Sessions** — Number of active sessions (`tomcat.sessions.active`)
+- **Created Sessions** — Rate of sessions created (`tomcat.sessions.created`)
+- **Expired Sessions** — Rate of sessions expired (`tomcat.sessions.expired`)
+- **Rejected Sessions** — Rate of sessions rejected (`tomcat.sessions.rejected`)
+
+### Section 4: JVM Memory
+- **JVM Heap Used** — Heap memory currently used (`jvm.memory.heap.used`)
+- **JVM Heap Max** — Heap memory max available (`jvm.memory.heap.max`)

--- a/tomcat/tomcat-otlp-v1.json
+++ b/tomcat/tomcat-otlp-v1.json
@@ -1,0 +1,1234 @@
+{
+  "id": "tomcat-overview",
+  "description": "Tomcat application server monitoring dashboard. Includes thread pool, request, session, and JVM memory metrics.",
+  "layout": [
+    {
+      "h": 3,
+      "i": "2bf02b5a-7c6c-407e-a186-cb9f75a8e451",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 3,
+      "i": "c7e0f755-d665-4972-bc0f-2f58c0251838",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 0
+    },
+    {
+      "h": 3,
+      "i": "c7404696-b5e6-4b34-8784-7ea2bf9dd90b",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 3
+    },
+    {
+      "h": 3,
+      "i": "fcab3b4b-8f6b-45d3-b82b-1b8dd8eb52ad",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 3
+    },
+    {
+      "h": 3,
+      "i": "217b639d-7ceb-4f7f-9b4f-88f81a645480",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 6
+    },
+    {
+      "h": 3,
+      "i": "b899960e-ba67-45d6-ac28-cf6157de87c5",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 6
+    },
+    {
+      "h": 3,
+      "i": "360b35b4-ffec-4b42-a0a6-060010beb860",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 9
+    },
+    {
+      "h": 3,
+      "i": "614e2ca0-1da1-4356-8192-96666aee5e8c",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 9
+    },
+    {
+      "h": 3,
+      "i": "645e4c1a-58a9-456b-88c1-56dda6936b5f",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 12
+    },
+    {
+      "h": 3,
+      "i": "2fd987e8-3006-48f7-98b6-ac202db443f3",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 12
+    },
+    {
+      "h": 3,
+      "i": "ed752f50-36b1-44bf-ad69-7ab16204d6a3",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 15
+    },
+    {
+      "h": 3,
+      "i": "e6f73a74-6334-4653-ae61-cc39cca002ec",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 15
+    }
+  ],
+  "name": "",
+  "tags": [
+    "tomcat",
+    "java",
+    "jmx"
+  ],
+  "title": "Tomcat Overview",
+  "variables": {
+    "8d4be92a-4ae5-4c2a-b04b-315e3f3cddc9": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "List of hosts sending Tomcat metrics",
+      "id": "8d4be92a-4ae5-4c2a-b04b-315e3f3cddc9",
+      "key": "8d4be92a-4ae5-4c2a-b04b-315e3f3cddc9",
+      "modificationUUID": "bae8d6a3-e794-4ee3-81ce-49b26b9fa0d2",
+      "multiSelect": true,
+      "name": "host.name",
+      "order": 0,
+      "queryValue": "SELECT JSONExtractString(labels, 'host.name') AS `host.name`\nFROM signoz_metrics.distributed_time_series_v4_1day\nWHERE metric_name = 'tomcat.threads.current'\nGROUP BY `host.name`",
+      "selectedValue": [],
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "widgets": [
+    {
+      "description": "Current number of threads in the Tomcat thread pool.",
+      "fillSpans": false,
+      "id": "2bf02b5a-7c6c-407e-a186-cb9f75a8e451",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "tomcat.threads.current--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "tomcat.threads.current",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b1ca94ed",
+                    "key": {
+                      "dataType": "string",
+                      "id": "host.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "host.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.host.name}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Active Threads",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b5720a23-9b1a-4242-a5de-b04dc9a947f8",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Threads",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Number of busy threads in the Tomcat thread pool.",
+      "fillSpans": false,
+      "id": "c7e0f755-d665-4972-bc0f-2f58c0251838",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "tomcat.threads.busy--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "tomcat.threads.busy",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "924a9914",
+                    "key": {
+                      "dataType": "string",
+                      "id": "host.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "host.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.host.name}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Busy Threads",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b276a8ba-f48c-4cd8-aa5f-13d6412de12b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Busy Threads",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Maximum configured threads in the Tomcat thread pool.",
+      "fillSpans": false,
+      "id": "c7404696-b5e6-4b34-8784-7ea2bf9dd90b",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "tomcat.threads.max_config--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "tomcat.threads.max_config",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "3b66d3e5",
+                    "key": {
+                      "dataType": "string",
+                      "id": "host.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "host.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.host.name}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Max Threads",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b45b5e79-0fd4-44ed-92f0-fb1b0f417760",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Max Threads",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Rate of Tomcat requests per second.",
+      "fillSpans": false,
+      "id": "fcab3b4b-8f6b-45d3-b82b-1b8dd8eb52ad",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "tomcat.request_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "tomcat.request_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "be1db920",
+                    "key": {
+                      "dataType": "string",
+                      "id": "host.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "host.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.host.name}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Request Rate",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "5ae8adeb-2b6e-44e1-9728-8c9c84344f1e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Rate",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Rate of Tomcat errors per second.",
+      "fillSpans": false,
+      "id": "217b639d-7ceb-4f7f-9b4f-88f81a645480",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "tomcat.error_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "tomcat.error_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b52112af",
+                    "key": {
+                      "dataType": "string",
+                      "id": "host.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "host.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.host.name}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Error Rate",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0a40f75a-b983-4445-ae9a-54fcdcedd1ae",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Error Rate",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Rate of Tomcat processing time.",
+      "fillSpans": false,
+      "id": "b899960e-ba67-45d6-ac28-cf6157de87c5",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "tomcat.processing_time--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "tomcat.processing_time",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "068c4134",
+                    "key": {
+                      "dataType": "string",
+                      "id": "host.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "host.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.host.name}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Processing Time Rate",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "16ec1586-f27b-4d09-a99c-6cbfdadfd140",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Processing Time Rate",
+      "yAxisUnit": "ns"
+    },
+    {
+      "description": "Number of active sessions in Tomcat.",
+      "fillSpans": false,
+      "id": "360b35b4-ffec-4b42-a0a6-060010beb860",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "tomcat.sessions.active--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "tomcat.sessions.active",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "a887e85c",
+                    "key": {
+                      "dataType": "string",
+                      "id": "host.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "host.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.host.name}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Active Sessions",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "10a58679-f93f-4739-a1b1-312c3b7a09cb",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Sessions",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Rate of sessions created in Tomcat.",
+      "fillSpans": false,
+      "id": "614e2ca0-1da1-4356-8192-96666aee5e8c",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "tomcat.sessions.created--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "tomcat.sessions.created",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "2c2b7f8c",
+                    "key": {
+                      "dataType": "string",
+                      "id": "host.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "host.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.host.name}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Created Sessions",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "3a4ea01d-981c-4a31-a3e6-592bcda53291",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Created Sessions",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Rate of sessions expired in Tomcat.",
+      "fillSpans": false,
+      "id": "645e4c1a-58a9-456b-88c1-56dda6936b5f",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "tomcat.sessions.expired--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "tomcat.sessions.expired",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f2c75fff",
+                    "key": {
+                      "dataType": "string",
+                      "id": "host.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "host.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.host.name}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Expired Sessions",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9af1c3ee-7f34-41e1-8fb0-8e5be1970fb4",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Expired Sessions",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Rate of sessions rejected in Tomcat.",
+      "fillSpans": false,
+      "id": "2fd987e8-3006-48f7-98b6-ac202db443f3",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "tomcat.sessions.rejected--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "tomcat.sessions.rejected",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "374e3fab",
+                    "key": {
+                      "dataType": "string",
+                      "id": "host.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "host.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.host.name}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Rejected Sessions",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d0d7d846-6562-4d4c-bf7d-6f1190f4f0cc",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Rejected Sessions",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "JVM heap memory currently used.",
+      "fillSpans": false,
+      "id": "ed752f50-36b1-44bf-ad69-7ab16204d6a3",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm.memory.heap.used--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm.memory.heap.used",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "14db4d5d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "host.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "host.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.host.name}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "pool.name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "pool.name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "JVM Heap Used",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "3b5e334a-700a-4d6e-abe6-3495b4030989",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "JVM Heap Used",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "JVM heap memory max available.",
+      "fillSpans": false,
+      "id": "e6f73a74-6334-4653-ae61-cc39cca002ec",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm.memory.heap.max--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm.memory.heap.max",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "81a96245",
+                    "key": {
+                      "dataType": "string",
+                      "id": "host.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "host.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.host.name}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "pool.name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "pool.name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "JVM Heap Max",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "79a9b513-ec25-4868-8a55-423191ede105",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "JVM Heap Max",
+      "yAxisUnit": "bytes"
+    }
+  ]
+}


### PR DESCRIPTION
## Description
Adds a new monitoring dashboard for Apache Tomcat application server.

### Panels
- **Thread Pool**: Active Threads, Busy Threads, Max Threads
- **Request Metrics**: Request Rate, Error Rate, Processing Time Rate
- **Session Metrics**: Active, Created, Expired, Rejected Sessions
- **JVM Memory**: Heap Used, Heap Max

### Metrics Source
Metrics collected via OpenTelemetry JMX Receiver for Tomcat.

Related to SigNoz issue: https://github.com/SigNoz/signoz/issues/9200