### PR TITLE
feat: add Elasticsearch monitoring dashboard

### DIFF
--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -1,0 +1,80 @@
+# Elasticsearch Monitoring Dashboard
+
+A comprehensive SigNoz dashboard for monitoring Elasticsearch clusters, nodes, indices, and query performance using the **OpenTelemetry Elasticsearch receiver**.
+
+## Panels
+
+### Node Metrics
+| Panel | Metric | Description |
+|---|---|---|
+| Node Disk Total | `elasticsearch.node.fs.disk.total` | Total disk space per node |
+| Node Disk Free | `elasticsearch.node.fs.disk.free` | Free disk space per node |
+| Node Disk Available | `elasticsearch.node.fs.disk.available` | Disk available to the JVM per node |
+| Node CPU Usage | `elasticsearch.os.cpu.usage` | OS-level CPU usage % per node |
+| JVM Heap Memory Used | `jvm.memory.heap.used` | JVM heap memory in use per node |
+| JVM Non-Heap Memory Used | `jvm.memory.nonheap.used` | JVM non-heap memory in use per node |
+
+### Cluster Health Metrics
+| Panel | Metric | Description |
+|---|---|---|
+| Cluster Health Status | `elasticsearch.cluster.health` | Health status grouped by green/yellow/red |
+| Active Shards | `elasticsearch.cluster.shards` | Number of active shards |
+| Cluster Pending Tasks | `elasticsearch.cluster.pending_tasks` | Unexecuted cluster-level changes |
+| Unassigned Shards | `elasticsearch.cluster.shards` | Shards not assigned to any node |
+| Total Nodes | `elasticsearch.cluster.nodes` | Total nodes in the cluster |
+| In-Flight Fetches | `elasticsearch.cluster.in_flight_fetch` | Ongoing shard info requests |
+
+### Index Metrics
+| Panel | Metric | Description |
+|---|---|---|
+| Index Document Count | `elasticsearch.index.documents` | Active documents per index |
+| Index Shard Size | `elasticsearch.index.shards.size` | Estimated disk usage per index |
+
+### Query and Request Metrics
+| Panel | Metric | Description |
+|---|---|---|
+| Query Operations Rate | `elasticsearch.node.operations.completed` | Query ops/sec per node |
+| Fetch Operations Rate | `elasticsearch.node.operations.completed` | Fetch ops/sec per node |
+| Index Operations Rate | `elasticsearch.node.operations.completed` | Index ops/sec per node |
+| Query Latency | `elasticsearch.node.operations.time` | Time spent on query operations |
+| Fetch Latency | `elasticsearch.node.operations.time` | Time spent on fetch operations |
+| Indexing Latency | `elasticsearch.node.operations.time` | Time spent on index operations |
+
+## Prerequisites
+
+1. **SigNoz** running (v0.30+ recommended)
+2. **OpenTelemetry Collector** with the `elasticsearchreceiver` configured:
+
+```yaml
+receivers:
+  elasticsearch:
+    endpoint: http://localhost:9200
+    collection_interval: 60s
+    # username: elastic       # if authentication is enabled
+    # password: changeme
+
+service:
+  pipelines:
+    metrics:
+      receivers: [elasticsearch]
+      exporters: [otlp]
+```
+
+See the [OpenTelemetry Elasticsearch Receiver docs](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/elasticsearchreceiver) for full configuration options.
+
+## Importing into SigNoz
+
+1. Open SigNoz → **Dashboards** → **New Dashboard**
+2. Click **Import JSON**
+3. Upload or paste the contents of `elasticsearch-otlp-v1.json`
+4. Click **Import**
+
+## Template Variables
+
+| Variable | Description |
+|---|---|
+| `elasticsearch.node.name` | Filter all node-level panels by specific node(s) |
+
+## Related Issues
+
+- Fixes [SigNoz/signoz#6010](https://github.com/SigNoz/signoz/issues/6010)

--- a/elasticsearch/elasticsearch-otlp-v1.json
+++ b/elasticsearch/elasticsearch-otlp-v1.json
@@ -1,0 +1,1913 @@
+{
+  "description": "Comprehensive Elasticsearch monitoring dashboard covering node resources, cluster health, index statistics, and query/request performance. Uses metrics from the OpenTelemetry Elasticsearch receiver.",
+  "id": "elasticsearch-overview",
+  "layout": [
+    {
+      "h": 1,
+      "i": "0c4794b2-3687-4d9c-9584-d7eef7c6da04",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 0,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 1,
+      "i": "f4dd69d3-f199-4197-9ee7-34e9cf4fdbd5",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 1,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 1,
+      "i": "26700262-60d7-436f-9b8f-48e93ec311d4",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 2,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 1,
+      "i": "04bc0e46-0b4d-441a-a62d-89e5577b7455",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 3,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    }
+  ],
+  "name": "",
+  "panelMap": {
+    "0c4794b2-3687-4d9c-9584-d7eef7c6da04": {
+      "collapsed": true,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "4249d753-4b95-4f91-8e18-7b2ddd87fec7",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 1
+        },
+        {
+          "h": 6,
+          "i": "5a96a424-6dff-435c-80cc-a26ec1575db3",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 1
+        },
+        {
+          "h": 6,
+          "i": "b2155dae-9e39-47ed-bac5-f4d8f0729e2f",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 7
+        },
+        {
+          "h": 6,
+          "i": "67b123e1-949f-4ca8-8e58-0a0109a9c22e",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 7
+        },
+        {
+          "h": 6,
+          "i": "dfc34cd3-ea36-48eb-ab23-0e6e772c5c46",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 13
+        },
+        {
+          "h": 6,
+          "i": "b388f4e5-e16d-4633-a82d-f37d95844a46",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 13
+        }
+      ]
+    },
+    "f4dd69d3-f199-4197-9ee7-34e9cf4fdbd5": {
+      "collapsed": true,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "45b94bd7-fa19-4419-a7af-35c16925abc2",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 20
+        },
+        {
+          "h": 6,
+          "i": "c1e0f97b-d143-4926-abc7-9f0e375fd0b2",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 20
+        },
+        {
+          "h": 6,
+          "i": "cd4c85ae-b24d-46ab-a76b-ff830982660a",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 26
+        },
+        {
+          "h": 6,
+          "i": "2ba4f247-e046-4a17-b7c1-dca034e5258b",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 26
+        },
+        {
+          "h": 6,
+          "i": "9f507312-4cc5-4f4e-bfe5-41043e05b980",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 32
+        },
+        {
+          "h": 6,
+          "i": "b5fdd9fb-36af-45bf-aca8-c301e4c139b9",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 32
+        }
+      ]
+    },
+    "26700262-60d7-436f-9b8f-48e93ec311d4": {
+      "collapsed": true,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "421dc585-c886-4070-84b6-e56a7cef2fc1",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 39
+        },
+        {
+          "h": 6,
+          "i": "ed49a465-6a11-477d-a692-368c69f08898",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 39
+        }
+      ]
+    },
+    "04bc0e46-0b4d-441a-a62d-89e5577b7455": {
+      "collapsed": true,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "83e2d562-a89b-4a9a-b55b-faabe77a26f3",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 46
+        },
+        {
+          "h": 6,
+          "i": "105e6058-3ac3-4d80-8257-335c0543296a",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 46
+        },
+        {
+          "h": 6,
+          "i": "fca58232-c3cd-42de-877e-399153b9b464",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 52
+        },
+        {
+          "h": 6,
+          "i": "aa2aaeea-bd5b-485d-8b25-bf82b321bc1b",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 52
+        },
+        {
+          "h": 6,
+          "i": "06cb4092-983b-437b-bd38-7843a2c5e11a",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 58
+        },
+        {
+          "h": 6,
+          "i": "648f6352-0731-4f51-9a3f-6851476453bb",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 58
+        }
+      ]
+    }
+  },
+  "tags": [
+    "elasticsearch",
+    "database",
+    "search",
+    "otel"
+  ],
+  "title": "Elasticsearch Monitoring Dashboard",
+  "uploadedGrafana": false,
+  "variables": {
+    "c44662d3-7119-484b-8bcf-44f71eae5287": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "Elasticsearch node name",
+      "id": "c44662d3-7119-484b-8bcf-44f71eae5287",
+      "modificationUUID": "c44662d3-7119-484b-8bcf-44f71eae5287",
+      "multiSelect": true,
+      "name": "elasticsearch.node.name",
+      "order": 0,
+      "queryValue": "SELECT JSONExtractString(labels, 'elasticsearch.node.name') AS `elasticsearch.node.name`\nFROM signoz_metrics.distributed_time_series_v4_1day\nWHERE metric_name = 'elasticsearch.node.open_files'\nGROUP BY `elasticsearch.node.name`",
+      "selectedValue": "",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "version": "v4",
+  "widgets": [
+    {
+      "description": "",
+      "id": "0c4794b2-3687-4d9c-9584-d7eef7c6da04",
+      "panelTypes": "row",
+      "title": "Node Metrics"
+    },
+    {
+      "description": "",
+      "id": "f4dd69d3-f199-4197-9ee7-34e9cf4fdbd5",
+      "panelTypes": "row",
+      "title": "Cluster Health Metrics"
+    },
+    {
+      "description": "",
+      "id": "26700262-60d7-436f-9b8f-48e93ec311d4",
+      "panelTypes": "row",
+      "title": "Index Metrics"
+    },
+    {
+      "description": "",
+      "id": "04bc0e46-0b4d-441a-a62d-89e5577b7455",
+      "panelTypes": "row",
+      "title": "Query and Request Metrics"
+    },
+    {
+      "description": "Total disk space available to the node filesystem.",
+      "fillSpans": false,
+      "id": "4249d753-4b95-4f91-8e18-7b2ddd87fec7",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.node.fs.disk.total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.node.fs.disk.total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "elasticsearch.node.name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "elasticsearch.node.name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{elasticsearch.node.name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b5d5b6f9-e7ae-4ebc-a2d6-2dae77e384bb",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Node Disk Total",
+      "yAxisUnit": "decbytes"
+    },
+    {
+      "description": "Free disk space on the node filesystem.",
+      "fillSpans": false,
+      "id": "5a96a424-6dff-435c-80cc-a26ec1575db3",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.node.fs.disk.free--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.node.fs.disk.free",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "elasticsearch.node.name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "elasticsearch.node.name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{elasticsearch.node.name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0da9121b-98fe-42df-8f9c-f8437a47f15d",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Node Disk Free",
+      "yAxisUnit": "decbytes"
+    },
+    {
+      "description": "Disk space available to the JVM across all file stores.",
+      "fillSpans": false,
+      "id": "b2155dae-9e39-47ed-bac5-f4d8f0729e2f",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.node.fs.disk.available--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.node.fs.disk.available",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "elasticsearch.node.name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "elasticsearch.node.name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{elasticsearch.node.name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "cf1f7443-f343-4d13-aa95-4e3b541d5a96",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Node Disk Available",
+      "yAxisUnit": "decbytes"
+    },
+    {
+      "description": "OS-level CPU usage percentage for the Elasticsearch node.",
+      "fillSpans": false,
+      "id": "67b123e1-949f-4ca8-8e58-0a0109a9c22e",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.os.cpu.usage--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.os.cpu.usage",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "elasticsearch.node.name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "elasticsearch.node.name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{elasticsearch.node.name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "5bf8b851-a388-40f6-8397-083504ffee84",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Node CPU Usage",
+      "yAxisUnit": "percent"
+    },
+    {
+      "description": "Amount of JVM heap memory currently in use.",
+      "fillSpans": false,
+      "id": "dfc34cd3-ea36-48eb-ab23-0e6e772c5c46",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm.memory.heap.used--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm.memory.heap.used",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "elasticsearch.node.name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "elasticsearch.node.name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{elasticsearch.node.name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "198eb162-5ba2-4994-a7cd-52a1e9dfb59b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "JVM Heap Memory Used",
+      "yAxisUnit": "decbytes"
+    },
+    {
+      "description": "Amount of JVM non-heap memory currently in use (code cache, metaspace, etc.).",
+      "fillSpans": false,
+      "id": "b388f4e5-e16d-4633-a82d-f37d95844a46",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm.memory.nonheap.used--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm.memory.nonheap.used",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "elasticsearch.node.name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "elasticsearch.node.name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{elasticsearch.node.name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ac190634-073b-4273-9b5c-254cf3e1a803",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "JVM Non-Heap Memory Used",
+      "yAxisUnit": "decbytes"
+    },
+    {
+      "description": "Current health status of the cluster (green/yellow/red).",
+      "id": "45b94bd7-fa19-4419-a7af-35c16925abc2",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.cluster.health--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.cluster.health",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "health_status--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "health_status",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{health_status}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0cf6d907-72c2-40a3-872d-febf0ea1f930",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Cluster Health Status",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "Number of active shards in the cluster.",
+      "id": "c1e0f97b-d143-4926-abc7-9f0e375fd0b2",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.cluster.shards--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.cluster.shards",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "fa1b2c3d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "shard_state--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "shard_state",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "active"
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "69dcf4fc-7744-4ffe-b3c5-e5c406c22527",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Shards",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "Cluster-level changes not yet executed.",
+      "id": "cd4c85ae-b24d-46ab-a76b-ff830982660a",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.cluster.pending_tasks--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.cluster.pending_tasks",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "e47abb16-67b2-49c8-8c2b-8782ccb87654",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Cluster Pending Tasks",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "Number of shards not assigned to any node.",
+      "id": "2ba4f247-e046-4a17-b7c1-dca034e5258b",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.cluster.shards--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.cluster.shards",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "fb2c3d4e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "shard_state--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "shard_state",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "unassigned"
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "dc634d23-ddcf-441e-afcb-4faa0f83c4fc",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Unassigned Shards",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "Total number of nodes in the cluster.",
+      "id": "9f507312-4cc5-4f4e-bfe5-41043e05b980",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.cluster.nodes--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.cluster.nodes",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d1f9b54c-b00a-4db6-ac31-5f2deecaa201",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Nodes",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "Number of ongoing shard info requests.",
+      "id": "b5fdd9fb-36af-45bf-aca8-c301e4c139b9",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.cluster.in_flight_fetch--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.cluster.in_flight_fetch",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "e212fbdc-9cc4-4047-8f6f-48a1cb393913",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "In-Flight Fetches",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "Number of active (non-deleted) documents per index.",
+      "fillSpans": false,
+      "id": "421dc585-c886-4070-84b6-e56a7cef2fc1",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.index.documents--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.index.documents",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "fc3d4e5f",
+                    "key": {
+                      "dataType": "string",
+                      "id": "document_state--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "document_state",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "active"
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "elasticsearch.index.name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "elasticsearch.index.name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{elasticsearch.index.name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "629763c7-208f-429b-a99b-19a4d218e67c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Index Document Count",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "Estimated disk space used by index shards.",
+      "fillSpans": false,
+      "id": "ed49a465-6a11-477d-a692-368c69f08898",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.index.shards.size--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.index.shards.size",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "elasticsearch.index.name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "elasticsearch.index.name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{elasticsearch.index.name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ee606afc-ee9d-4e81-a421-1111321c005c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Index Shard Size",
+      "yAxisUnit": "decbytes"
+    },
+    {
+      "description": "Rate of query operations completed per second.",
+      "fillSpans": false,
+      "id": "83e2d562-a89b-4a9a-b55b-faabe77a26f3",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.node.operations.completed--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.node.operations.completed",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "fd4e5f6a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "operation--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "operation",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "query"
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "elasticsearch.node.name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "elasticsearch.node.name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{elasticsearch.node.name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "3d819988-df87-4bc9-8afa-5705305343aa",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Query Operations Rate",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "Rate of fetch operations completed per second.",
+      "fillSpans": false,
+      "id": "105e6058-3ac3-4d80-8257-335c0543296a",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.node.operations.completed--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.node.operations.completed",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "fe5f6a7b",
+                    "key": {
+                      "dataType": "string",
+                      "id": "operation--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "operation",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "fetch"
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "elasticsearch.node.name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "elasticsearch.node.name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{elasticsearch.node.name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8d65158a-a17e-474c-95dc-c27a9e0303b9",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Fetch Operations Rate",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "Rate of indexing operations completed per second.",
+      "fillSpans": false,
+      "id": "fca58232-c3cd-42de-877e-399153b9b464",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.node.operations.completed--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.node.operations.completed",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "ff6a7b8c",
+                    "key": {
+                      "dataType": "string",
+                      "id": "operation--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "operation",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "index"
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "elasticsearch.node.name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "elasticsearch.node.name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{elasticsearch.node.name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "2c8c0d83-ebde-420a-a935-1e8a3cc41974",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Index Operations Rate",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "Time spent performing query operations.",
+      "fillSpans": false,
+      "id": "aa2aaeea-bd5b-485d-8b25-bf82b321bc1b",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.node.operations.time--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.node.operations.time",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "fa7b8c9d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "operation--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "operation",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "query"
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "elasticsearch.node.name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "elasticsearch.node.name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{elasticsearch.node.name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "2195efc4-c56e-43fc-ae33-1eb682a11f0b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Query Latency",
+      "yAxisUnit": "ms"
+    },
+    {
+      "description": "Time spent performing fetch operations.",
+      "fillSpans": false,
+      "id": "06cb4092-983b-437b-bd38-7843a2c5e11a",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.node.operations.time--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.node.operations.time",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "fb8c9d0e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "operation--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "operation",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "fetch"
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "elasticsearch.node.name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "elasticsearch.node.name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{elasticsearch.node.name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ecff8aba-1f69-49d0-8438-cb5c538d3a4e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Fetch Latency",
+      "yAxisUnit": "ms"
+    },
+    {
+      "description": "Time spent performing index operations.",
+      "fillSpans": false,
+      "id": "648f6352-0731-4f51-9a3f-6851476453bb",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "elasticsearch.node.operations.time--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "elasticsearch.node.operations.time",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "fc9d0e1f",
+                    "key": {
+                      "dataType": "string",
+                      "id": "operation--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "operation",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "index"
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "elasticsearch.node.name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "elasticsearch.node.name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{elasticsearch.node.name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "70ba925f-2b8a-4e94-8f65-e289548d8f11",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Indexing Latency",
+      "yAxisUnit": "ms"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a comprehensive Elasticsearch monitoring dashboard using metrics from the OpenTelemetry Elasticsearch receiver.

**4 sections, 20 panels:**

- **Node Metrics** — Disk total/free/available, OS CPU usage, JVM heap and non-heap memory (grouped by node)
- **Cluster Health** — Health status (green/yellow/red), active/unassigned shards, pending tasks, total nodes, in-flight fetches
- **Index Metrics** — Document count and shard size per index
- **Query & Request Metrics** — Query/fetch/index operation rates and latencies

All metric names sourced directly from the [OTel Elasticsearch receiver metadata.yaml](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/elasticsearchreceiver/metadata.yaml).

Fixes SigNoz/signoz#6010
