### PR TITLE
feat: add Rancher Kubernetes control plane dashboard

### DIFF
--- a/rancher-k8s/README.md
+++ b/rancher-k8s/README.md
@@ -1,0 +1,36 @@
+# Rancher Kubernetes Control Plane Dashboard
+
+This dashboard provides monitoring for Rancher Kubernetes Control Plane components using OpenTelemetry metrics.
+
+## Panels
+
+| Panel | Description | Metric |
+|-------|-------------|--------|
+| API Server Request Rate | Request rate across the Kubernetes API server | `apiserver_request_total` |
+| API Server Request Latency (p99) | p99 latency of API server requests | `apiserver_request_duration_seconds` |
+| etcd WAL Fsync Duration (p99) | p99 WAL fsync latency | `etcd_disk_wal_fsync_duration_seconds` |
+| etcd Backend Commit Duration (p99) | p99 backend commit latency | `etcd_disk_backend_commit_duration_seconds` |
+| Scheduler Queue Depth | Pending items in the scheduler queue | `scheduler_queue_depth` |
+| Controller Manager Work Queue Depth | Pending items in controller manager work queues | `workqueue_depth` |
+| Node Ready Count | Number of ready nodes by node name | `k8s.node.condition_ready` |
+| Pods by Phase | Pod count grouped by phase (Running, Pending, etc.) | `k8s.pod.phase` |
+| CPU Usage | Node CPU utilization | `k8s.node.cpu.utilization` |
+| Memory Usage | Node memory utilization | `k8s.node.memory.utilization` |
+
+## Variables
+
+- `k8s.cluster.name` — Select the target Kubernetes cluster
+- `k8s.namespace.name` — Filter by namespace (multi-select)
+
+## Metrics Source
+
+Kubernetes control plane metrics collected via the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) with the `k8s_cluster` receiver and `kubeletstats` receiver.
+
+## Data Source
+
+Metrics via OpenTelemetry (OTLP).
+
+## Related
+
+- Issue: [SigNoz/signoz#9628](https://github.com/SigNoz/signoz/issues/9628)
+- Reference: [Rancher Monitoring Charts](https://github.com/rancher/charts/tree/dev-v2.12/charts/rancher-monitoring/107.2.2-rc.2%2Bup69.8.2-rancher.26/templates/grafana/dashboards-1.14)

--- a/rancher-k8s/rancher-k8s-otlp-v1.json
+++ b/rancher-k8s/rancher-k8s-otlp-v1.json
@@ -1,0 +1,1070 @@
+{
+  "collapsableRowsMigrated": false,
+  "description": "Rancher Kubernetes Control Plane monitoring dashboard. Shows API Server, etcd, Scheduler, Controller Manager metrics along with cluster resource usage.",
+  "dotMigrated": true,
+  "image": "",
+  "layout": [
+    {
+      "h": 7,
+      "i": "ac42f731-d8ca-42c6-b961-11d10add5432",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 7,
+      "i": "ef41cf4c-5a8a-4cbe-be05-08a97f4d9fb2",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 7
+    },
+    {
+      "h": 7,
+      "i": "a488750f-2f32-46de-8d16-200d11d10383",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 14
+    },
+    {
+      "h": 7,
+      "i": "fb0b29ef-24a8-4429-a98e-394dfa601741",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 14
+    },
+    {
+      "h": 7,
+      "i": "2eabe9c7-bccc-4d37-a7d9-10dfd1f45347",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 21
+    },
+    {
+      "h": 7,
+      "i": "b44427b2-bf49-4ba9-a554-67d35be67761",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 21
+    },
+    {
+      "h": 7,
+      "i": "40f5ee78-edc7-4e06-9ab7-a9f375b2b32a",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 28
+    },
+    {
+      "h": 7,
+      "i": "88fbb735-59fe-4874-96bf-9ad73795934b",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 28
+    },
+    {
+      "h": 7,
+      "i": "b8718410-0069-4ef1-a50f-86efc80e3840",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 35
+    },
+    {
+      "h": 7,
+      "i": "6bdf9997-dd2a-4da2-9e57-85f0b1411cf7",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 35
+    }
+  ],
+  "name": "Rancher Kubernetes Control Plane",
+  "panelMap": {},
+  "tags": [
+    "k8s",
+    "rancher",
+    "kubernetes",
+    "control-plane"
+  ],
+  "title": "Rancher Kubernetes Control Plane",
+  "uploadedGrafana": false,
+  "variables": {
+    "1d437204-1ffc-4a04-abb0-b3e347a8f1c9": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "Name of the cluster",
+      "id": "1d437204-1ffc-4a04-abb0-b3e347a8f1c9",
+      "key": "1d437204-1ffc-4a04-abb0-b3e347a8f1c9",
+      "modificationUUID": "e65bb38e-6ba0-483a-b692-f5093940bd6d",
+      "multiSelect": false,
+      "name": "k8s.cluster.name",
+      "order": 0,
+      "queryValue": "SELECT JSONExtractString(labels, 'k8s.cluster.name') AS `k8s.cluster.name` FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'k8s.container.ready' GROUP BY `k8s.cluster.name`",
+      "showALLOption": false,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "653c8898-6c19-4fbc-9c35-941a1c8e1e13": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "The k8s namespace name",
+      "id": "653c8898-6c19-4fbc-9c35-941a1c8e1e13",
+      "modificationUUID": "5ee37a4d-a12c-4878-bbad-c567d651c511",
+      "multiSelect": true,
+      "name": "k8s.namespace.name",
+      "order": 1,
+      "queryValue": "SELECT JSONExtractString(labels, 'k8s.namespace.name') AS `k8s.namespace.name` FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'k8s.container.ready' AND JSONExtractString(labels, 'k8s.cluster.name') = $k8s.cluster.name GROUP BY `k8s.namespace.name`",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "version": "v4",
+  "widgets": [
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "ac42f731-d8ca-42c6-b961-11d10add5432",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "apiserver_request_total--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "apiserver_request_total",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "77502c2c",
+                    "key": {
+                      "dataType": "string",
+                      "id": "k8s.cluster.name--string--tag--false",
+                      "isColumn": false,
+                      "key": "k8s.cluster.name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.k8s.cluster.name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{resource.k8s.cluster.name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "372ad94a-c69f-480c-8d70-4668456577d6",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "API Server Request Rate",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "ef41cf4c-5a8a-4cbe-be05-08a97f4d9fb2",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "apiserver_request_duration_seconds--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "apiserver_request_duration_seconds",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "p99",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "83479347",
+                    "key": {
+                      "dataType": "string",
+                      "id": "k8s.cluster.name--string--tag--false",
+                      "isColumn": false,
+                      "key": "k8s.cluster.name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.k8s.cluster.name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{resource.k8s.cluster.name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "histogram_p99"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "938ada1d-bbc2-4e64-9c18-20847ddf411a",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "API Server Request Latency (p99)",
+      "yAxisUnit": "s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "a488750f-2f32-46de-8d16-200d11d10383",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "etcd_disk_wal_fsync_duration_seconds--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "etcd_disk_wal_fsync_duration_seconds",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "p99",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b018d552",
+                    "key": {
+                      "dataType": "string",
+                      "id": "k8s.cluster.name--string--tag--false",
+                      "isColumn": false,
+                      "key": "k8s.cluster.name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.k8s.cluster.name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{resource.k8s.cluster.name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "histogram_p99"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c90d568a-3ac3-4b95-b407-5dd27130b729",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "etcd WAL Fsync Duration (p99)",
+      "yAxisUnit": "s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "fb0b29ef-24a8-4429-a98e-394dfa601741",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "etcd_disk_backend_commit_duration_seconds--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "etcd_disk_backend_commit_duration_seconds",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "p99",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "33bfb8f4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "k8s.cluster.name--string--tag--false",
+                      "isColumn": false,
+                      "key": "k8s.cluster.name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.k8s.cluster.name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{resource.k8s.cluster.name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "histogram_p99"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "71653597-4a35-4898-b5e3-1fde3f3fc0d5",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "etcd Backend Commit Duration (p99)",
+      "yAxisUnit": "s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "2eabe9c7-bccc-4d37-a7d9-10dfd1f45347",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "scheduler_queue_depth--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "scheduler_queue_depth",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "3e78ba09",
+                    "key": {
+                      "dataType": "string",
+                      "id": "k8s.cluster.name--string--tag--false",
+                      "isColumn": false,
+                      "key": "k8s.cluster.name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.k8s.cluster.name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{resource.k8s.cluster.name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "dbf721de-6769-4c1c-a41b-656c3d3c7b6e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Scheduler Queue Depth",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "b44427b2-bf49-4ba9-a554-67d35be67761",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "workqueue_depth--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "workqueue_depth",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "94e40654",
+                    "key": {
+                      "dataType": "string",
+                      "id": "k8s.cluster.name--string--tag--false",
+                      "isColumn": false,
+                      "key": "k8s.cluster.name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.k8s.cluster.name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{resource.k8s.cluster.name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6c1741d4-f513-4f05-a52a-1d3e0fa9a712",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Controller Manager Work Queue Depth",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "40f5ee78-edc7-4e06-9ab7-a9f375b2b32a",
+      "isStacked": true,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "k8s.node.condition_ready--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "k8s.node.condition_ready",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "da40a91d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "k8s.cluster.name--string--tag--false",
+                      "isColumn": false,
+                      "key": "k8s.cluster.name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.k8s.cluster.name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "k8s.node.name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "k8s.node.name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{k8s.node.name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "aee222bf-f419-43f7-afb6-f8984bc6634f",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": true,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Node Ready Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "88fbb735-59fe-4874-96bf-9ad73795934b",
+      "isStacked": true,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "k8s.pod.phase--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "k8s.pod.phase",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "3d3686f8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "k8s.cluster.name--string--tag--false",
+                      "isColumn": false,
+                      "key": "k8s.cluster.name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.k8s.cluster.name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "k8s.pod.phase--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "k8s.pod.phase",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{k8s.pod.phase}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "71f9617d-c67d-40cd-9f8a-2b6edd680d28",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": true,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Pods by Phase",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "b8718410-0069-4ef1-a50f-86efc80e3840",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "k8s.node.cpu.utilization--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "k8s.node.cpu.utilization",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "e3fb1976",
+                    "key": {
+                      "dataType": "string",
+                      "id": "k8s.cluster.name--string--tag--false",
+                      "isColumn": false,
+                      "key": "k8s.cluster.name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.k8s.cluster.name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "k8s.node.name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "k8s.node.name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{k8s.node.name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "35d38c67-03aa-4ac3-928a-0bb9fcdc120c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "CPU Usage",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "6bdf9997-dd2a-4da2-9e57-85f0b1411cf7",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "k8s.node.memory.utilization--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "k8s.node.memory.utilization",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "c74cac95",
+                    "key": {
+                      "dataType": "string",
+                      "id": "k8s.cluster.name--string--tag--false",
+                      "isColumn": false,
+                      "key": "k8s.cluster.name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.k8s.cluster.name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "k8s.node.name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "k8s.node.name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{k8s.node.name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a4314761-1d04-4c85-a7c3-35fad749dfb4",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memory Usage",
+      "yAxisUnit": "percent"
+    }
+  ]
+}


### PR DESCRIPTION
## Description
Adds a monitoring dashboard for Rancher Kubernetes Control Plane.

### Panels
- API Server Request Rate/Latency
- etcd WAL Fsync/Backend Commit Duration
- Scheduler Queue Depth, Controller Manager Work Queue
- Node Ready Count, Pods by Phase
- CPU/Memory Usage

### Metrics Source
Kubernetes control plane metrics via OpenTelemetry.

Related to SigNoz issue: https://github.com/SigNoz/signoz/issues/9628