### PR TITLE
feat: add Hadoop monitoring dashboard queries

### DIFF
--- a/hadoop/hadoop-otlp-v1.json
+++ b/hadoop/hadoop-otlp-v1.json
@@ -1,1 +1,4478 @@
-{"layout":[{"h":1,"i":"0e8723fe-970d-4a02-946a-f11a7cbb4b3e","maxH":1,"minH":1,"minW":12,"moved":false,"static":false,"w":12,"x":0,"y":0},{"h":4,"i":"a1011a2a-37da-47e5-ac3d-2b604e2bd1ef","moved":false,"static":false,"w":2,"x":0,"y":1},{"h":4,"i":"70943c30-150c-4110-adbf-13cb1319c8cf","moved":false,"static":false,"w":2,"x":2,"y":1},{"h":4,"i":"de9eb368-f881-46b0-874e-b7fbb0de21cc","moved":false,"static":false,"w":2,"x":4,"y":1},{"h":4,"i":"efebd111-1cbb-4051-8501-3edef7d493be","moved":false,"static":false,"w":2,"x":6,"y":1},{"h":4,"i":"97b667c5-5141-4433-bca0-f1bc5711a49d","moved":false,"static":false,"w":2,"x":8,"y":1},{"h":4,"i":"267c0ef8-8df2-4f09-8e5d-b0eac595f15e","moved":false,"static":false,"w":2,"x":10,"y":1},{"h":1,"i":"57788c0f-5351-4d9d-b4a4-eaec7eb37db1","maxH":1,"minH":1,"minW":12,"moved":false,"static":false,"w":12,"x":0,"y":5},{"h":4,"i":"b2a1d929-8a9f-4eff-8ad4-d9932e760c62","moved":false,"static":false,"w":4,"x":0,"y":6},{"h":4,"i":"d91cd6a7-c1f7-4b8b-a747-1a4a2e0588e7","moved":false,"static":false,"w":4,"x":4,"y":6},{"h":4,"i":"4f705a1b-6e20-4647-bcd8-f972be636460","moved":false,"static":false,"w":4,"x":8,"y":6},{"h":4,"i":"114bb452-5350-41bb-bee7-aba51ea37c23","moved":false,"static":false,"w":2,"x":0,"y":10},{"h":4,"i":"66cb1d57-a6b4-4e75-9ffe-d3931e740d27","moved":false,"static":false,"w":2,"x":2,"y":10},{"h":4,"i":"4a0971b3-f87d-4b5a-a398-7e0a64ed6df6","moved":false,"static":false,"w":2,"x":4,"y":10},{"h":4,"i":"2d24cea2-264a-43e9-b4d9-6298a1e48371","moved":false,"static":false,"w":2,"x":6,"y":10},{"h":4,"i":"7fff698b-24e6-45ff-b5fc-457847101996","moved":false,"static":false,"w":2,"x":8,"y":10},{"h":4,"i":"5857b298-fc8a-4b65-890c-6ae90596170f","moved":false,"static":false,"w":2,"x":10,"y":10},{"h":6,"i":"cec839c9-da6d-4aba-946a-dea00cff40be","moved":false,"static":false,"w":6,"x":0,"y":14},{"h":6,"i":"22198113-656b-47e5-8642-0666c29fa785","moved":false,"static":false,"w":6,"x":6,"y":14},{"h":1,"i":"209f81d2-b96a-4d50-a480-e38ebc37911a","maxH":1,"minH":1,"minW":12,"moved":false,"static":false,"w":12,"x":0,"y":20},{"h":4,"i":"89bd953a-d45f-4182-8a99-6ae2fb2d13fc","moved":false,"static":false,"w":4,"x":0,"y":21},{"h":4,"i":"ad63c678-833a-4b32-ab37-5c3701593659","moved":false,"static":false,"w":4,"x":4,"y":21},{"h":4,"i":"d89a4902-f040-442f-9041-cadbd1d6aea4","moved":false,"static":false,"w":4,"x":8,"y":21},{"h":7,"i":"1198a093-0966-42d8-a794-46286bc792b2","moved":false,"static":false,"w":4,"x":0,"y":25},{"h":7,"i":"737fdbfe-1cc2-4faf-b6f2-5587c0a0a3a0","moved":false,"static":false,"w":4,"x":4,"y":25},{"h":7,"i":"62204433-c0d4-498d-8e42-11a47b47a799","moved":false,"static":false,"w":4,"x":8,"y":25},{"h":6,"i":"bf9c2195-4079-4ed6-bde2-8ae359126c50","moved":false,"static":false,"w":6,"x":0,"y":32},{"h":6,"i":"46d8d065-1931-4889-9419-6ba7b8b3f1a0","moved":false,"static":false,"w":6,"x":6,"y":32}],"panelMap":{"0e8723fe-970d-4a02-946a-f11a7cbb4b3e":{"collapsed":false,"widgets":[{"h":4,"i":"a1011a2a-37da-47e5-ac3d-2b604e2bd1ef","moved":false,"static":false,"w":2,"x":0,"y":1},{"h":4,"i":"70943c30-150c-4110-adbf-13cb1319c8cf","moved":false,"static":false,"w":2,"x":2,"y":1},{"h":4,"i":"de9eb368-f881-46b0-874e-b7fbb0de21cc","moved":false,"static":false,"w":2,"x":4,"y":1},{"h":4,"i":"efebd111-1cbb-4051-8501-3edef7d493be","moved":false,"static":false,"w":2,"x":6,"y":1},{"h":4,"i":"97b667c5-5141-4433-bca0-f1bc5711a49d","moved":false,"static":false,"w":2,"x":8,"y":1},{"h":4,"i":"267c0ef8-8df2-4f09-8e5d-b0eac595f15e","moved":false,"static":false,"w":2,"x":10,"y":1}]},"209f81d2-b96a-4d50-a480-e38ebc37911a":{"collapsed":false,"widgets":[{"h":4,"i":"89bd953a-d45f-4182-8a99-6ae2fb2d13fc","moved":false,"static":false,"w":4,"x":0,"y":46},{"h":4,"i":"ad63c678-833a-4b32-ab37-5c3701593659","moved":false,"static":false,"w":4,"x":4,"y":46},{"h":4,"i":"d89a4902-f040-442f-9041-cadbd1d6aea4","moved":false,"static":false,"w":4,"x":8,"y":46},{"h":7,"i":"1198a093-0966-42d8-a794-46286bc792b2","moved":false,"static":false,"w":4,"x":0,"y":50},{"h":7,"i":"737fdbfe-1cc2-4faf-b6f2-5587c0a0a3a0","moved":false,"static":false,"w":4,"x":4,"y":50},{"h":7,"i":"62204433-c0d4-498d-8e42-11a47b47a799","moved":false,"static":false,"w":4,"x":8,"y":50},{"h":6,"i":"bf9c2195-4079-4ed6-bde2-8ae359126c50","moved":false,"static":false,"w":6,"x":0,"y":57},{"h":6,"i":"46d8d065-1931-4889-9419-6ba7b8b3f1a0","moved":false,"static":false,"w":6,"x":6,"y":57}]},"57788c0f-5351-4d9d-b4a4-eaec7eb37db1":{"collapsed":false,"widgets":[{"h":4,"i":"b2a1d929-8a9f-4eff-8ad4-d9932e760c62","moved":false,"static":false,"w":4,"x":0,"y":14},{"h":4,"i":"d91cd6a7-c1f7-4b8b-a747-1a4a2e0588e7","moved":false,"static":false,"w":4,"x":4,"y":14},{"h":4,"i":"4f705a1b-6e20-4647-bcd8-f972be636460","moved":false,"static":false,"w":4,"x":8,"y":14},{"h":4,"i":"114bb452-5350-41bb-bee7-aba51ea37c23","moved":false,"static":false,"w":2,"x":0,"y":18},{"h":4,"i":"66cb1d57-a6b4-4e75-9ffe-d3931e740d27","moved":false,"static":false,"w":2,"x":2,"y":18},{"h":4,"i":"4a0971b3-f87d-4b5a-a398-7e0a64ed6df6","moved":false,"static":false,"w":2,"x":4,"y":18},{"h":4,"i":"2d24cea2-264a-43e9-b4d9-6298a1e48371","moved":false,"static":false,"w":2,"x":6,"y":18},{"h":4,"i":"7fff698b-24e6-45ff-b5fc-457847101996","moved":false,"static":false,"w":2,"x":8,"y":18},{"h":4,"i":"5857b298-fc8a-4b65-890c-6ae90596170f","moved":false,"static":false,"w":2,"x":10,"y":18},{"h":6,"i":"cec839c9-da6d-4aba-946a-dea00cff40be","moved":false,"static":false,"w":6,"x":0,"y":22},{"h":6,"i":"22198113-656b-47e5-8642-0666c29fa785","moved":false,"static":false,"w":6,"x":6,"y":22}]}},"title":"Hadoop Dashboard","uploadedGrafana":false,"variables":{"4d1d128e-8b58-4ab5-9b77-114ef9b8000e":{"allSelected":false,"customValue":"","description":"The deployment environment for the service.","id":"4d1d128e-8b58-4ab5-9b77-114ef9b8000e","key":"4d1d128e-8b58-4ab5-9b77-114ef9b8000e","modificationUUID":"38dba338-ba78-43f4-89fe-d37a50643ded","multiSelect":false,"name":"deployment_environment","order":0,"queryValue":"SELECT DISTINCT(JSONExtractString(labels, 'deployment_environment'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name like '%hadoop_hdfs_%'","showALLOption":false,"sort":"DISABLED","textboxValue":"","type":"QUERY"},"ab996dc3-7360-48fb-8778-1f530b944025":{"allSelected":false,"customValue":"","description":"Hadoop cluster","id":"ab996dc3-7360-48fb-8778-1f530b944025","modificationUUID":"7dbcaaf6-80af-4ccf-af22-3e5f4bcae3a1","multiSelect":false,"name":"cluster","order":0,"queryValue":"SELECT DISTINCT(JSONExtractString(labels, 'cluster'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name like '%hadoop_hdfs_%'","showALLOption":false,"sort":"DISABLED","textboxValue":"","type":"QUERY"}},"version":"v4","widgets":[{"description":"","id":"0e8723fe-970d-4a02-946a-f11a7cbb4b3e","panelTypes":"row","title":"Applications"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"description":"Number of applications that are in Submitted status at present.","fillSpans":false,"id":"a1011a2a-37da-47e5-ac3d-2b604e2bd1ef","isStacked":false,"mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregateAttribute":{"dataType":"float64","id":"hadoop_yarn_resourcemanager_application_count--float64--Gauge--true","isColumn":true,"isJSON":false,"key":"hadoop_yarn_resourcemanager_application_count","type":"Gauge"},"aggregateOperator":"latest","dataSource":"metrics","disabled":false,"expression":"A","filters":{"items":[{"id":"86ae370c","key":{"dataType":"string","id":"deployment_environment--string--tag--false","isColumn":false,"isJSON":false,"key":"deployment_environment","type":"tag"},"op":"=","value":"{{.deployment_environment}}"},{"id":"8d631386","key":{"dataType":"string","id":"cluster--string--tag--false","isColumn":false,"isJSON":false,"key":"cluster","type":"tag"},"op":"=","value":"{{.cluster}}"},{"id":"19a6ff8d","key":{"dataType":"string","id":"status--string--tag--false","isColumn":false,"isJSON":false,"key":"status","type":"tag"},"op":"=","value":"Submitted"}],"op":"AND"},"functions":[],"groupBy":[],"having":[],"legend":"","limit":null,"orderBy":[],"queryName":"A","reduceTo":"last","spaceAggregation":"sum","stepInterval":60,"timeAggregation":"latest"}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"439f9afa-8009-49af-b722-1cdcabcd94dc","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"string","name":"body","type":""},{"dataType":"string","name":"timestamp","type":""}],"selectedTracesFields":[{"dataType":"string","id":"serviceName--string--tag--true","isColumn":true,"isJSON":false,"key":"serviceName","type":"tag"},{"dataType":"string","id":"name--string--tag--true","isColumn":true,"isJSON":false,"key":"name","type":"tag"},{"dataType":"float64","id":"durationNano--float64--tag--true","isColumn":true,"isJSON":false,"key":"durationNano","type":"tag"},{"dataType":"string","id":"httpMethod--string--tag--true","isColumn":true,"isJSON":false,"key":"httpMethod","type":"tag"},{"dataType":"string","id":"responseStatusCode--string--tag--true","isColumn":true,"isJSON":false,"key":"responseStatusCode","type":"tag"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Submitted","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"description":"Number of applications that are in Running status at present.","fillSpans":false,"id":"70943c30-150c-4110-adbf-13cb1319c8cf","isStacked":false,"mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregateAttribute":{"dataType":"float64","id":"hadoop_yarn_resourcemanager_application_count--float64--Gauge--true","isColumn":true,"isJSON":false,"key":"hadoop_yarn_resourcemanager_application_count","type":"Gauge"},"aggregateOperator":"latest","dataSource":"metrics","disabled":false,"expression":"A","filters":{"items":[{"id":"a5ed58b4","key":{"dataType":"string","id":"deployment_environment--string--tag--false","isColumn":false,"isJSON":false,"key":"deployment_environment","type":"tag"},"op":"=","value":"{{.deployment_environment}}"},{"id":"009fd47c","key":{"dataType":"string","id":"cluster--string--tag--false","isColumn":false,"isJSON":false,"key":"cluster","type":"tag"},"op":"=","value":"{{.cluster}}"},{"id":"92ff1b1b","key":{"dataType":"string","id":"status--string--tag--false","isColumn":false,"isJSON":false,"key":"status","type":"tag"},"op":"=","value":"Running"}],"op":"AND"},"functions":[],"groupBy":[],"having":[],"legend":"","limit":null,"orderBy":[],"queryName":"A","reduceTo":"last","spaceAggregation":"sum","stepInterval":60,"timeAggregation":"latest"}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"37d6ef15-3af9-4e56-a53a-867efba94b2d","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"string","name":"body","type":""},{"dataType":"string","name":"timestamp","type":""}],"selectedTracesFields":[{"dataType":"string","id":"serviceName--string--tag--true","isColumn":true,"isJSON":false,"key":"serviceName","type":"tag"},{"dataType":"string","id":"name--string--tag--true","isColumn":true,"isJSON":false,"key":"name","type":"tag"},{"dataType":"float64","id":"durationNano--float64--tag--true","isColumn":true,"isJSON":false,"key":"durationNano","type":"tag"},{"dataType":"string","id":"httpMethod--string--tag--true","isColumn":true,"isJSON":false,"key":"httpMethod","type":"tag"},{"dataType":"string","id":"responseStatusCode--string--tag--true","isColumn":true,"isJSON":false,"key":"responseStatusCode","type":"tag"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Running","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"description":"Number of applications that are in Pending status at present.","fillSpans":false,"id":"de9eb368-f881-46b0-874e-b7fbb0de21cc","isStacked":false,"mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregateAttribute":{"dataType":"float64","id":"hadoop_yarn_resourcemanager_application_count--float64--Gauge--true","isColumn":true,"isJSON":false,"key":"hadoop_yarn_resourcemanager_application_count","type":"Gauge"},"aggregateOperator":"latest","dataSource":"metrics","disabled":false,"expression":"A","filters":{"items":[{"id":"251840d9","key":{"dataType":"string","id":"deployment_environment--string--tag--false","isColumn":false,"isJSON":false,"key":"deployment_environment","type":"tag"},"op":"=","value":"{{.deployment_environment}}"},{"id":"b82a862d","key":{"dataType":"string","id":"cluster--string--tag--false","isColumn":false,"isJSON":false,"key":"cluster","type":"tag"},"op":"=","value":"{{.cluster}}"},{"id":"aabee1b6","key":{"dataType":"string","id":"status--string--tag--false","isColumn":false,"isJSON":false,"key":"status","type":"tag"},"op":"=","value":"Pending"}],"op":"AND"},"functions":[],"groupBy":[],"having":[],"legend":"","limit":null,"orderBy":[],"queryName":"A","reduceTo":"last","spaceAggregation":"sum","stepInterval":60,"timeAggregation":"latest"}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"028a6c4f-73f2-4318-b76c-3d138919f234","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"string","name":"body","type":""},{"dataType":"string","name":"timestamp","type":""}],"selectedTracesFields":[{"dataType":"string","id":"serviceName--string--tag--true","isColumn":true,"isJSON":false,"key":"serviceName","type":"tag"},{"dataType":"string","id":"name--string--tag--true","isColumn":true,"isJSON":false,"key":"name","type":"tag"},{"dataType":"float64","id":"durationNano--float64--tag--true","isColumn":true,"isJSON":false,"key":"durationNano","type":"tag"},{"dataType":"string","id":"httpMethod--string--tag--true","isColumn":true,"isJSON":false,"key":"httpMethod","type":"tag"},{"dataType":"string","id":"responseStatusCode--string--tag--true","isColumn":true,"isJSON":false,"key":"responseStatusCode","type":"tag"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Pending","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"description":"Number of applications that are in Failed status at present.","fillSpans":false,"id":"efebd111-1cbb-4051-8501-3edef7d493be","isStacked":false,"mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregateAttribute":{"dataType":"float64","id":"hadoop_yarn_resourcemanager_application_count--float64--Gauge--true","isColumn":true,"isJSON":false,"key":"hadoop_yarn_resourcemanager_application_count","type":"Gauge"},"aggregateOperator":"latest","dataSource":"metrics","disabled":false,"expression":"A","filters":{"items":[{"id":"5b5a4c09","key":{"dataType":"string","id":"deployment_environment--string--tag--false","isColumn":false,"isJSON":false,"key":"deployment_environment","type":"tag"},"op":"=","value":"{{.deployment_environment}}"},{"id":"1dcbae8e","key":{"dataType":"string","id":"cluster--string--tag--false","isColumn":false,"isJSON":false,"key":"cluster","type":"tag"},"op":"=","value":"{{.cluster}}"},{"id":"fd29d416","key":{"dataType":"string","id":"status--string--tag--false","isColumn":false,"isJSON":false,"key":"status","type":"tag"},"op":"=","value":"Failed"}],"op":"AND"},"functions":[],"groupBy":[],"having":[],"legend":"","limit":null,"orderBy":[],"queryName":"A","reduceTo":"last","spaceAggregation":"sum","stepInterval":60,"timeAggregation":"latest"}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"c3ec15dd-dba5-486b-b492-b93295cac91a","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"string","name":"body","type":""},{"dataType":"string","name":"timestamp","type":""}],"selectedTracesFields":[{"dataType":"string","id":"serviceName--string--tag--true","isColumn":true,"isJSON":false,"key":"serviceName","type":"tag"},{"dataType":"string","id":"name--string--tag--true","isColumn":true,"isJSON":false,"key":"name","type":"tag"},{"dataType":"float64","id":"durationNano--float64--tag--true","isColumn":true,"isJSON":false,"key":"durationNano","type":"tag"},{"dataType":"string","id":"httpMethod--string--tag--true","isColumn":true,"isJSON":false,"key":"httpMethod","type":"tag"},{"dataType":"string","id":"responseStatusCode--string--tag--true","isColumn":true,"isJSON":false,"key":"responseStatusCode","type":"tag"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Failed","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"description":"Number of applications that are in Killed status at present.","fillSpans":false,"id":"97b667c5-5141-4433-bca0-f1bc5711a49d","isStacked":false,"mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregateAttribute":{"dataType":"float64","id":"hadoop_yarn_resourcemanager_application_count--float64--Gauge--true","isColumn":true,"isJSON":false,"key":"hadoop_yarn_resourcemanager_application_count","type":"Gauge"},"aggregateOperator":"latest","dataSource":"metrics","disabled":false,"expression":"A","filters":{"items":[{"id":"b0f79eb1","key":{"dataType":"string","id":"deployment_environment--string--tag--false","isColumn":false,"isJSON":false,"key":"deployment_environment","type":"tag"},"op":"=","value":"{{.deployment_environment}}"},{"id":"8e3c29a1","key":{"dataType":"string","id":"cluster--string--tag--false","isColumn":false,"isJSON":false,"key":"cluster","type":"tag"},"op":"=","value":"{{.cluster}}"},{"id":"5e160961","key":{"dataType":"string","id":"status--string--tag--false","isColumn":false,"isJSON":false,"key":"status","type":"tag"},"op":"=","value":"Killed"}],"op":"AND"},"functions":[],"groupBy":[],"having":[],"legend":"","limit":null,"orderBy":[],"queryName":"A","reduceTo":"last","spaceAggregation":"sum","stepInterval":60,"timeAggregation":"latest"}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"93a2fe4c-84fe-4b82-b409-3c29ca3eaeff","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"string","name":"body","type":""},{"dataType":"string","name":"timestamp","type":""}],"selectedTracesFields":[{"dataType":"string","id":"serviceName--string--tag--true","isColumn":true,"isJSON":false,"key":"serviceName","type":"tag"},{"dataType":"string","id":"name--string--tag--true","isColumn":true,"isJSON":false,"key":"name","type":"tag"},{"dataType":"float64","id":"durationNano--float64--tag--true","isColumn":true,"isJSON":false,"key":"durationNano","type":"tag"},{"dataType":"string","id":"httpMethod--string--tag--true","isColumn":true,"isJSON":false,"key":"httpMethod","type":"tag"},{"dataType":"string","id":"responseStatusCode--string--tag--true","isColumn":true,"isJSON":false,"key":"responseStatusCode","type":"tag"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Killed","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"description":"Number of applications that are in Completed status at present.","fillSpans":false,"id":"267c0ef8-8df2-4f09-8e5d-b0eac595f15e","isStacked":false,"mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregateAttribute":{"dataType":"float64","id":"hadoop_yarn_resourcemanager_application_count--float64--Gauge--true","isColumn":true,"isJSON":false,"key":"hadoop_yarn_resourcemanager_application_count","type":"Gauge"},"aggregateOperator":"latest","dataSource":"metrics","disabled":false,"expression":"A","filters":{"items":[{"id":"0e189540","key":{"dataType":"string","id":"deployment_environment--string--tag--false","isColumn":false,"isJSON":false,"key":"deployment_environment","type":"tag"},"op":"=","value":"{{.deployment_environment}}"},{"id":"ded9f29e","key":{"dataType":"string","id":"cluster--string--tag--false","isColumn":false,"isJSON":false,"key":"cluster","type":"tag"},"op":"=","value":"{{.cluster}}"},{"id":"1e8d2d7e","key":{"dataType":"string","id":"status--string--tag--false","isColumn":false,"isJSON":false,"key":"status","type":"tag"},"op":"=","value":"Completed"}],"op":"AND"},"functions":[],"groupBy":[],"having":[],"legend":"","limit":null,"orderBy":[],"queryName":"A","reduceTo":"last","spaceAggregation":"sum","stepInterval":60,"timeAggregation":"latest"}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"7fc6397f-ef0a-4a6c-be77-e06b6284241e","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"string","name":"body","type":""},{"dataType":"string","name":"timestamp","type":""}],"selectedTracesFields":[{"dataType":"string","id":"serviceName--string--tag--true","isColumn":true,"isJSON":false,"key":"serviceName","type":"tag"},{"dataType":"string","id":"name--string--tag--true","isColumn":true,"isJSON":false,"key":"name","type":"tag"},{"dataType":"float64","id":"durationNano--float64--tag--true","isColumn":true,"isJSON":false,"key":"durationNano","type":"tag"},{"dataType":"string","id":"httpMethod--string--tag--true","isColumn":true,"isJSON":false,"key":"httpMethod","type":"tag"},{"dataType":"string","id":"responseStatusCode--string--tag--true","isColumn":true,"isJSON":false,"key":"responseStatusCode","type":"tag"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Completed","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"description":"Live DataNodes at present.","fillSpans":false,"id":"b2a1d929-8a9f-4eff-8ad4-d9932e760c62","isStacked":false,"mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregateAttribute":{"dataType":"float64","id":"hadoop_hdfs_namenode_fsname_system_state_num_live_data_nodes--float64--Gauge--true","isColumn":true,"isJSON":false,"key":"hadoop_hdfs_namenode_fsname_system_state_num_live_data_nodes","type":"Gauge"},"aggregateOperator":"latest","dataSource":"metrics","disabled":false,"expression":"A","filters":{"items":[{"id":"1fde941f","key":{"dataType":"string","id":"deployment_environment--string--tag--false","isColumn":false,"isJSON":false,"key":"deployment_environment","type":"tag"},"op":"=","value":"{{.deployment_environment}}"},{"id":"6ead7377","key":{"dataType":"string","id":"cluster--string--tag--false","isColumn":false,"isJSON":false,"key":"cluster","type":"tag"},"op":"=","value":"{{.cluster}}"},{"id":"7cbbc06e","key":{"dataType":"string","id":"state--string--tag--false","isColumn":false,"isJSON":false,"key":"state","type":"tag"},"op":"=","value":"Live"}],"op":"AND"},"functions":[],"groupBy":[],"having":[],"legend":"","limit":null,"orderBy":[],"queryName":"A","reduceTo":"last","spaceAggregation":"sum","stepInterval":60,"timeAggregation":"latest"}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"1e31208d-4079-4fc2-9e8b-295b16891d3d","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"string","name":"body","type":""},{"dataType":"string","name":"timestamp","type":""}],"selectedTracesFields":[{"dataType":"string","id":"serviceName--string--tag--true","isColumn":true,"isJSON":false,"key":"serviceName","type":"tag"},{"dataType":"string","id":"name--string--tag--true","isColumn":true,"isJSON":false,"key":"name","type":"tag"},{"dataType":"float64","id":"durationNano--float64--tag--true","isColumn":true,"isJSON":false,"key":"durationNano","type":"tag"},{"dataType":"string","id":"httpMethod--string--tag--true","isColumn":true,"isJSON":false,"key":"httpMethod","type":"tag"},{"dataType":"string","id":"responseStatusCode--string--tag--true","isColumn":true,"isJSON":false,"key":"responseStatusCode","type":"tag"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Live DataNodes","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"description":"Dead DataNodes at present.","fillSpans":false,"id":"d91cd6a7-c1f7-4b8b-a747-1a4a2e0588e7","isStacked":false,"mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregateAttribute":{"dataType":"float64","id":"hadoop_hdfs_namenode_fsname_system_state_num_live_data_nodes--float64--Gauge--true","isColumn":true,"isJSON":false,"key":"hadoop_hdfs_namenode_fsname_system_state_num_live_data_nodes","type":"Gauge"},"aggregateOperator":"latest","dataSource":"metrics","disabled":false,"expression":"A","filters":{"items":[{"id":"c148c435","key":{"dataType":"string","id":"deployment_environment--string--tag--false","isColumn":false,"isJSON":false,"key":"deployment_environment","type":"tag"},"op":"=","value":"{{.deployment_environment}}"},{"id":"9b81b966","key":{"dataType":"string","id":"cluster--string--tag--false","isColumn":false,"isJSON":false,"key":"cluster","type":"tag"},"op":"=","value":"{{.cluster}}"},{"id":"bbcfcff8","key":{"dataType":"string","id":"state--string--tag--false","isColumn":false,"isJSON":false,"key":"state","type":"tag"},"op":"=","value":"Dead"}],"op":"AND"},"functions":[],"groupBy":[],"having":[],"legend":"","limit":null,"orderBy":[],"queryName":"A","reduceTo":"last","spaceAggregation":"sum","stepInterval":60,"timeAggregation":"latest"}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"ecfe8e70-2618-4951-bf79-aa23458e2bf4","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"string","name":"body","type":""},{"dataType":"string","name":"timestamp","type":""}],"selectedTracesFields":[{"dataType":"string","id":"serviceName--string--tag--true","isColumn":true,"isJSON":false,"key":"serviceName","type":"tag"},{"dataType":"string","id":"name--string--tag--true","isColumn":true,"isJSON":false,"key":"name","type":"tag"},{"dataType":"float64","id":"durationNano--float64--tag--true","isColumn":true,"isJSON":false,"key":"durationNano","type":"tag"},{"dataType":"string","id":"httpMethod--string--tag--true","isColumn":true,"isJSON":false,"key":"httpMethod","type":"tag"},{"dataType":"string","id":"responseStatusCode--string--tag--true","isColumn":true,"isJSON":false,"key":"responseStatusCode","type":"tag"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Dead DataNodes","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"description":"Total volume failures at present.","fillSpans":false,"id":"4f705a1b-6e20-4647-bcd8-f972be636460","isStacked":false,"mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregateAttribute":{"dataType":"float64","id":"hadoop_hdfs_namenode_fsname_system_state_volume_failures_total--float64--Gauge--true","isColumn":true,"isJSON":false,"key":"hadoop_hdfs_namenode_fsname_system_state_volume_failures_total","type":"Gauge"},"aggregateOperator":"latest","dataSource":"metrics","disabled":false,"expression":"A","filters":{"items":[{"id":"c55485b7","key":{"dataType":"string","id":"deployment_environment--string--tag--false","isColumn":false,"isJSON":false,"key":"deployment_environment","type":"tag"},"op":"=","value":"{{.deployment_environment}}"},{"id":"0ac4365b","key":{"dataType":"string","id":"cluster--string--tag--false","isColumn":false,"isJSON":false,"key":"cluster","type":"tag"},"op":"=","value":"{{.cluster}}"}],"op":"AND"},"functions":[],"groupBy":[],"having":[],"legend":"","limit":null,"orderBy":[],"queryName":"A","reduceTo":"last","spaceAggregation":"sum","stepInterval":60,"timeAggregation":"latest"}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"9f94deb6-5ad8-4138-83ce-d13a056c59e7","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"string","name":"body","type":""},{"dataType":"string","name":"timestamp","type":""}],"selectedTracesFields":[{"dataType":"string","id":"serviceName--string--tag--true","isColumn":true,"isJSON":false,"key":"serviceName","type":"tag"},{"dataType":"string","id":"name--string--tag--true","isColumn":true,"isJSON":false,"key":"name","type":"tag"},{"dataType":"float64","id":"durationNano--float64--tag--true","isColumn":true,"isJSON":false,"key":"durationNano","type":"tag"},{"dataType":"string","id":"httpMethod--string--tag--true","isColumn":true,"isJSON":false,"key":"httpMethod","type":"tag"},{"dataType":"string","id":"responseStatusCode--string--tag--true","isColumn":true,"isJSON":false,"key":"responseStatusCode","type":"tag"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Volume Failures","yAxisUnit":"none"},{"description":"","id":"57788c0f-5351-4d9d-b4a4-eaec7eb37db1","panelTypes":"row","title":"HDFS"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"description":"Total number of blocks in the system at present.","fillSpans":false,"id":"114bb452-5350-41bb-bee7-aba51ea37c23","isStacked":false,"mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregateAttribute":{"dataType":"float64","id":"hadoop_hdfs_namenode_nninfo_total_blocks--float64--Gauge--true","isColumn":true,"isJSON":false,"key":"hadoop_hdfs_namenode_nninfo_total_blocks","type":"Gauge"},"aggregateOperator":"latest","dataSource":"metrics","disabled":false,"expression":"A","filters":{"items":[{"id":"601c1d64","key":{"dataType":"string","id":"deployment_environment--string--tag--false","isColumn":false,"isJSON":false,"key":"deployment_environment","type":"tag"},"op":"=","value":"{{.deployment_environment}}"},{"id":"bac2e4bf","key":{"dataType":"string","id":"cluster--string--tag--false","isColumn":false,"isJSON":false,"key":"cluster","type":"tag"},"op":"=","value":"{{.cluster}}"}],"op":"AND"},"functions":[],"groupBy":[],"having":[],"legend":"","limit":null,"orderBy":[],"queryName":"A","reduceTo":"last","spaceAggregation":"sum","stepInterval":60,"timeAggregation":"latest"}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"4ff43d67-bc5c-453f-8acb-c620110f4416","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"string","name":"body","type":""},{"dataType":"string","name":"timestamp","type":""}],"selectedTracesFields":[{"dataType":"string","id":"serviceName--string--tag--true","isColumn":true,"isJSON":false,"key":"serviceName","type":"tag"},{"dataType":"string","id":"name--string--tag--true","isColumn":true,"isJSON":false,"key":"name","type":"tag"},{"dataType":"float64","id":"durationNano--float64--tag--true","isColumn":true,"isJSON":false,"key":"durationNano","type":"tag"},{"dataType":"string","id":"httpMethod--string--tag--true","isColumn":true,"isJSON":false,"key":"httpMethod","type":"tag"},{"dataType":"string","id":"responseStatusCode--string--tag--true","isColumn":true,"isJSON":false,"key":"responseStatusCode","type":"tag"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Total blocks","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"description":"Total number of blocks in the live nodes at present.","fillSpans":false,"id":"66cb1d57-a6b4-4e75-9ffe-d3931e740d27","isStacked":false,"mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregateAttribute":{"dataType":"float64","id":"hadoop_hdfs_namenode_nninfo_live_nodes_num_blocks--float64--Gauge--true","isColumn":true,"isJSON":false,"key":"hadoop_hdfs_namenode_nninfo_live_nodes_num_blocks","type":"Gauge"},"aggregateOperator":"latest","dataSource":"metrics","disabled":false,"expression":"A","filters":{"items":[{"id":"34836914","key":{"dataType":"string","id":"deployment_environment--string--tag--false","isColumn":false,"isJSON":false,"key":"deployment_environment","type":"tag"},"op":"=","value":"{{.deployment_environment}}"},{"id":"d3746a09","key":{"dataType":"string","id":"cluster--string--tag--false","isColumn":false,"isJSON":false,"key":"cluster","type":"tag"},"op":"=","value":"{{.cluster}}"}],"op":"AND"},"functions":[],"groupBy":[],"having":[],"legend":"","limit":null,"orderBy":[],"queryName":"A","reduceTo":"last","spaceAggregation":"sum","stepInterval":60,"timeAggregation":"latest"}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"b58463b2-f1d1-48f7-bafb-d7fef296be7b","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"string","name":"body","type":""},{"dataType":"string","name":"timestamp","type":""}],"selectedTracesFields":[{"dataType":"string","id":"serviceName--string--tag--true","isColumn":true,"isJSON":false,"key":"serviceName","type":"tag"},{"dataType":"string","id":"name--string--tag--true","isColumn":true,"isJSON":false,"key":"name","type":"tag"},{"dataType":"float64","id":"durationNano--float64--tag--true","isColumn":true,"isJSON":false,"key":"durationNano","type":"tag"},{"dataType":"string","id":"httpMethod--string--tag--true","isColumn":true,"isJSON":false,"key":"httpMethod","type":"tag"},{"dataType":"string","id":"responseStatusCode--string--tag--true","isColumn":true,"isJSON":false,"key":"responseStatusCode","type":"tag"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Num blocks","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"description":"Total number of blocks under replicated at present.\n","fillSpans":false,"id":"4a0971b3-f87d-4b5a-a398-7e0a64ed6df6","isStacked":false,"mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregateAttribute":{"dataType":"float64","id":"hadoop_hdfs_namenode_fsname_system_under_replicated_blocks--float64--Gauge--true","isColumn":true,"isJSON":false,"key":"hadoop_hdfs_namenode_fsname_system_under_replicated_blocks","type":"Gauge"},"aggregateOperator":"latest","dataSource":"metrics","disabled":false,"expression":"A","filters":{"items":[{"id":"abee7c99","key":{"dataType":"string","id":"deployment_environment--string--tag--false","isColumn":false,"isJSON":false,"key":"deployment_environment","type":"tag"},"op":"=","value":"{{.deployment_environment}}"},{"id":"35096b45","key":{"dataType":"string","id":"cluster--string--tag--false","isColumn":false,"isJSON":false,"key":"cluster","type":"tag"},"op":"=","value":"{{.cluster}}"}],"op":"AND"},"functions":[],"groupBy":[],"having":[],"legend":"","limit":null,"orderBy":[],"queryName":"A","reduceTo":"last","spaceAggregation":"sum","stepInterval":60,"timeAggregation":"latest"}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"aed13050-6ab0-495e-96bb-8da13e197d21","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"string","name":"body","type":""},{"dataType":"string","name":"timestamp","type":""}],"selectedTracesFields":[{"dataType":"string","id":"serviceName--string--tag--true","isColumn":true,"isJSON":false,"key":"serviceName","type":"tag"},{"dataType":"string","id":"name--string--tag--true","isColumn":true,"isJSON":false,"key":"name","type":"tag"},{"dataType":"float64","id":"durationNano--float64--tag--true","isColumn":true,"isJSON":false,"key":"durationNano","type":"tag"},{"dataType":"string","id":"httpMethod--string--tag--true","isColumn":true,"isJSON":false,"key":"httpMethod","type":"tag"},{"dataType":"string","id":"responseStatusCode--string--tag--true","isColumn":true,"isJSON":false,"key":"responseStatusCode","type":"tag"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Under replicated blocks","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"description":"Total number of corrupt blocks at present.","fillSpans":false,"id":"2d24cea2-264a-43e9-b4d9-6298a1e48371","isStacked":false,"mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregateAttribute":{"dataType":"float64","id":"hadoop_hdfs_namenode_fsname_system_corrupt_blocks--float64--Gauge--true","isColumn":true,"isJSON":false,"key":"hadoop_hdfs_namenode_fsname_system_corrupt_blocks","type":"Gauge"},"aggregateOperator":"latest","dataSource":"metrics","disabled":false,"expression":"A","filters":{"items":[{"id":"3b4cdabd","key":{"dataType":"string","id":"deployment_environment--string--tag--false","isColumn":false,"isJSON":false,"key":"deployment_environment","type":"tag"},"op":"=","value":"{{.deployment_environment}}"},{"id":"5c1ace7d","key":{"dataType":"string","id":"cluster--string--tag--false","isColumn":false,"isJSON":false,"key":"cluster","type":"tag"},"op":"=","value":"{{.cluster}}"}],"op":"AND"},"functions":[],"groupBy":[],"having":[],"legend":"","limit":null,"orderBy":[],"queryName":"A","reduceTo":"last","spaceAggregation":"sum","stepInterval":60,"timeAggregation":"latest"}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"24086c2f-4518-4b3b-aaf5-9ccc2a4336c7","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"string","name":"body","type":""},{"dataType":"string","name":"timestamp","type":""}],"selectedTracesFields":[{"dataType":"string","id":"serviceName--string--tag--true","isColumn":true,"isJSON":false,"key":"serviceName","type":"tag"},{"dataType":"string","id":"name--string--tag--true","isColumn":true,"isJSON":false,"key":"name","type":"tag"},{"dataType":"float64","id":"durationNano--float64--tag--true","isColumn":true,"isJSON":false,"key":"durationNano","type":"tag"},{"dataType":"string","id":"httpMethod--string--tag--true","isColumn":true,"isJSON":false,"key":"httpMethod","type":"tag"},{"dataType":"string","id":"responseStatusCode--string--tag--true","isColumn":true,"isJSON":false,"key":"responseStatusCode","type":"tag"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Corrupt blocks","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"description":"Total number of missing blocks at present.","fillSpans":false,"id":"7fff698b-24e6-45ff-b5fc-457847101996","isStacked":false,"mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregateAttribute":{"dataType":"float64","id":"hadoop_hdfs_namenode_fsname_system_missing_blocks--float64--Gauge--true","isColumn":true,"isJSON":false,"key":"hadoop_hdfs_namenode_fsname_system_missing_blocks","type":"Gauge"},"aggregateOperator":"latest","dataSource":"metrics","disabled":false,"expression":"A","filters":{"items":[{"id":"dbf65eb4","key":{"dataType":"string","id":"deployment_environment--string--tag--false","isColumn":false,"isJSON":false,"key":"deployment_environment","type":"tag"},"op":"=","value":"{{.deployment_environment}}"},{"id":"d5d12102","key":{"dataType":"string","id":"cluster--string--tag--false","isColumn":false,"isJSON":false,"key":"cluster","type":"tag"},"op":"=","value":"{{.cluster}}"}],"op":"AND"},"functions":[],"groupBy":[],"having":[],"legend":"","limit":null,"orderBy":[],"queryName":"A","reduceTo":"last","spaceAggregation":"sum","stepInterval":60,"timeAggregation":"latest"}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"62ac398f-75f6-46f6-a694-a4566da43188","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"string","name":"body","type":""},{"dataType":"string","name":"timestamp","type":""}],"selectedTracesFields":[{"dataType":"string","id":"serviceName--string--tag--true","isColumn":true,"isJSON":false,"key":"serviceName","type":"tag"},{"dataType":"string","id":"name--string--tag--true","isColumn":true,"isJSON":false,"key":"name","type":"tag"},{"dataType":"float64","id":"durationNano--float64--tag--true","isColumn":true,"isJSON":false,"key":"durationNano","type":"tag"},{"dataType":"string","id":"httpMethod--string--tag--true","isColumn":true,"isJSON":false,"key":"httpMethod","type":"tag"},{"dataType":"string","id":"responseStatusCode--string--tag--true","isColumn":true,"isJSON":false,"key":"responseStatusCode","type":"tag"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Missing blocks","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"description":"Total number of blocks pending to be replicated at present.","fillSpans":false,"id":"5857b298-fc8a-4b65-890c-6ae90596170f","isStacked":false,"mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregateAttribute":{"dataType":"float64","id":"hadoop_hdfs_namenode_fsname_system_pending_replication_blocks--float64--Gauge--true","isColumn":true,"isJSON":false,"key":"hadoop_hdfs_namenode_fsname_system_pending_replication_blocks","type":"Gauge"},"aggregateOperator":"latest","dataSource":"metrics","disabled":false,"expression":"A","filters":{"items":[{"id":"5ef8ba2f","key":{"dataType":"string","id":"deployment_environment--string--tag--false","isColumn":false,"isJSON":false,"key":"deployment_environment","type":"tag"},"op":"=","value":"{{.deployment_environment}}"},{"id":"b3a7579f","key":{"dataType":"string","id":"cluster--string--tag--false","isColumn":false,"isJSON":false,"key":"cluster","type":"tag"},"op":"=","value":"{{.cluster}}"}],"op":"AND"},"functions":[],"groupBy":[],"having":[],"legend":"","limit":null,"orderBy":[],"queryName":"A","reduceTo":"last","spaceAggregation":"sum","stepInterval":60,"timeAggregation":"latest"}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"66ae69e3-0e9a-43c6-a054-d25d719adee4","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"string","name":"body","type":""},{"dataType":"string","name":"timestamp","type":""}],"selectedTracesFields":[{"dataType":"string","id":"serviceName--string--tag--true","isColumn":true,"isJSON":false,"key":"serviceName","type":"tag"},{"dataType":"string","id":"name--string--tag--true","isColumn":true,"isJSON":false,"key":"name","type":"tag"},{"dataType":"float64","id":"durationNano--float64--tag--true","isColumn":true,"isJSON":false,"key":"durationNano","type":"tag"},{"dataType":"string","id":"httpMethod--string--tag--true","isColumn":true,"isJSON":false,"key":"httpMethod","type":"tag"},{"dataType":"string","id":"responseStatusCode--string--tag--true","isColumn":true,"isJSON":false,"key":"responseStatusCode","type":"tag"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Pending replication blocks","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"description":"Current remaining capacity in DataNodes.","fillSpans":false,"id":"cec839c9-da6d-4aba-946a-dea00cff40be","isStacked":false,"mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregateAttribute":{"dataType":"float64","id":"hadoop_hdfs_namenode_fsname_system_capacity_bytes--float64--Gauge--true","isColumn":true,"isJSON":false,"key":"hadoop_hdfs_namenode_fsname_system_capacity_bytes","type":"Gauge"},"aggregateOperator":"latest","dataSource":"metrics","disabled":true,"expression":"A","filters":{"items":[{"id":"f1b79b1d","key":{"dataType":"string","id":"mode--string--tag--false","isColumn":false,"isJSON":false,"key":"mode","type":"tag"},"op":"=","value":"Remaining"},{"id":"8db9f862","key":{"dataType":"string","id":"deployment_environment--string--tag--false","isColumn":false,"isJSON":false,"key":"deployment_environment","type":"tag"},"op":"=","value":"{{.deployment_environment}}"},{"id":"4f4e206f","key":{"dataType":"string","id":"cluster--string--tag--false","isColumn":false,"isJSON":false,"key":"cluster","type":"tag"},"op":"=","value":"{{.cluster}}"}],"op":"AND"},"functions":[],"groupBy":[{"dataType":"string","id":"cluster--string--tag--false","isColumn":false,"isJSON":false,"key":"cluster","type":"tag"}],"having":[],"legend":"","limit":null,"orderBy":[],"queryName":"A","reduceTo":"avg","spaceAggregation":"sum","stepInterval":60,"timeAggregation":"latest"},{"aggregateAttribute":{"dataType":"float64","id":"hadoop_hdfs_namenode_fsname_system_capacity_bytes--float64--Gauge--true","isColumn":true,"isJSON":false,"key":"hadoop_hdfs_namenode_fsname_system_capacity_bytes","type":"Gauge"},"aggregateOperator":"latest","dataSource":"metrics","disabled":true,"expression":"B","filters":{"items":[{"id":"ea4b8215","key":{"dataType":"string","id":"mode--string--tag--false","isColumn":false,"isJSON":false,"key":"mode","type":"tag"},"op":"=","value":"Total"},{"id":"2d87122b","key":{"dataType":"string","id":"deployment_environment--string--tag--false","isColumn":false,"isJSON":false,"key":"deployment_environment","type":"tag"},"op":"=","value":"{{.deployment_environment}}"},{"id":"7a82c3e0","key":{"dataType":"string","id":"cluster--string--tag--false","isColumn":false,"isJSON":false,"key":"cluster","type":"tag"},"op":"=","value":"{{.cluster}}"}],"op":"AND"},"functions":[],"groupBy":[{"dataType":"string","id":"cluster--string--tag--false","isColumn":false,"isJSON":false,"key":"cluster","type":"tag"}],"having":[],"legend":"","limit":null,"orderBy":[],"queryName":"B","reduceTo":"avg","spaceAggregation":"sum","stepInterval":60,"timeAggregation":"latest"}],"queryFormulas":[{"disabled":false,"expression":"A/B * 100","legend":"Remaining Capacity ","queryName":"F1"}]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"e8fe370c-6d15-4692-91a0-0ee96ccb389d","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"string","name":"body","type":""},{"dataType":"string","name":"timestamp","type":""}],"selectedTracesFields":[{"dataType":"string","id":"serviceName--string--tag--true","isColumn":true,"isJSON":false,"key":"serviceName","type":"tag"},{"dataType":"string","id":"name--string--tag--true","isColumn":true,"isJSON":false,"key":"name","type":"tag"},{"dataType":"float64","id":"durationNano--float64--tag--true","isColumn":true,"isJSON":false,"key":"durationNano","type":"tag"},{"dataType":"string","id":"httpMethod--string--tag--true","isColumn":true,"isJSON":false,"key":"httpMethod","type":"tag"},{"dataType":"string","id":"responseStatusCode--string--tag--true","isColumn":true,"isJSON":false,"key":"responseStatusCode","type":"tag"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Remaining capacity in DataNodes","yAxisUnit":"percent"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"description":"Current capacity remaining per DataNode in bytes.","fillSpans":false,"id":"22198113-656b-47e5-8642-0666c29fa785","isStacked":false,"mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregateAttribute":{"dataType":"float64","id":"hadoop_hdfs_namenode_nninfo_live_nodes_remaining--float64--Gauge--true","isColumn":true,"isJSON":false,"key":"hadoop_hdfs_namenode_nninfo_live_nodes_remaining","type":"Gauge"},"aggregateOperator":"latest","dataSource":"metrics","disabled":false,"expression":"A","filters":{"items":[{"id":"ae4b2f9b","key":{"dataType":"string","id":"deployment_environment--string--tag--false","isColumn":false,"isJSON":false,"key":"deployment_environment","type":"tag"},"op":"=","value":"{{.deployment_environment}}"},{"id":"6ca7bb82","key":{"dataType":"string","id":"cluster--string--tag--false","isColumn":false,"isJSON":false,"key":"cluster","type":"tag"},"op":"=","value":"{{.cluster}}"}],"op":"AND"},"functions":[],"groupBy":[{"dataType":"string","id":"datanode--string--tag--false","isColumn":false,"isJSON":false,"key":"datanode","type":"tag"}],"having":[],"legend":"DataNode: {{datanode}}","limit":null,"orderBy":[],"queryName":"A","reduceTo":"avg","spaceAggregation":"sum","stepInterval":60,"timeAggregation":"latest"}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"d41b8e89-58c7-4cca-be90-b6806d7e61d6","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"string","name":"body","type":""},{"dataType":"string","name":"timestamp","type":""}],"selectedTracesFields":[{"dataType":"string","id":"serviceName--string--tag--true","isColumn":true,"isJSON":false,"key":"serviceName","type":"tag"},{"dataType":"string","id":"name--string--tag--true","isColumn":true,"isJSON":false,"key":"name","type":"tag"},{"dataType":"float64","id":"durationNano--float64--tag--true","isColumn":true,"isJSON":false,"key":"durationNano","type":"tag"},{"dataType":"string","id":"httpMethod--string--tag--true","isColumn":true,"isJSON":false,"key":"httpMethod","type":"tag"},{"dataType":"string","id":"responseStatusCode--string--tag--true","isColumn":true,"isJSON":false,"key":"responseStatusCode","type":"tag"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Capacity remaining per DataNode","yAxisUnit":"decbytes"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"description":"The total amount of memory currently used on the host.","fillSpans":false,"id":"89bd953a-d45f-4182-8a99-6ae2fb2d13fc","isStacked":false,"mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregateAttribute":{"dataType":"float64","id":"hadoop_yarn_resourcemanager_node_memory_used_mb--float64--Gauge--true","isColumn":true,"isJSON":false,"key":"hadoop_yarn_resourcemanager_node_memory_used_mb","type":"Gauge"},"aggregateOperator":"latest","dataSource":"metrics","disabled":false,"expression":"A","filters":{"items":[{"id":"3c664153","key":{"dataType":"string","id":"deployment_environment--string--tag--false","isColumn":false,"isJSON":false,"key":"deployment_environment","type":"tag"},"op":"=","value":"{{.deployment_environment}}"},{"id":"5ebd5340","key":{"dataType":"string","id":"cluster--string--tag--false","isColumn":false,"isJSON":false,"key":"cluster","type":"tag"},"op":"=","value":"{{.cluster}}"}],"op":"AND"},"functions":[],"groupBy":[],"having":[],"legend":"","limit":null,"orderBy":[],"queryName":"A","reduceTo":"last","spaceAggregation":"sum","stepInterval":60,"timeAggregation":"latest"}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"3c5d44a3-56d2-437e-be00-03a8afb405b6","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"string","name":"body","type":""},{"dataType":"string","name":"timestamp","type":""}],"selectedTracesFields":[{"dataType":"string","id":"serviceName--string--tag--true","isColumn":true,"isJSON":false,"key":"serviceName","type":"tag"},{"dataType":"string","id":"name--string--tag--true","isColumn":true,"isJSON":false,"key":"name","type":"tag"},{"dataType":"float64","id":"durationNano--float64--tag--true","isColumn":true,"isJSON":false,"key":"durationNano","type":"tag"},{"dataType":"string","id":"httpMethod--string--tag--true","isColumn":true,"isJSON":false,"key":"httpMethod","type":"tag"},{"dataType":"string","id":"responseStatusCode--string--tag--true","isColumn":true,"isJSON":false,"key":"responseStatusCode","type":"tag"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Memory used","yAxisUnit":"decmbytes"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"description":"Total number of vCores at present.","fillSpans":false,"id":"ad63c678-833a-4b32-ab37-5c3701593659","isStacked":false,"mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregateAttribute":{"dataType":"float64","id":"hadoop_yarn_resourcemanager_vcore_count--float64--Gauge--true","isColumn":true,"isJSON":false,"key":"hadoop_yarn_resourcemanager_vcore_count","type":"Gauge"},"aggregateOperator":"latest","dataSource":"metrics","disabled":false,"expression":"A","filters":{"items":[{"id":"101c9b52","key":{"dataType":"string","id":"deployment_environment--string--tag--false","isColumn":false,"isJSON":false,"key":"deployment_environment","type":"tag"},"op":"=","value":"{{.deployment_environment}}"},{"id":"96e963e5","key":{"dataType":"string","id":"cluster--string--tag--false","isColumn":false,"isJSON":false,"key":"cluster","type":"tag"},"op":"=","value":"{{.cluster}}"},{"id":"4906a261","key":{"dataType":"string","id":"queue--string--tag--false","isColumn":false,"isJSON":false,"key":"queue","type":"tag"},"op":"=","value":"root"}],"op":"AND"},"functions":[],"groupBy":[],"having":[],"legend":"","limit":null,"orderBy":[],"queryName":"A","reduceTo":"last","spaceAggregation":"sum","stepInterval":60,"timeAggregation":"latest"}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"7fd26ad5-c0ca-4d2e-b3bf-175255438017","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"string","name":"body","type":""},{"dataType":"string","name":"timestamp","type":""}],"selectedTracesFields":[{"dataType":"string","id":"serviceName--string--tag--true","isColumn":true,"isJSON":false,"key":"serviceName","type":"tag"},{"dataType":"string","id":"name--string--tag--true","isColumn":true,"isJSON":false,"key":"name","type":"tag"},{"dataType":"float64","id":"durationNano--float64--tag--true","isColumn":true,"isJSON":false,"key":"durationNano","type":"tag"},{"dataType":"string","id":"httpMethod--string--tag--true","isColumn":true,"isJSON":false,"key":"httpMethod","type":"tag"},{"dataType":"string","id":"responseStatusCode--string--tag--true","isColumn":true,"isJSON":false,"key":"responseStatusCode","type":"tag"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Total vCores","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"description":"Total number of containers currently running on the host","fillSpans":false,"id":"d89a4902-f040-442f-9041-cadbd1d6aea4","isStacked":false,"mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregateAttribute":{"dataType":"float64","id":"hadoop_yarn_resourcemanager_node_containers_total--float64--Gauge--true","isColumn":true,"isJSON":false,"key":"hadoop_yarn_resourcemanager_node_containers_total","type":"Gauge"},"aggregateOperator":"latest","dataSource":"metrics","disabled":false,"expression":"A","filters":{"items":[{"id":"52770f87","key":{"dataType":"string","id":"deployment_environment--string--tag--false","isColumn":false,"isJSON":false,"key":"deployment_environment","type":"tag"},"op":"=","value":"{{.deployment_environment}}"},{"id":"0dfc9820","key":{"dataType":"string","id":"cluster--string--tag--false","isColumn":false,"isJSON":false,"key":"cluster","type":"tag"},"op":"=","value":"{{.cluster}}"}],"op":"AND"},"functions":[],"groupBy":[],"having":[],"legend":"","limit":null,"orderBy":[],"queryName":"A","reduceTo":"last","spaceAggregation":"sum","stepInterval":60,"timeAggregation":"latest"}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"2da9ea05-64ac-45b4-a4fa-bcd85efaa50c","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"string","name":"body","type":""},{"dataType":"string","name":"timestamp","type":""}],"selectedTracesFields":[{"dataType":"string","id":"serviceName--string--tag--true","isColumn":true,"isJSON":false,"key":"serviceName","type":"tag"},{"dataType":"string","id":"name--string--tag--true","isColumn":true,"isJSON":false,"key":"name","type":"tag"},{"dataType":"float64","id":"durationNano--float64--tag--true","isColumn":true,"isJSON":false,"key":"durationNano","type":"tag"},{"dataType":"string","id":"httpMethod--string--tag--true","isColumn":true,"isJSON":false,"key":"httpMethod","type":"tag"},{"dataType":"string","id":"responseStatusCode--string--tag--true","isColumn":true,"isJSON":false,"key":"responseStatusCode","type":"tag"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Total containers","yAxisUnit":"none"},{"description":"","id":"209f81d2-b96a-4d50-a480-e38ebc37911a","panelTypes":"row","title":"YARN Cluster"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"description":"Number of NodeManagers in each status at present.","fillSpans":false,"id":"1198a093-0966-42d8-a794-46286bc792b2","isStacked":false,"mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregateAttribute":{"dataType":"float64","id":"hadoop_yarn_resourcemanager_nodemanager_total--float64--Gauge--true","isColumn":true,"isJSON":false,"key":"hadoop_yarn_resourcemanager_nodemanager_total","type":"Gauge"},"aggregateOperator":"latest","dataSource":"metrics","disabled":false,"expression":"A","filters":{"items":[{"id":"dd0f5c2e","key":{"dataType":"string","id":"deployment_environment--string--tag--false","isColumn":false,"isJSON":false,"key":"deployment_environment","type":"tag"},"op":"=","value":"{{.deployment_environment}}"},{"id":"e7ed3eac","key":{"dataType":"string","id":"cluster--string--tag--false","isColumn":false,"isJSON":false,"key":"cluster","type":"tag"},"op":"=","value":"{{.cluster}}"}],"op":"AND"},"functions":[],"groupBy":[{"dataType":"string","id":"status--string--tag--false","isColumn":false,"isJSON":false,"key":"status","type":"tag"}],"having":[],"legend":"","limit":null,"orderBy":[],"queryName":"A","reduceTo":"last","spaceAggregation":"sum","stepInterval":60,"timeAggregation":"latest"}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"b85a90cb-ecfc-4d92-912c-b540c4ba976e","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"string","name":"body","type":""},{"dataType":"string","name":"timestamp","type":""}],"selectedTracesFields":[{"dataType":"string","id":"serviceName--string--tag--true","isColumn":true,"isJSON":false,"key":"serviceName","type":"tag"},{"dataType":"string","id":"name--string--tag--true","isColumn":true,"isJSON":false,"key":"name","type":"tag"},{"dataType":"float64","id":"durationNano--float64--tag--true","isColumn":true,"isJSON":false,"key":"durationNano","type":"tag"},{"dataType":"string","id":"httpMethod--string--tag--true","isColumn":true,"isJSON":false,"key":"httpMethod","type":"tag"},{"dataType":"string","id":"responseStatusCode--string--tag--true","isColumn":true,"isJSON":false,"key":"responseStatusCode","type":"tag"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"NodeManager status","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"description":"Total application count in each status at present.","fillSpans":false,"id":"737fdbfe-1cc2-4faf-b6f2-5587c0a0a3a0","isStacked":false,"mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregateAttribute":{"dataType":"float64","id":"hadoop_yarn_resourcemanager_application_count--float64--Gauge--true","isColumn":true,"isJSON":false,"key":"hadoop_yarn_resourcemanager_application_count","type":"Gauge"},"aggregateOperator":"latest","dataSource":"metrics","disabled":false,"expression":"A","filters":{"items":[{"id":"59d11703","key":{"dataType":"string","id":"deployment_environment--string--tag--false","isColumn":false,"isJSON":false,"key":"deployment_environment","type":"tag"},"op":"=","value":"{{.deployment_environment}}"},{"id":"938327ab","key":{"dataType":"string","id":"cluster--string--tag--false","isColumn":false,"isJSON":false,"key":"cluster","type":"tag"},"op":"=","value":"{{.cluster}}"},{"id":"6752c759","key":{"dataType":"string","id":"queue--string--tag--false","isColumn":false,"isJSON":false,"key":"queue","type":"tag"},"op":"=","value":"root"}],"op":"AND"},"functions":[],"groupBy":[{"dataType":"string","id":"status--string--tag--false","isColumn":false,"isJSON":false,"key":"status","type":"tag"}],"having":[],"legend":"","limit":null,"orderBy":[],"queryName":"A","reduceTo":"last","spaceAggregation":"sum","stepInterval":60,"timeAggregation":"latest"}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"fb9ac9c8-2983-40c3-93ac-d1914fc22c6f","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"string","name":"body","type":""},{"dataType":"string","name":"timestamp","type":""}],"selectedTracesFields":[{"dataType":"string","id":"serviceName--string--tag--true","isColumn":true,"isJSON":false,"key":"serviceName","type":"tag"},{"dataType":"string","id":"name--string--tag--true","isColumn":true,"isJSON":false,"key":"name","type":"tag"},{"dataType":"float64","id":"durationNano--float64--tag--true","isColumn":true,"isJSON":false,"key":"durationNano","type":"tag"},{"dataType":"string","id":"httpMethod--string--tag--true","isColumn":true,"isJSON":false,"key":"httpMethod","type":"tag"},{"dataType":"string","id":"responseStatusCode--string--tag--true","isColumn":true,"isJSON":false,"key":"responseStatusCode","type":"tag"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Application count","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"description":"Count of container in each status at present.","fillSpans":false,"id":"62204433-c0d4-498d-8e42-11a47b47a799","isStacked":false,"mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregateAttribute":{"dataType":"float64","id":"hadoop_yarn_resourcemanager_container_count--float64--Gauge--true","isColumn":true,"isJSON":false,"key":"hadoop_yarn_resourcemanager_container_count","type":"Gauge"},"aggregateOperator":"latest","dataSource":"metrics","disabled":false,"expression":"A","filters":{"items":[{"id":"42a5413c","key":{"dataType":"string","id":"cluster--string--tag--false","isColumn":false,"isJSON":false,"key":"cluster","type":"tag"},"op":"=","value":"{{.cluster}}"},{"id":"aac922da","key":{"dataType":"string","id":"deployment_environment--string--tag--false","isColumn":false,"isJSON":false,"key":"deployment_environment","type":"tag"},"op":"=","value":"{{.deployment_environment}}"}],"op":"AND"},"functions":[],"groupBy":[{"dataType":"string","id":"status--string--tag--false","isColumn":false,"isJSON":false,"key":"status","type":"tag"}],"having":[],"legend":"","limit":null,"orderBy":[],"queryName":"A","reduceTo":"last","spaceAggregation":"sum","stepInterval":60,"timeAggregation":"latest"}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"b5f651de-422b-4848-a741-1637262fdae9","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"string","name":"body","type":""},{"dataType":"string","name":"timestamp","type":""}],"selectedTracesFields":[{"dataType":"string","id":"serviceName--string--tag--true","isColumn":true,"isJSON":false,"key":"serviceName","type":"tag"},{"dataType":"string","id":"name--string--tag--true","isColumn":true,"isJSON":false,"key":"name","type":"tag"},{"dataType":"float64","id":"durationNano--float64--tag--true","isColumn":true,"isJSON":false,"key":"durationNano","type":"tag"},{"dataType":"string","id":"httpMethod--string--tag--true","isColumn":true,"isJSON":false,"key":"httpMethod","type":"tag"},{"dataType":"string","id":"responseStatusCode--string--tag--true","isColumn":true,"isJSON":false,"key":"responseStatusCode","type":"tag"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Container by status","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"description":"Memory usage","fillSpans":false,"id":"bf9c2195-4079-4ed6-bde2-8ae359126c50","isStacked":false,"mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregateAttribute":{"dataType":"float64","id":"hadoop_yarn_resourcemanager_memory_in_mb--float64--Gauge--true","isColumn":true,"isJSON":false,"key":"hadoop_yarn_resourcemanager_memory_in_mb","type":"Gauge"},"aggregateOperator":"latest","dataSource":"metrics","disabled":false,"expression":"A","filters":{"items":[{"id":"48655883","key":{"dataType":"string","id":"status--string--tag--false","isColumn":false,"isJSON":false,"key":"status","type":"tag"},"op":"=","value":"Allocated"},{"id":"1d06be66","key":{"dataType":"string","id":"queue--string--tag--false","isColumn":false,"isJSON":false,"key":"queue","type":"tag"},"op":"=","value":"root"},{"id":"5449a0e0","key":{"dataType":"string","id":"cluster--string--tag--false","isColumn":false,"isJSON":false,"key":"cluster","type":"tag"},"op":"=","value":"{{.cluster}}"},{"id":"fa335390","key":{"dataType":"string","id":"deployment_environment--string--tag--false","isColumn":false,"isJSON":false,"key":"deployment_environment","type":"tag"},"op":"=","value":"{{.deployment_environment}}"}],"op":"AND"},"functions":[],"groupBy":[],"having":[],"legend":"Allocated Memory","limit":null,"orderBy":[],"queryName":"A","reduceTo":"avg","spaceAggregation":"sum","stepInterval":60,"timeAggregation":"latest"},{"aggregateAttribute":{"dataType":"float64","id":"hadoop_yarn_resourcemanager_memory_in_mb--float64--Gauge--true","isColumn":true,"isJSON":false,"key":"hadoop_yarn_resourcemanager_memory_in_mb","type":"Gauge"},"aggregateOperator":"latest","dataSource":"metrics","disabled":false,"expression":"B","filters":{"items":[{"id":"e9895b91","key":{"dataType":"string","id":"status--string--tag--false","isColumn":false,"isJSON":false,"key":"status","type":"tag"},"op":"=","value":"Available"},{"id":"a36104e9","key":{"dataType":"string","id":"queue--string--tag--false","isColumn":false,"isJSON":false,"key":"queue","type":"tag"},"op":"=","value":"root"},{"id":"da969c41","key":{"dataType":"string","id":"cluster--string--tag--false","isColumn":false,"isJSON":false,"key":"cluster","type":"tag"},"op":"=","value":"{{.cluster}}"},{"id":"4eb7899e","key":{"dataType":"string","id":"deployment_environment--string--tag--false","isColumn":false,"isJSON":false,"key":"deployment_environment","type":"tag"},"op":"=","value":"{{.deployment_environment}}"}],"op":"AND"},"functions":[],"groupBy":[],"having":[],"legend":"Available Memory","limit":null,"orderBy":[],"queryName":"B","reduceTo":"avg","spaceAggregation":"sum","stepInterval":60,"timeAggregation":"latest"}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"67ecc159-1a2a-4093-aaa5-20f7d0c7d92f","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"string","name":"body","type":""},{"dataType":"string","name":"timestamp","type":""}],"selectedTracesFields":[{"dataType":"string","id":"serviceName--string--tag--true","isColumn":true,"isJSON":false,"key":"serviceName","type":"tag"},{"dataType":"string","id":"name--string--tag--true","isColumn":true,"isJSON":false,"key":"name","type":"tag"},{"dataType":"float64","id":"durationNano--float64--tag--true","isColumn":true,"isJSON":false,"key":"durationNano","type":"tag"},{"dataType":"string","id":"httpMethod--string--tag--true","isColumn":true,"isJSON":false,"key":"httpMethod","type":"tag"},{"dataType":"string","id":"responseStatusCode--string--tag--true","isColumn":true,"isJSON":false,"key":"responseStatusCode","type":"tag"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Memory usage","yAxisUnit":"decmbytes"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"description":"vCore usage","fillSpans":false,"id":"46d8d065-1931-4889-9419-6ba7b8b3f1a0","isStacked":false,"mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregateAttribute":{"dataType":"float64","id":"hadoop_yarn_resourcemanager_vcore_count--float64--Gauge--true","isColumn":true,"isJSON":false,"key":"hadoop_yarn_resourcemanager_vcore_count","type":"Gauge"},"aggregateOperator":"latest","dataSource":"metrics","disabled":false,"expression":"A","filters":{"items":[{"id":"d04ec6a0","key":{"dataType":"string","id":"deployment_environment--string--tag--false","isColumn":false,"isJSON":false,"key":"deployment_environment","type":"tag"},"op":"=","value":"{{.deployment_environment}}"},{"id":"4412c9ef","key":{"dataType":"string","id":"cluster--string--tag--false","isColumn":false,"isJSON":false,"key":"cluster","type":"tag"},"op":"=","value":"{{.cluster}}"},{"id":"9aaabd32","key":{"dataType":"string","id":"queue--string--tag--false","isColumn":false,"isJSON":false,"key":"queue","type":"tag"},"op":"=","value":"root"},{"id":"99e72e4c","key":{"dataType":"string","id":"status--string--tag--false","isColumn":false,"isJSON":false,"key":"status","type":"tag"},"op":"=","value":"Allocated"}],"op":"AND"},"functions":[],"groupBy":[],"having":[],"legend":"Allocated Containers","limit":null,"orderBy":[],"queryName":"A","reduceTo":"avg","spaceAggregation":"sum","stepInterval":60,"timeAggregation":"latest"},{"aggregateAttribute":{"dataType":"float64","id":"hadoop_yarn_resourcemanager_vcore_count--float64--Gauge--true","isColumn":true,"isJSON":false,"key":"hadoop_yarn_resourcemanager_vcore_count","type":"Gauge"},"aggregateOperator":"latest","dataSource":"metrics","disabled":false,"expression":"B","filters":{"items":[{"id":"5dc7a553","key":{"dataType":"string","id":"deployment_environment--string--tag--false","isColumn":false,"isJSON":false,"key":"deployment_environment","type":"tag"},"op":"=","value":"{{.deployment_environment}}"},{"id":"5f2b7a0e","key":{"dataType":"string","id":"queue--string--tag--false","isColumn":false,"isJSON":false,"key":"queue","type":"tag"},"op":"=","value":"root"},{"id":"68bb93e9","key":{"dataType":"string","id":"status--string--tag--false","isColumn":false,"isJSON":false,"key":"status","type":"tag"},"op":"=","value":"Available"}],"op":"AND"},"functions":[],"groupBy":[],"having":[],"legend":"Available Containers","limit":null,"orderBy":[],"queryName":"B","reduceTo":"avg","spaceAggregation":"sum","stepInterval":60,"timeAggregation":"latest"}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"37c60ee2-f156-41a8-acc2-fabb99f4c907","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"string","name":"body","type":""},{"dataType":"string","name":"timestamp","type":""}],"selectedTracesFields":[{"dataType":"string","id":"serviceName--string--tag--true","isColumn":true,"isJSON":false,"key":"serviceName","type":"tag"},{"dataType":"string","id":"name--string--tag--true","isColumn":true,"isJSON":false,"key":"name","type":"tag"},{"dataType":"float64","id":"durationNano--float64--tag--true","isColumn":true,"isJSON":false,"key":"durationNano","type":"tag"},{"dataType":"string","id":"httpMethod--string--tag--true","isColumn":true,"isJSON":false,"key":"httpMethod","type":"tag"},{"dataType":"string","id":"responseStatusCode--string--tag--true","isColumn":true,"isJSON":false,"key":"responseStatusCode","type":"tag"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"vCore usage","yAxisUnit":"none"}]}
+{
+  "layout": [
+    {
+      "h": 1,
+      "i": "0e8723fe-970d-4a02-946a-f11a7cbb4b3e",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 4,
+      "i": "a1011a2a-37da-47e5-ac3d-2b604e2bd1ef",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 0,
+      "y": 1
+    },
+    {
+      "h": 4,
+      "i": "70943c30-150c-4110-adbf-13cb1319c8cf",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 2,
+      "y": 1
+    },
+    {
+      "h": 4,
+      "i": "de9eb368-f881-46b0-874e-b7fbb0de21cc",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 4,
+      "y": 1
+    },
+    {
+      "h": 4,
+      "i": "efebd111-1cbb-4051-8501-3edef7d493be",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 6,
+      "y": 1
+    },
+    {
+      "h": 4,
+      "i": "97b667c5-5141-4433-bca0-f1bc5711a49d",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 8,
+      "y": 1
+    },
+    {
+      "h": 4,
+      "i": "267c0ef8-8df2-4f09-8e5d-b0eac595f15e",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 10,
+      "y": 1
+    },
+    {
+      "h": 1,
+      "i": "57788c0f-5351-4d9d-b4a4-eaec7eb37db1",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 5
+    },
+    {
+      "h": 4,
+      "i": "b2a1d929-8a9f-4eff-8ad4-d9932e760c62",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 6
+    },
+    {
+      "h": 4,
+      "i": "d91cd6a7-c1f7-4b8b-a747-1a4a2e0588e7",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 6
+    },
+    {
+      "h": 4,
+      "i": "4f705a1b-6e20-4647-bcd8-f972be636460",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 6
+    },
+    {
+      "h": 4,
+      "i": "114bb452-5350-41bb-bee7-aba51ea37c23",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 0,
+      "y": 10
+    },
+    {
+      "h": 4,
+      "i": "66cb1d57-a6b4-4e75-9ffe-d3931e740d27",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 2,
+      "y": 10
+    },
+    {
+      "h": 4,
+      "i": "4a0971b3-f87d-4b5a-a398-7e0a64ed6df6",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 4,
+      "y": 10
+    },
+    {
+      "h": 4,
+      "i": "2d24cea2-264a-43e9-b4d9-6298a1e48371",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 6,
+      "y": 10
+    },
+    {
+      "h": 4,
+      "i": "7fff698b-24e6-45ff-b5fc-457847101996",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 8,
+      "y": 10
+    },
+    {
+      "h": 4,
+      "i": "5857b298-fc8a-4b65-890c-6ae90596170f",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 10,
+      "y": 10
+    },
+    {
+      "h": 6,
+      "i": "cec839c9-da6d-4aba-946a-dea00cff40be",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 14
+    },
+    {
+      "h": 6,
+      "i": "22198113-656b-47e5-8642-0666c29fa785",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 14
+    },
+    {
+      "h": 1,
+      "i": "209f81d2-b96a-4d50-a480-e38ebc37911a",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 20
+    },
+    {
+      "h": 4,
+      "i": "89bd953a-d45f-4182-8a99-6ae2fb2d13fc",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 21
+    },
+    {
+      "h": 4,
+      "i": "ad63c678-833a-4b32-ab37-5c3701593659",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 21
+    },
+    {
+      "h": 4,
+      "i": "d89a4902-f040-442f-9041-cadbd1d6aea4",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 21
+    },
+    {
+      "h": 7,
+      "i": "1198a093-0966-42d8-a794-46286bc792b2",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 25
+    },
+    {
+      "h": 7,
+      "i": "737fdbfe-1cc2-4faf-b6f2-5587c0a0a3a0",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 25
+    },
+    {
+      "h": 7,
+      "i": "62204433-c0d4-498d-8e42-11a47b47a799",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 25
+    },
+    {
+      "h": 6,
+      "i": "bf9c2195-4079-4ed6-bde2-8ae359126c50",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 32
+    },
+    {
+      "h": 6,
+      "i": "46d8d065-1931-4889-9419-6ba7b8b3f1a0",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 32
+    }
+  ],
+  "panelMap": {
+    "0e8723fe-970d-4a02-946a-f11a7cbb4b3e": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 4,
+          "i": "a1011a2a-37da-47e5-ac3d-2b604e2bd1ef",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 0,
+          "y": 1
+        },
+        {
+          "h": 4,
+          "i": "70943c30-150c-4110-adbf-13cb1319c8cf",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 2,
+          "y": 1
+        },
+        {
+          "h": 4,
+          "i": "de9eb368-f881-46b0-874e-b7fbb0de21cc",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 4,
+          "y": 1
+        },
+        {
+          "h": 4,
+          "i": "efebd111-1cbb-4051-8501-3edef7d493be",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 6,
+          "y": 1
+        },
+        {
+          "h": 4,
+          "i": "97b667c5-5141-4433-bca0-f1bc5711a49d",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 8,
+          "y": 1
+        },
+        {
+          "h": 4,
+          "i": "267c0ef8-8df2-4f09-8e5d-b0eac595f15e",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 10,
+          "y": 1
+        }
+      ]
+    },
+    "209f81d2-b96a-4d50-a480-e38ebc37911a": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 4,
+          "i": "89bd953a-d45f-4182-8a99-6ae2fb2d13fc",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 0,
+          "y": 46
+        },
+        {
+          "h": 4,
+          "i": "ad63c678-833a-4b32-ab37-5c3701593659",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 4,
+          "y": 46
+        },
+        {
+          "h": 4,
+          "i": "d89a4902-f040-442f-9041-cadbd1d6aea4",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 8,
+          "y": 46
+        },
+        {
+          "h": 7,
+          "i": "1198a093-0966-42d8-a794-46286bc792b2",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 0,
+          "y": 50
+        },
+        {
+          "h": 7,
+          "i": "737fdbfe-1cc2-4faf-b6f2-5587c0a0a3a0",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 4,
+          "y": 50
+        },
+        {
+          "h": 7,
+          "i": "62204433-c0d4-498d-8e42-11a47b47a799",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 8,
+          "y": 50
+        },
+        {
+          "h": 6,
+          "i": "bf9c2195-4079-4ed6-bde2-8ae359126c50",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 57
+        },
+        {
+          "h": 6,
+          "i": "46d8d065-1931-4889-9419-6ba7b8b3f1a0",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 57
+        }
+      ]
+    },
+    "57788c0f-5351-4d9d-b4a4-eaec7eb37db1": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 4,
+          "i": "b2a1d929-8a9f-4eff-8ad4-d9932e760c62",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 0,
+          "y": 14
+        },
+        {
+          "h": 4,
+          "i": "d91cd6a7-c1f7-4b8b-a747-1a4a2e0588e7",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 4,
+          "y": 14
+        },
+        {
+          "h": 4,
+          "i": "4f705a1b-6e20-4647-bcd8-f972be636460",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 8,
+          "y": 14
+        },
+        {
+          "h": 4,
+          "i": "114bb452-5350-41bb-bee7-aba51ea37c23",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 0,
+          "y": 18
+        },
+        {
+          "h": 4,
+          "i": "66cb1d57-a6b4-4e75-9ffe-d3931e740d27",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 2,
+          "y": 18
+        },
+        {
+          "h": 4,
+          "i": "4a0971b3-f87d-4b5a-a398-7e0a64ed6df6",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 4,
+          "y": 18
+        },
+        {
+          "h": 4,
+          "i": "2d24cea2-264a-43e9-b4d9-6298a1e48371",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 6,
+          "y": 18
+        },
+        {
+          "h": 4,
+          "i": "7fff698b-24e6-45ff-b5fc-457847101996",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 8,
+          "y": 18
+        },
+        {
+          "h": 4,
+          "i": "5857b298-fc8a-4b65-890c-6ae90596170f",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 10,
+          "y": 18
+        },
+        {
+          "h": 6,
+          "i": "cec839c9-da6d-4aba-946a-dea00cff40be",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 22
+        },
+        {
+          "h": 6,
+          "i": "22198113-656b-47e5-8642-0666c29fa785",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 22
+        }
+      ]
+    }
+  },
+  "title": "Hadoop Dashboard",
+  "uploadedGrafana": false,
+  "variables": {
+    "4d1d128e-8b58-4ab5-9b77-114ef9b8000e": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "The deployment environment for the service.",
+      "id": "4d1d128e-8b58-4ab5-9b77-114ef9b8000e",
+      "key": "4d1d128e-8b58-4ab5-9b77-114ef9b8000e",
+      "modificationUUID": "38dba338-ba78-43f4-89fe-d37a50643ded",
+      "multiSelect": false,
+      "name": "deployment_environment",
+      "order": 0,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'deployment_environment'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name like '%hadoop_hdfs_%'",
+      "showALLOption": false,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "ab996dc3-7360-48fb-8778-1f530b944025": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "Hadoop cluster",
+      "id": "ab996dc3-7360-48fb-8778-1f530b944025",
+      "modificationUUID": "7dbcaaf6-80af-4ccf-af22-3e5f4bcae3a1",
+      "multiSelect": false,
+      "name": "cluster",
+      "order": 0,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'cluster'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name like '%hadoop_hdfs_%'",
+      "showALLOption": false,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "version": "v4",
+  "widgets": [
+    {
+      "description": "",
+      "id": "0e8723fe-970d-4a02-946a-f11a7cbb4b3e",
+      "panelTypes": "row",
+      "title": "Applications",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "hadoop_yarn_resourcemanager_application_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "hadoop_yarn_resourcemanager_application_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b381ffa8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6227d778-ed34-49b2-8877-e15406e26818",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      }
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of applications that are in Submitted status at present.",
+      "fillSpans": false,
+      "id": "a1011a2a-37da-47e5-ac3d-2b604e2bd1ef",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "hadoop_yarn_resourcemanager_application_count--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "hadoop_yarn_resourcemanager_application_count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b381ffa8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  },
+                  {
+                    "id": "7ec36474",
+                    "key": {
+                      "dataType": "string",
+                      "id": "status--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "status",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "Submitted"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "Submitted applications",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "815d4e12-975c-4f44-a4cf-f778f809eb96",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Submitted",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of applications that are in Running status at present.",
+      "fillSpans": false,
+      "id": "70943c30-150c-4110-adbf-13cb1319c8cf",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "hadoop_yarn_resourcemanager_application_count--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "hadoop_yarn_resourcemanager_application_count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b381ffa8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  },
+                  {
+                    "id": "91567fb2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "status--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "status",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "Running"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "Running applications",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6a634c42-dd31-41a8-91d1-bb8a2bbeb617",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Running",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of applications that are in Pending status at present.",
+      "fillSpans": false,
+      "id": "de9eb368-f881-46b0-874e-b7fbb0de21cc",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "hadoop_yarn_resourcemanager_application_count--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "hadoop_yarn_resourcemanager_application_count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b381ffa8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  },
+                  {
+                    "id": "ebe03249",
+                    "key": {
+                      "dataType": "string",
+                      "id": "status--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "status",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "Pending"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "Pending applications",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "56eb95c8-3eb3-4c0a-ac63-3a68eabea080",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Pending",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of applications that are in Failed status at present.",
+      "fillSpans": false,
+      "id": "efebd111-1cbb-4051-8501-3edef7d493be",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "hadoop_yarn_resourcemanager_application_count--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "hadoop_yarn_resourcemanager_application_count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b381ffa8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  },
+                  {
+                    "id": "0bb0a636",
+                    "key": {
+                      "dataType": "string",
+                      "id": "status--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "status",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "Failed"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "Failed applications",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "2ab18492-0d27-427c-ad99-79220b950b5e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Failed",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of applications that are in Killed status at present.",
+      "fillSpans": false,
+      "id": "97b667c5-5141-4433-bca0-f1bc5711a49d",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "hadoop_yarn_resourcemanager_application_count--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "hadoop_yarn_resourcemanager_application_count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b381ffa8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  },
+                  {
+                    "id": "c13d521a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "status--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "status",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "Killed"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "Killed applications",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0be20c18-9655-4cbb-a663-3e24f1e9c960",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Killed",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of applications that are in Completed status at present.",
+      "fillSpans": false,
+      "id": "267c0ef8-8df2-4f09-8e5d-b0eac595f15e",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "hadoop_yarn_resourcemanager_application_count--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "hadoop_yarn_resourcemanager_application_count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b381ffa8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  },
+                  {
+                    "id": "d4724046",
+                    "key": {
+                      "dataType": "string",
+                      "id": "status--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "status",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "Completed"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "Completed applications",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "515219bc-4a67-49e9-a45e-7e3c28c70186",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Completed",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Live DataNodes at present.",
+      "fillSpans": false,
+      "id": "b2a1d929-8a9f-4eff-8ad4-d9932e760c62",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "hadoop_hdfs_namenode_fsname_system_state_num_live_data_nodes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "hadoop_hdfs_namenode_fsname_system_state_num_live_data_nodes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b381ffa8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  },
+                  {
+                    "id": "576af8d4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "state--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "state",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "Live"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "Live DataNodes",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f3bfae2d-d2f5-495b-8eff-ee640afd9ee5",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Live DataNodes",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Dead DataNodes at present.",
+      "fillSpans": false,
+      "id": "d91cd6a7-c1f7-4b8b-a747-1a4a2e0588e7",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "hadoop_hdfs_namenode_fsname_system_state_num_live_data_nodes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "hadoop_hdfs_namenode_fsname_system_state_num_live_data_nodes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b381ffa8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  },
+                  {
+                    "id": "8588ce61",
+                    "key": {
+                      "dataType": "string",
+                      "id": "state--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "state",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "Dead"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "Dead DataNodes",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c49d25c7-e4a2-4811-b75a-cd8daa53fd7f",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Dead DataNodes",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total volume failures at present.",
+      "fillSpans": false,
+      "id": "4f705a1b-6e20-4647-bcd8-f972be636460",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "hadoop_hdfs_namenode_fsname_system_state_volume_failures_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "hadoop_hdfs_namenode_fsname_system_state_volume_failures_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b381ffa8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "Volume failures",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9db02ba1-0518-490f-9e70-b9eb2a284f25",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Volume Failures",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "id": "57788c0f-5351-4d9d-b4a4-eaec7eb37db1",
+      "panelTypes": "row",
+      "title": "HDFS",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "hadoop_hdfs_namenode_fsname_system_capacity_bytes--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "hadoop_hdfs_namenode_fsname_system_capacity_bytes",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b381ffa8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "fca8df31-3cc4-4e29-9222-aebe22709473",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      }
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total number of blocks in the system at present.",
+      "fillSpans": false,
+      "id": "114bb452-5350-41bb-bee7-aba51ea37c23",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "hadoop_hdfs_namenode_nninfo_total_blocks--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "hadoop_hdfs_namenode_nninfo_total_blocks",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b381ffa8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "Total blocks",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "70d1807b-6fcf-4895-880e-e745ddec23f1",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total blocks",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total number of blocks in the live nodes at present.",
+      "fillSpans": false,
+      "id": "66cb1d57-a6b4-4e75-9ffe-d3931e740d27",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "hadoop_hdfs_namenode_nninfo_live_nodes_num_blocks--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "hadoop_hdfs_namenode_nninfo_live_nodes_num_blocks",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b381ffa8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "Blocks in live nodes",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "14d09dde-0e9b-4e53-a7b5-c5f86d9449fb",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Num blocks",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total number of blocks under replicated at present.\n",
+      "fillSpans": false,
+      "id": "4a0971b3-f87d-4b5a-a398-7e0a64ed6df6",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "hadoop_hdfs_namenode_fsname_system_under_replicated_blocks--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "hadoop_hdfs_namenode_fsname_system_under_replicated_blocks",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b381ffa8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "Under replicated blocks",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "548ec9a1-8c0a-4265-ab33-10cda333e7aa",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Under replicated blocks",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total number of corrupt blocks at present.",
+      "fillSpans": false,
+      "id": "2d24cea2-264a-43e9-b4d9-6298a1e48371",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "hadoop_hdfs_namenode_fsname_system_corrupt_blocks--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "hadoop_hdfs_namenode_fsname_system_corrupt_blocks",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b381ffa8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "Corrupt blocks",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9d6b1861-bd12-4d35-8a18-492db2a03fe6",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Corrupt blocks",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total number of missing blocks at present.",
+      "fillSpans": false,
+      "id": "7fff698b-24e6-45ff-b5fc-457847101996",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "hadoop_hdfs_namenode_fsname_system_missing_blocks--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "hadoop_hdfs_namenode_fsname_system_missing_blocks",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b381ffa8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "Missing blocks",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "34577178-fd57-4776-842a-b4f0f44e3bc5",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Missing blocks",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total number of blocks pending to be replicated at present.",
+      "fillSpans": false,
+      "id": "5857b298-fc8a-4b65-890c-6ae90596170f",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "hadoop_hdfs_namenode_fsname_system_pending_replication_blocks--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "hadoop_hdfs_namenode_fsname_system_pending_replication_blocks",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b381ffa8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "Pending replication blocks",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "bf62919b-206a-48aa-aea6-510790ebc6b6",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Pending replication blocks",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Current remaining capacity in DataNodes.",
+      "fillSpans": false,
+      "id": "cec839c9-da6d-4aba-946a-dea00cff40be",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "hadoop_hdfs_namenode_fsname_system_capacity_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "hadoop_hdfs_namenode_fsname_system_capacity_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b381ffa8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  },
+                  {
+                    "id": "4208d20a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "mode--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "mode",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "Remaining"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "Remaining capacity",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8a445dd0-3684-496a-a0a0-44ad43895768",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Remaining capacity in DataNodes",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Current capacity remaining per DataNode in bytes.",
+      "fillSpans": false,
+      "id": "22198113-656b-47e5-8642-0666c29fa785",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "hadoop_hdfs_namenode_nninfo_live_nodes_remaining--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "hadoop_hdfs_namenode_nninfo_live_nodes_remaining",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b381ffa8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "id": "datanode--string--tag--false",
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "datanode",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Capacity remaining per DataNode",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "12534129-d2d2-456d-bcd1-f045133a20a7",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Capacity remaining per DataNode",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "The total amount of memory currently used on the host.",
+      "fillSpans": false,
+      "id": "89bd953a-d45f-4182-8a99-6ae2fb2d13fc",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "hadoop_yarn_resourcemanager_node_memory_used_mb--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "hadoop_yarn_resourcemanager_node_memory_used_mb",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b381ffa8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "39a7c6d8-da25-4fa3-ba75-ff19dd244e12",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memory used",
+      "yAxisUnit": "decmbytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total number of vCores at present.",
+      "fillSpans": false,
+      "id": "ad63c678-833a-4b32-ab37-5c3701593659",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "hadoop_yarn_resourcemanager_vcore_count--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "hadoop_yarn_resourcemanager_vcore_count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b381ffa8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "Total vCores",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "38688558-3176-4516-8be4-489658eff836",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total vCores",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total number of containers currently running on the host",
+      "fillSpans": false,
+      "id": "d89a4902-f040-442f-9041-cadbd1d6aea4",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "hadoop_yarn_resourcemanager_node_containers_total--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "hadoop_yarn_resourcemanager_node_containers_total",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b381ffa8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "Total containers",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ff3f2b33-9881-4254-92e0-3b65fa713537",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total containers",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "id": "209f81d2-b96a-4d50-a480-e38ebc37911a",
+      "panelTypes": "row",
+      "title": "YARN Cluster",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "hadoop_yarn_resourcemanager_node_containers_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "hadoop_yarn_resourcemanager_node_containers_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b381ffa8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ce23033b-7941-47a0-a9d7-b333082a7e0f",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      }
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of NodeManagers in each status at present.",
+      "fillSpans": false,
+      "id": "1198a093-0966-42d8-a794-46286bc792b2",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "pie",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "hadoop_yarn_resourcemanager_nodemanager_total--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "hadoop_yarn_resourcemanager_nodemanager_total",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b381ffa8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "id": "state--string--tag--false",
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "state",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "NodeManager status",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "e43812c2-a1f9-4a67-a1a9-f0cfaa1cb19c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "NodeManager status",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total application count in each status at present.",
+      "fillSpans": false,
+      "id": "737fdbfe-1cc2-4faf-b6f2-5587c0a0a3a0",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "pie",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "hadoop_yarn_resourcemanager_application_count--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "hadoop_yarn_resourcemanager_application_count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b381ffa8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "id": "status--string--tag--false",
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "status",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Applications by status",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a4b91226-f31d-4cb2-8b19-97ab1df4b8b7",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Application count",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Count of container in each status at present.",
+      "fillSpans": false,
+      "id": "62204433-c0d4-498d-8e42-11a47b47a799",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "pie",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "hadoop_yarn_resourcemanager_container_count--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "hadoop_yarn_resourcemanager_container_count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b381ffa8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "id": "state--string--tag--false",
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "state",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Containers by status",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "5d018773-a47d-4649-81ba-b47e0ef342e4",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Container by status",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Memory usage",
+      "fillSpans": false,
+      "id": "bf9c2195-4079-4ed6-bde2-8ae359126c50",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "hadoop_yarn_resourcemanager_memory_in_mb--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "hadoop_yarn_resourcemanager_memory_in_mb",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b381ffa8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "id": "state--string--tag--false",
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "state",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Memory usage (MB)",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "98d49c59-39cb-489b-9a10-548971c78eea",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memory usage",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "vCore usage",
+      "fillSpans": false,
+      "id": "46d8d065-1931-4889-9419-6ba7b8b3f1a0",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "hadoop_yarn_resourcemanager_vcore_count--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "hadoop_yarn_resourcemanager_vcore_count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b381ffa8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment_environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment_environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "id": "state--string--tag--false",
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "state",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "vCore usage",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d971cb2f-3d3a-4e9f-b1db-868e3ee3c66e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "vCore usage",
+      "yAxisUnit": "none"
+    }
+  ]
+}


### PR DESCRIPTION
## Description
Adds query configurations to the Apache Hadoop monitoring dashboard for SigNoz.

### Changes
- hadoop/hadoop-otlp-v1.json: Added query definitions (Builder) for all 28 dashboard panels covering Application Metrics, HDFS Metrics, and YARN Cluster Metrics.

### Panels
- **Application Metrics**: Submitted, Running, Pending, Failed, Killed, Completed application counts
- **HDFS Metrics**: Live/Dead DataNodes, Volume Failures, Total/Under-replicated/Corrupt/Missing/Pending blocks, Remaining capacity, Capacity per DataNode
- **YARN Metrics**: Memory used, vCores, Total containers, NodeManager status, Application count by status, Container count by status, Memory usage, vCore usage

### Tech Stack
- JMX receiver with OpenTelemetry Collector
- Builder query type with metric-based aggregation
- Filtered by deployment_environment variable

### Acceptance Criteria (from issue #6426)
- [x] HDFS capacity/usage panels
- [x] NameNode health indicators
- [x] DataNode status panels
- [x] YARN container counts
- [x] ResourceManager metrics
- [x] Application metrics by status

Related to SigNoz issue: https://github.com/SigNoz/signoz/issues/6426