### PR TITLE
feat: add CloudNativePG monitoring dashboard

### DIFF
--- a/cloudnativepg/cloudnativepg-otlp-v1.json
+++ b/cloudnativepg/cloudnativepg-otlp-v1.json
@@ -1,0 +1,2136 @@
+{
+  "id": "cloudnativepg-overview",
+  "description": "CloudNativePG monitoring dashboard for PostgreSQL clusters on Kubernetes. Monitors cluster health, instance status, replication, WAL archiving, connections, database size, CPU/memory, and backup status.",
+  "layout": [
+    {
+      "h": 3,
+      "i": "b0f8b16c-a1dd-47da-a2ad-b4ad9979f90c",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 3,
+      "i": "20e3b952-8dfb-4a02-ba0b-d02ff351a9d5",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 0
+    },
+    {
+      "h": 3,
+      "i": "3e7a16ce-9b83-47b5-b054-7302c76c951d",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 3
+    },
+    {
+      "h": 3,
+      "i": "6be0806e-a91e-4730-89ea-a083c5be56ae",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 3
+    },
+    {
+      "h": 3,
+      "i": "d4a3b5b0-9a19-4b70-b2a3-c96125a61653",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 6
+    },
+    {
+      "h": 3,
+      "i": "99118a20-6b53-4d27-98d0-86b4ee4c0549",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 6
+    },
+    {
+      "h": 3,
+      "i": "85e34739-a6f5-430a-815b-8d8fe60e5087",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 9
+    },
+    {
+      "h": 3,
+      "i": "4f4c4c35-d00c-4cd0-8ccb-efba36bf4ff2",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 9
+    },
+    {
+      "h": 3,
+      "i": "ebfc12ed-3acc-426e-aa00-5efe67472354",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 12
+    },
+    {
+      "h": 3,
+      "i": "84330cc9-421a-449c-91f8-273da703f3eb",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 12
+    },
+    {
+      "h": 3,
+      "i": "6c383205-784b-469d-b54a-0cd9ecc81144",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 15
+    },
+    {
+      "h": 3,
+      "i": "9101aeed-9399-4a6e-bc29-b68a1dd53391",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 15
+    },
+    {
+      "h": 3,
+      "i": "df4d3142-a016-4aee-8fd3-58fb750eebf5",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 18
+    },
+    {
+      "h": 3,
+      "i": "0cf10ae8-e25d-4ca7-aacf-12fc55f56c80",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 18
+    },
+    {
+      "h": 3,
+      "i": "5b961158-e06c-4cfc-8541-2b8db6a5fb08",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 21
+    },
+    {
+      "h": 3,
+      "i": "a391a753-019c-4ce4-a3a3-d263e5db998b",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 21
+    },
+    {
+      "h": 3,
+      "i": "7160ce19-7c91-4e53-b7d3-be0cd335fad0",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 24
+    },
+    {
+      "h": 3,
+      "i": "9bdba8a1-259f-4399-90a0-b7f43c6544f4",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 24
+    }
+  ],
+  "name": "",
+  "tags": [
+    "cloudnativepg",
+    "cnpg",
+    "postgresql",
+    "kubernetes"
+  ],
+  "title": "CloudNativePG Overview",
+  "variables": {
+    "026dde4c-2f7f-476c-836d-7784224a586a": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "CloudNativePG cluster name",
+      "id": "149352d8-a232-4d6a-8f09-4ab0903fff05",
+      "key": "de7c968b-9c3a-46cb-b907-1df968107672",
+      "modificationUUID": "2326ecaf-20d6-4149-b1b5-b4666c21b4fb",
+      "multiSelect": true,
+      "name": "cnpg_cluster",
+      "order": 0,
+      "queryValue": "SELECT JSONExtractString(labels, 'cnpg_cluster') AS cnpg_cluster\nFROM signoz_metrics.distributed_time_series_v4_1day\nWHERE metric_name = 'cnpg_collector_up'\nGROUP BY cnpg_cluster",
+      "selectedValue": [],
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "a86f277b-58b6-4252-a071-0488ef90a611": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "CloudNativePG instance name",
+      "id": "5fa01334-b202-4dff-9d9e-55139e6ab0e8",
+      "key": "d6924666-769c-4117-99dc-8b608d022698",
+      "modificationUUID": "e5a3a133-0664-4a07-b47c-0410b9a9a4c7",
+      "multiSelect": true,
+      "name": "cnpg_instance",
+      "order": 1,
+      "queryValue": "SELECT JSONExtractString(labels, 'cnpg_instance') AS cnpg_instance\nFROM signoz_metrics.distributed_time_series_v4_1day\nWHERE metric_name = 'cnpg_collector_up'\nGROUP BY cnpg_instance",
+      "selectedValue": [],
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "84c8b42c-9686-4a12-977f-b5b3a749cd0d": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Kubernetes node name",
+      "id": "2690d902-a909-46cb-af3a-ee3bdbb506a3",
+      "key": "c8a099f5-247e-437f-b8d1-a05d260df29a",
+      "modificationUUID": "a7827506-4267-4d3b-9dea-456194a2820f",
+      "multiSelect": true,
+      "name": "k8s.node.name",
+      "order": 2,
+      "queryValue": "SELECT JSONExtractString(labels, 'k8s.node.name') AS `k8s.node.name`\nFROM signoz_metrics.distributed_time_series_v4_1day\nWHERE metric_name = 'cnpg_collector_up'\nGROUP BY `k8s.node.name`",
+      "selectedValue": [],
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "widgets": [
+    {
+      "description": "CloudNativePG instance up status (1=up, 0=down)",
+      "fillSpans": false,
+      "id": "b0f8b16c-a1dd-47da-a2ad-b4ad9979f90c",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_collector_up--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_collector_up",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "e50bc591",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cnpg_cluster--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cnpg_cluster",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cnpg_cluster}}"
+                    ]
+                  },
+                  {
+                    "id": "54b12053",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cnpg_instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cnpg_instance",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cnpg_instance}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "cnpg_instance--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "cnpg_instance",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{cnpg_instance}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "aa8e4f91-8f4c-4dbb-bae5-09698296f7d6",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreferance": {
+        "relativeTime": 3600,
+        "stepInterval": 60,
+        "timeGaps": true
+      },
+      "title": "Instance Status"
+    },
+    {
+      "description": "Time since PostgreSQL instance started",
+      "fillSpans": false,
+      "id": "20e3b952-8dfb-4a02-ba0b-d02ff351a9d5",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_collector_pg_postmaster_uptime_seconds--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_collector_pg_postmaster_uptime_seconds",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "78b13ece",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cnpg_cluster--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cnpg_cluster",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cnpg_cluster}}"
+                    ]
+                  },
+                  {
+                    "id": "e6ba0fc0",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cnpg_instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cnpg_instance",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cnpg_instance}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "cnpg_instance--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "cnpg_instance",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{cnpg_instance}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "2bb37ea5-7301-470f-94f8-46f4ba3c95b3",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreferance": {
+        "relativeTime": 3600,
+        "stepInterval": 60,
+        "timeGaps": true
+      },
+      "title": "Cluster Uptime (seconds)"
+    },
+    {
+      "description": "Number of active database connections by state",
+      "fillSpans": false,
+      "id": "3e7a16ce-9b83-47b5-b054-7302c76c951d",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_collector_pg_stat_activity_count--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_collector_pg_stat_activity_count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "860aa811",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cnpg_cluster--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cnpg_cluster",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cnpg_cluster}}"
+                    ]
+                  },
+                  {
+                    "id": "5f5052ed",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cnpg_instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cnpg_instance",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cnpg_instance}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "cnpg_instance--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "cnpg_instance",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "state--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "state",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{cnpg_instance}} - {{state}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "81e9067c-931d-439b-bfda-ece5072da6cb",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreferance": {
+        "relativeTime": 3600,
+        "stepInterval": 60,
+        "timeGaps": true
+      },
+      "title": "Active Connections"
+    },
+    {
+      "description": "Maximum number of allowed connections per instance",
+      "fillSpans": false,
+      "id": "6be0806e-a91e-4730-89ea-a083c5be56ae",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_collector_pg_settings_max_connections--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_collector_pg_settings_max_connections",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b62fd833",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cnpg_cluster--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cnpg_cluster",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cnpg_cluster}}"
+                    ]
+                  },
+                  {
+                    "id": "b3c4049f",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cnpg_instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cnpg_instance",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cnpg_instance}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "cnpg_instance--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "cnpg_instance",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{cnpg_instance}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "7717f091-04a5-4a06-8829-649fd759bb42",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreferance": {
+        "relativeTime": 3600,
+        "stepInterval": 60,
+        "timeGaps": true
+      },
+      "title": "Max Connections"
+    },
+    {
+      "description": "Total database size in bytes per database",
+      "fillSpans": false,
+      "id": "d4a3b5b0-9a19-4b70-b2a3-c96125a61653",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_collector_pg_database_size_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_collector_pg_database_size_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "8ad86ed0",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cnpg_cluster--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cnpg_cluster",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cnpg_cluster}}"
+                    ]
+                  },
+                  {
+                    "id": "2982070a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cnpg_instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cnpg_instance",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cnpg_instance}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "cnpg_instance--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "cnpg_instance",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "datname--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "datname",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{cnpg_instance}} - {{datname}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c8b282ba-0b44-4613-b380-b6fddfb065cf",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreferance": {
+        "relativeTime": 3600,
+        "stepInterval": 60,
+        "timeGaps": true
+      },
+      "title": "Database Size (bytes)"
+    },
+    {
+      "description": "Number of committed transactions",
+      "fillSpans": false,
+      "id": "99118a20-6b53-4d27-98d0-86b4ee4c0549",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_collector_pg_stat_database_xact_commit--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_collector_pg_stat_database_xact_commit",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "85bdd265",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cnpg_cluster--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cnpg_cluster",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cnpg_cluster}}"
+                    ]
+                  },
+                  {
+                    "id": "e0bdd4d7",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cnpg_instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cnpg_instance",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cnpg_instance}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "cnpg_instance--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "cnpg_instance",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "datname--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "datname",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{cnpg_instance}} - {{datname}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "20defa9d-f81c-4b9f-bde1-b81cfc5837d7",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreferance": {
+        "relativeTime": 3600,
+        "stepInterval": 60,
+        "timeGaps": true
+      },
+      "title": "Transactions (committed)"
+    },
+    {
+      "description": "Replication lag between primary and replicas",
+      "fillSpans": false,
+      "id": "85e34739-a6f5-430a-815b-8d8fe60e5087",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_collector_pg_replication_lag_seconds--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_collector_pg_replication_lag_seconds",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "18d83390",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cnpg_cluster--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cnpg_cluster",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cnpg_cluster}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "cnpg_instance--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "cnpg_instance",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{cnpg_instance}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "82489c9a-5ca3-4f46-9aba-0dcd4050c38b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreferance": {
+        "relativeTime": 3600,
+        "stepInterval": 60,
+        "timeGaps": true
+      },
+      "title": "Replication Lag (seconds)"
+    },
+    {
+      "description": "Replication lag in bytes",
+      "fillSpans": false,
+      "id": "4f4c4c35-d00c-4cd0-8ccb-efba36bf4ff2",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_collector_pg_replication_lag_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_collector_pg_replication_lag_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "97d1435e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cnpg_cluster--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cnpg_cluster",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cnpg_cluster}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "cnpg_instance--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "cnpg_instance",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{cnpg_instance}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f7c7e564-eaa8-4b39-aa94-bd744a3d7863",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreferance": {
+        "relativeTime": 3600,
+        "stepInterval": 60,
+        "timeGaps": true
+      },
+      "title": "Replication Lag (bytes)"
+    },
+    {
+      "description": "Number of WAL files successfully archived",
+      "fillSpans": false,
+      "id": "ebfc12ed-3acc-426e-aa00-5efe67472354",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_collector_pg_stat_archiver_archived_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_collector_pg_stat_archiver_archived_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "31510d57",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cnpg_cluster--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cnpg_cluster",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cnpg_cluster}}"
+                    ]
+                  },
+                  {
+                    "id": "9d4540a0",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cnpg_instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cnpg_instance",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cnpg_instance}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "cnpg_instance--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "cnpg_instance",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{cnpg_instance}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d54f98dc-033d-4556-a1e7-e7908c8ee58c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreferance": {
+        "relativeTime": 3600,
+        "stepInterval": 60,
+        "timeGaps": true
+      },
+      "title": "WAL Archived Count"
+    },
+    {
+      "description": "Number of failed WAL archive attempts",
+      "fillSpans": false,
+      "id": "84330cc9-421a-449c-91f8-273da703f3eb",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_collector_pg_stat_archiver_failed_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_collector_pg_stat_archiver_failed_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "7cfda332",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cnpg_cluster--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cnpg_cluster",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cnpg_cluster}}"
+                    ]
+                  },
+                  {
+                    "id": "be1c6246",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cnpg_instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cnpg_instance",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cnpg_instance}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "cnpg_instance--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "cnpg_instance",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{cnpg_instance}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ffdd27f3-034a-4876-89de-5fe872183d10",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreferance": {
+        "relativeTime": 3600,
+        "stepInterval": 60,
+        "timeGaps": true
+      },
+      "title": "WAL Archive Failures"
+    },
+    {
+      "description": "Container CPU usage in seconds (rate)",
+      "fillSpans": false,
+      "id": "6c383205-784b-469d-b54a-0cd9ecc81144",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "container_cpu_usage_seconds_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "container_cpu_usage_seconds_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "64fa476e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "k8s.pod.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "k8s.pod.name",
+                      "type": "tag"
+                    },
+                    "op": "contains",
+                    "value": "{{.cnpg_cluster}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "k8s.pod.name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "k8s.pod.name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{k8s.pod.name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f3bf57d5-b139-4ad8-b734-6f0f802fe6f5",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreferance": {
+        "relativeTime": 3600,
+        "stepInterval": 60,
+        "timeGaps": true
+      },
+      "title": "CPU Usage (seconds)"
+    },
+    {
+      "description": "Container memory working set in bytes",
+      "fillSpans": false,
+      "id": "9101aeed-9399-4a6e-bc29-b68a1dd53391",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "container_memory_working_set_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "container_memory_working_set_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b8e71938",
+                    "key": {
+                      "dataType": "string",
+                      "id": "k8s.pod.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "k8s.pod.name",
+                      "type": "tag"
+                    },
+                    "op": "contains",
+                    "value": "{{.cnpg_cluster}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "k8s.pod.name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "k8s.pod.name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{k8s.pod.name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "22af18ba-7742-4457-9d81-e50aa8127090",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreferance": {
+        "relativeTime": 3600,
+        "stepInterval": 60,
+        "timeGaps": true
+      },
+      "title": "Memory Working Set (bytes)"
+    },
+    {
+      "description": "Buffers written during checkpoints vs backends",
+      "fillSpans": false,
+      "id": "df4d3142-a016-4aee-8fd3-58fb750eebf5",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_collector_pg_stat_bgwriter_buffers_checkpoint--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_collector_pg_stat_bgwriter_buffers_checkpoint",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "be9f026b",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cnpg_cluster--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cnpg_cluster",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cnpg_cluster}}"
+                    ]
+                  },
+                  {
+                    "id": "2511f0e4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cnpg_instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cnpg_instance",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cnpg_instance}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "cnpg_instance--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "cnpg_instance",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "checkpoint - {{cnpg_instance}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8f3060e8-65e4-4daa-b491-a873441df0b5",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreferance": {
+        "relativeTime": 3600,
+        "stepInterval": 60,
+        "timeGaps": true
+      },
+      "title": "Checkpoint Buffers"
+    },
+    {
+      "description": "Time spent writing checkpoint data to disk",
+      "fillSpans": false,
+      "id": "0cf10ae8-e25d-4ca7-aacf-12fc55f56c80",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_collector_pg_stat_bgwriter_checkpoint_write_time--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_collector_pg_stat_bgwriter_checkpoint_write_time",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b7bdf907",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cnpg_cluster--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cnpg_cluster",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cnpg_cluster}}"
+                    ]
+                  },
+                  {
+                    "id": "b3f793b8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cnpg_instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cnpg_instance",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cnpg_instance}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "cnpg_instance--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "cnpg_instance",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{cnpg_instance}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "86f11cdd-49c6-449a-a837-cf01842cb4e8",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreferance": {
+        "relativeTime": 3600,
+        "stepInterval": 60,
+        "timeGaps": true
+      },
+      "title": "Checkpoint Write Time (ms)"
+    },
+    {
+      "description": "Number of deadlocks detected per database",
+      "fillSpans": false,
+      "id": "5b961158-e06c-4cfc-8541-2b8db6a5fb08",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_collector_pg_stat_database_deadlocks--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_collector_pg_stat_database_deadlocks",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "ffeba39f",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cnpg_cluster--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cnpg_cluster",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cnpg_cluster}}"
+                    ]
+                  },
+                  {
+                    "id": "225a596d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cnpg_instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cnpg_instance",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cnpg_instance}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "cnpg_instance--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "cnpg_instance",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "datname--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "datname",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{cnpg_instance}} - {{datname}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a72acff7-79e3-4bc1-92e1-61fa1efa7c11",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreferance": {
+        "relativeTime": 3600,
+        "stepInterval": 60,
+        "timeGaps": true
+      },
+      "title": "Deadlocks"
+    },
+    {
+      "description": "Buffer cache hit ratio (blks_hit / (blks_hit + blks_read))",
+      "fillSpans": false,
+      "id": "a391a753-019c-4ce4-a3a3-d263e5db998b",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_collector_pg_stat_database_blks_hit--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_collector_pg_stat_database_blks_hit",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "218958ec",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cnpg_cluster--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cnpg_cluster",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cnpg_cluster}}"
+                    ]
+                  },
+                  {
+                    "id": "7330a177",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cnpg_instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cnpg_instance",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cnpg_instance}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "cnpg_instance--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "cnpg_instance",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "datname--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "datname",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{cnpg_instance}} - {{datname}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "655eca27-13cc-4aa1-9551-5cde46e95968",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreferance": {
+        "relativeTime": 3600,
+        "stepInterval": 60,
+        "timeGaps": true
+      },
+      "title": "Cache Hit Ratio"
+    },
+    {
+      "description": "Number of cluster reconciliation errors from the operator",
+      "fillSpans": false,
+      "id": "7160ce19-7c91-4e53-b7d3-be0cd335fad0",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_collector_pg_stat_replication_replay_lag--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_collector_pg_stat_replication_replay_lag",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "af18c4d8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cnpg_cluster--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cnpg_cluster",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cnpg_cluster}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "cnpg_instance--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "cnpg_instance",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{cnpg_instance}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "85b9c48d-270f-4068-9cce-28a85083834b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreferance": {
+        "relativeTime": 3600,
+        "stepInterval": 60,
+        "timeGaps": true
+      },
+      "title": "Cluster Reconcile Errors"
+    },
+    {
+      "description": "Last backup completion status",
+      "fillSpans": false,
+      "id": "9bdba8a1-259f-4399-90a0-b7f43c6544f4",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cnpg_collector_pg_postmaster_uptime_seconds--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cnpg_collector_pg_postmaster_uptime_seconds",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "acf38d8f",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cnpg_cluster--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cnpg_cluster",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cnpg_cluster}}"
+                    ]
+                  },
+                  {
+                    "id": "605f9eff",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cnpg_instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cnpg_instance",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.cnpg_instance}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "cnpg_instance--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "cnpg_instance",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{cnpg_instance}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9cd89f32-b1cb-4e3e-9366-335020a35b1c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "timePreferance": {
+        "relativeTime": 3600,
+        "stepInterval": 60,
+        "timeGaps": true
+      },
+      "title": "Backup Status"
+    }
+  ]
+}

--- a/cloudnativepg/readme.md
+++ b/cloudnativepg/readme.md
@@ -1,0 +1,70 @@
+# CloudNativePG Dashboard
+
+This dashboard provides monitoring for [CloudNativePG](https://cloudnative-pg.io/) PostgreSQL clusters running on Kubernetes.
+
+## Panels
+
+### Health
+- **Instance Status** — Instance up status (1=up, 0=down) per CNPG instance
+- **Uptime (seconds)** — Time since each PostgreSQL instance started
+
+### Connections
+- **Connections by State** — Active connections grouped by state (active, idle, idle in transaction, etc.)
+- **Max Connections** — Maximum allowed connections per instance
+
+### Database
+- **Database Size (bytes)** — Total database size per database and instance
+- **Transactions Committed** — Committed transactions per second (rate)
+
+### Replication
+- **Replication Lag (seconds)** — Replication delay between primary and replicas
+- **Replication Lag (bytes)** — Replication delay in bytes
+
+### WAL Archiving
+- **WAL Archived (rate)** — WAL files successfully archived per second
+- **WAL Archive Failures (rate)** — Failed WAL archive attempts per second
+
+### Resources
+- **CPU Usage (cores)** — Container CPU usage rate
+- **Memory Working Set (bytes)** — Container memory usage
+
+### Checkpoints
+- **Checkpoint Buffers Written** — Buffers written during checkpoints
+- **Checkpoint Write Time (ms)** — Time spent writing checkpoint data
+
+### Operations
+- **Deadlocks** — Deadlocks detected per database
+- **Tuple Operations (rate)** — Tuples returned/fetched/inserted/updated/deleted
+
+### Locks & Temp
+- **Active Locks** — Number of locks by mode
+- **Temp Bytes Written (rate)** — Temporary data written to disk
+
+## Variables
+
+| Variable | Description |
+|----------|-------------|
+| `cnpg_cluster` | CloudNativePG cluster name |
+| `cnpg_instance` | CloudNativePG instance name |
+| `k8s.node.name` | Kubernetes node name |
+
+## Metrics Source
+
+This dashboard uses metrics from the CloudNativePG metrics exporter. Key metrics:
+
+- `cnpg_collector_up` — Instance health
+- `cnpg_collector_pg_postmaster_uptime_seconds` — Instance uptime
+- `cnpg_collector_pg_stat_activity_count` — Connection counts
+- `cnpg_collector_pg_database_size_bytes` — Database sizes
+- `cnpg_collector_pg_replication_lag_seconds` — Replication lag
+- `cnpg_collector_pg_stat_archiver_archived_count` — WAL archiver stats
+- `cnpg_collector_pg_stat_database_*` — Per-database statistics
+- `cnpg_collector_pg_stat_bgwriter_*` — Background writer stats
+- `container_cpu_usage_seconds_total` — Container CPU (Kubernetes)
+- `container_memory_working_set_bytes` — Container memory (Kubernetes)
+
+## References
+
+- [CloudNativePG Documentation](https://cloudnative-pg.io/documentation/)
+- [CNPG Grafana Dashboard](https://github.com/cloudnative-pg/grafana-dashboards)
+- [SigNoz Issue #7875](https://github.com/SigNoz/signoz/issues/7875)


### PR DESCRIPTION
## Description
Adds a monitoring dashboard for CloudNativePG (PostgreSQL operator for Kubernetes).

### Panels
- Cluster Health: Instance Status, Uptime
- Connections: Connections by State, Max Connections
- Database: Size, Transactions Committed
- Replication: Lag (seconds & bytes)
- WAL Archiving: Archived Count, Failures
- Resources: CPU Usage, Memory Working Set
- Checkpoints: Buffers Written, Write Time
- Operations: Deadlocks, Tuple Operations
- Locks & Temp: Active Locks, Temp Bytes

### Variables
- cnpg_cluster, cnpg_instance, k8s.node.name

### Metrics Source
Metrics collected via CloudNativePG metrics exporter (cnpg_collector_*).

### References
Related to SigNoz issue: https://github.com/SigNoz/signoz/issues/7875
CNPG Grafana dashboard: https://github.com/cloudnative-pg/grafana-dashboards