### PR TITLE
feat: add NVIDIA DCGM Exporter monitoring dashboard

### DIFF
--- a/dcgm/README.md
+++ b/dcgm/README.md
@@ -1,0 +1,68 @@
+# NVIDIA DCGM Exporter Dashboard
+
+Monitoring dashboard for NVIDIA GPUs using the [DCGM Exporter](https://github.com/NVIDIA/dcgm-exporter) with SigNoz.
+
+## Panels
+
+| Panel | Metric | Description |
+|-------|--------|-------------|
+| GPU Utilization | `DCGM_FI_DEV_GPU_UTIL` | GPU utilization percentage |
+| GPU Memory Used | `DCGM_FI_DEV_FB_USED` | Framebuffer memory used (MB) |
+| GPU Temperature | `DCGM_FI_DEV_GPU_TEMP` | GPU temperature (°C) |
+| GPU Power Draw | `DCGM_FI_DEV_POWER_USAGE` | GPU power consumption (W) |
+| PCIe TX Throughput | `DCGM_FI_DEV_PCIE_TX_THRU` | PCIe transmit throughput |
+| PCIe RX Throughput | `DCGM_FI_DEV_PCIE_RX_THRU` | PCIe receive throughput |
+| SM Occupancy | `DCGM_FI_PROF_SM_OCCUPANCY` | Streaming multiprocessor occupancy (%) |
+| XID Errors | `DCGM_FI_DEV_XID_ERRORS` | XID error count |
+
+## Variables
+
+- **gpu** — Filter by GPU identifier
+- **k8s.node.name** — Filter by Kubernetes node
+
+## Data Ingestion
+
+### Prerequisites
+
+1. Deploy [DCGM Exporter](https://github.com/NVIDIA/dcgm-exporter) on GPU nodes
+2. Configure OpenTelemetry Collector to scrape DCGM metrics
+
+### OTel Collector Config
+
+```yaml
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: 'dcgm-exporter'
+          scrape_interval: 15s
+          static_configs:
+            - targets: ['dcgm-exporter:9400']
+
+processors:
+  resource/env:
+    attributes:
+      - key: deployment.environment
+        value: prod
+        action: upsert
+  batch: {}
+
+exporters:
+  otlp:
+    endpoint: "ingest.{region}.signoz.cloud:443"
+    tls:
+      insecure: false
+    headers:
+      "signoz-access-token": "<SIGNOZ_INGESTION_KEY>"
+
+service:
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      processors: [resource/env, batch]
+      exporters: [otlp]
+```
+
+## Import
+
+Import `dcgm-otlp-v1.json` via **Dashboards → Import** in SigNoz.

--- a/dcgm/dcgm-otlp-v1.json
+++ b/dcgm/dcgm-otlp-v1.json
@@ -1,0 +1,2244 @@
+{
+  "layout": [
+    {
+      "h": 1,
+      "i": "6b96dd16-2996-4a4d-95a6-dd0200106d5c",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 4,
+      "i": "e51676ce-853b-4f35-a7ef-2c1485343d18",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 0,
+      "y": 1
+    },
+    {
+      "h": 4,
+      "i": "9c13a493-d66f-44f8-b012-bb9be600646b",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 3,
+      "y": 1
+    },
+    {
+      "h": 4,
+      "i": "0063b2d8-aff6-40ec-806d-e5e833efb097",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 6,
+      "y": 1
+    },
+    {
+      "h": 4,
+      "i": "99e77d7d-1faf-498b-b849-901cf86e8028",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 9,
+      "y": 1
+    },
+    {
+      "h": 1,
+      "i": "128042c2-4503-4eef-8611-c4e907ef425f",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 5
+    },
+    {
+      "h": 6,
+      "i": "fe2d5320-a200-4599-856b-57881d7acf7b",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 6
+    },
+    {
+      "h": 6,
+      "i": "15934862-3a6b-477a-b78d-2313d3e9849f",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 6
+    },
+    {
+      "h": 6,
+      "i": "4a522ab0-6a3e-4c87-bd94-316f3f3bb4e6",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 12
+    },
+    {
+      "h": 6,
+      "i": "81b5219a-c06b-4d75-b98a-f1302306d72d",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 12
+    },
+    {
+      "h": 1,
+      "i": "12b9dbfb-5c24-4163-84e4-5707f627ca3e",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 18
+    },
+    {
+      "h": 6,
+      "i": "2dcfa373-4988-4528-bc01-a4985435ba21",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 19
+    },
+    {
+      "h": 6,
+      "i": "dc1f50fa-3b33-4761-839a-2bbf8246e6e8",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 19
+    },
+    {
+      "h": 6,
+      "i": "303dcbd7-dc00-4188-865a-8dcb3837e8c1",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 25
+    },
+    {
+      "h": 6,
+      "i": "381da0e6-ea81-4d79-8877-f8bdb9370664",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 25
+    }
+  ],
+  "panelMap": {
+    "6b96dd16-2996-4a4d-95a6-dd0200106d5c": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 4,
+          "i": "e51676ce-853b-4f35-a7ef-2c1485343d18",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 0,
+          "y": 1
+        },
+        {
+          "h": 4,
+          "i": "9c13a493-d66f-44f8-b012-bb9be600646b",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 3,
+          "y": 1
+        },
+        {
+          "h": 4,
+          "i": "0063b2d8-aff6-40ec-806d-e5e833efb097",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 6,
+          "y": 1
+        },
+        {
+          "h": 4,
+          "i": "99e77d7d-1faf-498b-b849-901cf86e8028",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 9,
+          "y": 1
+        }
+      ]
+    },
+    "128042c2-4503-4eef-8611-c4e907ef425f": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "fe2d5320-a200-4599-856b-57881d7acf7b",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 6
+        },
+        {
+          "h": 6,
+          "i": "15934862-3a6b-477a-b78d-2313d3e9849f",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 6
+        },
+        {
+          "h": 6,
+          "i": "4a522ab0-6a3e-4c87-bd94-316f3f3bb4e6",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 12
+        },
+        {
+          "h": 6,
+          "i": "81b5219a-c06b-4d75-b98a-f1302306d72d",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 12
+        }
+      ]
+    },
+    "12b9dbfb-5c24-4163-84e4-5707f627ca3e": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "2dcfa373-4988-4528-bc01-a4985435ba21",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 19
+        },
+        {
+          "h": 6,
+          "i": "dc1f50fa-3b33-4761-839a-2bbf8246e6e8",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 19
+        },
+        {
+          "h": 6,
+          "i": "303dcbd7-dc00-4188-865a-8dcb3837e8c1",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 25
+        },
+        {
+          "h": 6,
+          "i": "381da0e6-ea81-4d79-8877-f8bdb9370664",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 25
+        }
+      ]
+    }
+  },
+  "title": "NVIDIA DCGM Exporter",
+  "uploadedGrafana": false,
+  "variables": {
+    "ece172a8-8afb-481d-b325-1c01223f5d81": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "NVIDIA GPU identifier",
+      "dynamicVariablesAttribute": "gpu",
+      "dynamicVariablesSource": "All telemetry",
+      "id": "ece172a8-8afb-481d-b325-1c01223f5d81",
+      "key": "ece172a8-8afb-481d-b325-1c01223f5d81",
+      "modificationUUID": "6869187f-0da6-48f7-89e8-d12cb28b8430",
+      "multiSelect": true,
+      "name": "gpu",
+      "order": 0,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    },
+    "2de3b297-be3b-4226-8ef5-bb9dae31cb03": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Kubernetes node name",
+      "dynamicVariablesAttribute": "k8s.node.name",
+      "dynamicVariablesSource": "All telemetry",
+      "id": "2de3b297-be3b-4226-8ef5-bb9dae31cb03",
+      "key": "2de3b297-be3b-4226-8ef5-bb9dae31cb03",
+      "modificationUUID": "d2229075-43be-44a7-8fb5-79794cc04209",
+      "multiSelect": true,
+      "name": "k8s.node.name",
+      "order": 0,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    }
+  },
+  "version": "v4",
+  "widgets": [
+    {
+      "description": "",
+      "id": "6b96dd16-2996-4a4d-95a6-dd0200106d5c",
+      "panelTypes": "row",
+      "title": "GPU Overview"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Current GPU utilization percentage",
+      "fillSpans": false,
+      "id": "e51676ce-853b-4f35-a7ef-2c1485343d18",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "DCGM_FI_DEV_GPU_UTIL--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "DCGM_FI_DEV_GPU_UTIL",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "c34a22e8",
+                    "key": {
+                      "id": "gpu--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gpu",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gpu}}"
+                  },
+                  {
+                    "id": "f8f161a7",
+                    "key": {
+                      "id": "k8s.node.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "k8s.node.name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.k8s.node.name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0dab5db7-205d-4ffa-b706-e6804ac50db6",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "GPU Utilization",
+      "yAxisUnit": "%"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Current framebuffer memory used in MB",
+      "fillSpans": false,
+      "id": "9c13a493-d66f-44f8-b012-bb9be600646b",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "DCGM_FI_DEV_FB_USED--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "DCGM_FI_DEV_FB_USED",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "7ac86e55",
+                    "key": {
+                      "id": "gpu--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gpu",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gpu}}"
+                  },
+                  {
+                    "id": "0c8e6ba0",
+                    "key": {
+                      "id": "k8s.node.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "k8s.node.name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.k8s.node.name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "74da604e-9f06-4998-950a-cf0f41626881",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "GPU Memory Used",
+      "yAxisUnit": "MBy"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Current GPU temperature in Celsius",
+      "fillSpans": false,
+      "id": "0063b2d8-aff6-40ec-806d-e5e833efb097",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "DCGM_FI_DEV_GPU_TEMP--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "DCGM_FI_DEV_GPU_TEMP",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "31ae62b7",
+                    "key": {
+                      "id": "gpu--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gpu",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gpu}}"
+                  },
+                  {
+                    "id": "fdf4ae66",
+                    "key": {
+                      "id": "k8s.node.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "k8s.node.name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.k8s.node.name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0b77fb13-001d-47d7-b2ca-593c418aae6b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "GPU Temperature",
+      "yAxisUnit": "celsius"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Current GPU power draw in watts",
+      "fillSpans": false,
+      "id": "99e77d7d-1faf-498b-b849-901cf86e8028",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "DCGM_FI_DEV_POWER_USAGE--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "DCGM_FI_DEV_POWER_USAGE",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "e86d7965",
+                    "key": {
+                      "id": "gpu--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gpu",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gpu}}"
+                  },
+                  {
+                    "id": "a6d8cdd5",
+                    "key": {
+                      "id": "k8s.node.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "k8s.node.name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.k8s.node.name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f7197fd5-8673-44c5-9da0-3431501f6e8a",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "GPU Power Draw",
+      "yAxisUnit": "watt"
+    },
+    {
+      "description": "",
+      "id": "128042c2-4503-4eef-8611-c4e907ef425f",
+      "panelTypes": "row",
+      "title": "GPU Metrics"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "GPU utilization percentage over time",
+      "fillSpans": false,
+      "id": "fe2d5320-a200-4599-856b-57881d7acf7b",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "DCGM_FI_DEV_GPU_UTIL--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "DCGM_FI_DEV_GPU_UTIL",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "26516ecc",
+                    "key": {
+                      "id": "gpu--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gpu",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gpu}}"
+                  },
+                  {
+                    "id": "b056ee3e",
+                    "key": {
+                      "id": "k8s.node.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "k8s.node.name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.k8s.node.name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "gpu--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "gpu",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "GPU {{gpu}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "51a86326-70b2-4f1f-92ac-e5aade946ca8",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "GPU Utilization",
+      "yAxisUnit": "%"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Framebuffer memory used over time",
+      "fillSpans": false,
+      "id": "15934862-3a6b-477a-b78d-2313d3e9849f",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "DCGM_FI_DEV_FB_USED--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "DCGM_FI_DEV_FB_USED",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "3060793f",
+                    "key": {
+                      "id": "gpu--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gpu",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gpu}}"
+                  },
+                  {
+                    "id": "e4035187",
+                    "key": {
+                      "id": "k8s.node.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "k8s.node.name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.k8s.node.name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "gpu--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "gpu",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "GPU {{gpu}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8cc7b1ca-1822-4472-a549-867edc6784b1",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "GPU Memory Used",
+      "yAxisUnit": "MBy"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "GPU temperature over time",
+      "fillSpans": false,
+      "id": "4a522ab0-6a3e-4c87-bd94-316f3f3bb4e6",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "DCGM_FI_DEV_GPU_TEMP--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "DCGM_FI_DEV_GPU_TEMP",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d80443e0",
+                    "key": {
+                      "id": "gpu--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gpu",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gpu}}"
+                  },
+                  {
+                    "id": "cbc3d534",
+                    "key": {
+                      "id": "k8s.node.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "k8s.node.name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.k8s.node.name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "gpu--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "gpu",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "GPU {{gpu}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "1ca27f9d-d936-4c24-890a-042839c630ed",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "GPU Temperature",
+      "yAxisUnit": "celsius"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "GPU power draw over time",
+      "fillSpans": false,
+      "id": "81b5219a-c06b-4d75-b98a-f1302306d72d",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "DCGM_FI_DEV_POWER_USAGE--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "DCGM_FI_DEV_POWER_USAGE",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "071f4591",
+                    "key": {
+                      "id": "gpu--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gpu",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gpu}}"
+                  },
+                  {
+                    "id": "71cc5de0",
+                    "key": {
+                      "id": "k8s.node.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "k8s.node.name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.k8s.node.name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "gpu--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "gpu",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "GPU {{gpu}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d455092b-dee5-41be-aaaf-62fd9b37988a",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "GPU Power Draw",
+      "yAxisUnit": "watt"
+    },
+    {
+      "description": "",
+      "id": "12b9dbfb-5c24-4163-84e4-5707f627ca3e",
+      "panelTypes": "row",
+      "title": "PCIe & Profiling"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "PCIe transmit throughput",
+      "fillSpans": false,
+      "id": "2dcfa373-4988-4528-bc01-a4985435ba21",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "DCGM_FI_DEV_PCIE_TX_THRU--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "DCGM_FI_DEV_PCIE_TX_THRU",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "4209cc58",
+                    "key": {
+                      "id": "gpu--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gpu",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gpu}}"
+                  },
+                  {
+                    "id": "38009a66",
+                    "key": {
+                      "id": "k8s.node.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "k8s.node.name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.k8s.node.name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "gpu--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "gpu",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "GPU {{gpu}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "11f6a59b-6a1f-4e90-85fd-a982c8b8c11c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "PCIe TX Throughput",
+      "yAxisUnit": "ByPerSec"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "PCIe receive throughput",
+      "fillSpans": false,
+      "id": "dc1f50fa-3b33-4761-839a-2bbf8246e6e8",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "DCGM_FI_DEV_PCIE_RX_THRU--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "DCGM_FI_DEV_PCIE_RX_THRU",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d8960580",
+                    "key": {
+                      "id": "gpu--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gpu",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gpu}}"
+                  },
+                  {
+                    "id": "abb6f0db",
+                    "key": {
+                      "id": "k8s.node.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "k8s.node.name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.k8s.node.name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "gpu--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "gpu",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "GPU {{gpu}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "5e83d6b7-f7a2-4b0d-a9e9-3afeadb6791a",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "PCIe RX Throughput",
+      "yAxisUnit": "ByPerSec"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Streaming multiprocessor occupancy percentage",
+      "fillSpans": false,
+      "id": "303dcbd7-dc00-4188-865a-8dcb3837e8c1",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "DCGM_FI_PROF_SM_OCCUPANCY--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "DCGM_FI_PROF_SM_OCCUPANCY",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "aa1be38f",
+                    "key": {
+                      "id": "gpu--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gpu",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gpu}}"
+                  },
+                  {
+                    "id": "de7d50aa",
+                    "key": {
+                      "id": "k8s.node.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "k8s.node.name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.k8s.node.name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "gpu--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "gpu",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "GPU {{gpu}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "246fbc60-be5a-4962-b8ac-f6eb4093609a",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "SM Occupancy",
+      "yAxisUnit": "%"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "XID error count",
+      "fillSpans": false,
+      "id": "381da0e6-ea81-4d79-8877-f8bdb9370664",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "DCGM_FI_DEV_XID_ERRORS--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "DCGM_FI_DEV_XID_ERRORS",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f66c987f",
+                    "key": {
+                      "id": "gpu--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gpu",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gpu}}"
+                  },
+                  {
+                    "id": "7c87d562",
+                    "key": {
+                      "id": "k8s.node.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "k8s.node.name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.k8s.node.name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "gpu--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "gpu",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "GPU {{gpu}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a761b6e4-6aea-417c-8e87-96b7d7d291d3",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "XID Errors",
+      "yAxisUnit": "none"
+    }
+  ]
+}


### PR DESCRIPTION
## Description
Monitoring dashboard for NVIDIA DCGM Exporter (GPU metrics).

### Panels
- GPU Utilization, Memory Usage, Temperature
- Power Draw, PCIe Throughput
- SM Occupancy, XID Errors

### Changes
- dcgm/dcgm-otlp-v1.json: Complete SigNoz dashboard with 8 DCGM metrics
- dcgm/README.md: Documentation with OTel collector config

Related to https://github.com/SigNoz/signoz/issues/8093