### PR TITLE
feat(dashboard): Add Kafka Server Monitoring dashboard

### DIFF
--- a/kafka-server-monitoring/README.md
+++ b/kafka-server-monitoring/README.md
@@ -1,0 +1,95 @@
+# Kafka Server Monitoring Dashboard
+
+This dashboard provides comprehensive monitoring for Apache Kafka clusters using the [OpenTelemetry Kafka Metrics Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kafkametricsreceiver).
+
+## Dashboard Sections
+
+### Broker Metrics
+Overview gauges for the entire cluster:
+- **Number of Brokers** — total active brokers (`kafka.brokers`)
+- **Number of Topics** — distinct topics with partitions
+- **Total Partitions** — sum of all partitions across topics
+- **Consumer Groups** — number of distinct consumer groups
+
+### Topic Metrics
+Per-topic visibility:
+- **Partitions per Topic** — `kafka.topic.partitions` grouped by topic (top 20)
+- **Replicas per Topic** — total replicas summed per topic (`kafka.partition.replicas`)
+
+### Partition Metrics
+Partition-level health:
+- **Partition Current Offset** — log-end offset per partition, showing produce progress (`kafka.partition.current_offset`)
+- **Partition Oldest Offset** — log-start offset, showing retention boundary (`kafka.partition.oldest_offset`)
+- **In-Sync Replicas per Partition** — minimum ISR count; drops below replication factor indicate risk (`kafka.partition.replicas_in_sync`)
+- **Partition Leader Election Status** — 1 = healthy leader, 0 = under election (`kafka.partition.leader`)
+
+### Consumer Group Metrics
+Consumer health and throughput:
+- **Consumer Group Lag per Partition** — per-partition lag for each group (`kafka.consumer_group.lag`)
+- **Total Consumer Group Lag** — lag summed per group across all topics
+- **Consumer Group Offset per Partition** — consumer progress through the log (`kafka.consumer_group.offset`)
+- **Consumer Group Members** — active members per group (`kafka.consumer_group.members`)
+
+## Metrics Source
+
+All metrics are collected via the **OpenTelemetry Kafka Metrics Receiver** (`kafkametricsreceiver`) and ingested via OTLP.
+
+| Metric | Description |
+|--------|-------------|
+| `kafka.brokers` | Number of brokers in the cluster |
+| `kafka.topic.partitions` | Number of partitions per topic |
+| `kafka.partition.replicas` | Total replicas for a partition |
+| `kafka.partition.replicas_in_sync` | In-sync replicas for a partition |
+| `kafka.partition.leader` | 1 if partition has a leader, 0 otherwise |
+| `kafka.partition.current_offset` | Current (log-end) offset |
+| `kafka.partition.oldest_offset` | Oldest (log-start) offset |
+| `kafka.consumer_group.lag` | Lag for a consumer group on a partition |
+| `kafka.consumer_group.lag_sum` | Total lag summed across partitions |
+| `kafka.consumer_group.offset` | Consumer group committed offset |
+| `kafka.consumer_group.members` | Number of members in the group |
+
+## Setup
+
+### Configure OpenTelemetry Collector
+
+Add the following to your OpenTelemetry Collector configuration:
+
+```yaml
+receivers:
+  kafkametrics:
+    brokers:
+      - localhost:9092
+    protocol_version: 2.0.0
+    scrapers:
+      - brokers
+      - topics
+      - consumers
+
+service:
+  pipelines:
+    metrics:
+      receivers: [kafkametrics]
+      exporters: [otlp]
+```
+
+For authentication (SASL/TLS), refer to the [kafkametricsreceiver documentation](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kafkametricsreceiver).
+
+## Dashboard Variables
+
+| Variable | Description |
+|----------|-------------|
+| `deployment.environment` | Filter by deployment environment (e.g., `production`, `staging`) |
+| `kafka.cluster.alias` | Filter by Kafka cluster alias when monitoring multiple clusters |
+
+## Importing the Dashboard
+
+1. Open SigNoz and navigate to **Dashboards**.
+2. Click **New Dashboard** → **Import JSON**.
+3. Paste the contents of `kafka-server-monitoring-otlp-v1.json`.
+4. Set the `deployment.environment` variable to match your cluster.
+
+## References
+
+- [OpenTelemetry Kafka Metrics Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kafkametricsreceiver)
+- [SigNoz Kafka Monitoring Guide](https://signoz.io/docs/messaging-queues/kafka/)
+- [Apache Kafka Documentation](https://kafka.apache.org/documentation/)

--- a/kafka-server-monitoring/kafka-server-monitoring-otlp-v1.json
+++ b/kafka-server-monitoring/kafka-server-monitoring-otlp-v1.json
@@ -1,0 +1,1840 @@
+{
+  "description": "Kafka Server Monitoring Dashboard using OpenTelemetry Kafka Metrics Receiver. Tracks broker health, topic metrics, partition status, and consumer group lag.",
+  "image": "",
+  "layout": [
+    {
+      "h": 2,
+      "i": "section-broker",
+      "moved": false,
+      "static": false,
+      "w": 24,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 6,
+      "i": "w-broker-count",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 2
+    },
+    {
+      "h": 6,
+      "i": "w-topic-count",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 2
+    },
+    {
+      "h": 6,
+      "i": "w-partition-count",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 12,
+      "y": 2
+    },
+    {
+      "h": 6,
+      "i": "w-consumer-group-count",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 18,
+      "y": 2
+    },
+    {
+      "h": 2,
+      "i": "section-topic",
+      "moved": false,
+      "static": false,
+      "w": 24,
+      "x": 0,
+      "y": 8
+    },
+    {
+      "h": 7,
+      "i": "w-topic-partitions",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 10
+    },
+    {
+      "h": 7,
+      "i": "w-partition-replicas",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 12,
+      "y": 10
+    },
+    {
+      "h": 2,
+      "i": "section-partition",
+      "moved": false,
+      "static": false,
+      "w": 24,
+      "x": 0,
+      "y": 17
+    },
+    {
+      "h": 7,
+      "i": "w-partition-current-offset",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 19
+    },
+    {
+      "h": 7,
+      "i": "w-partition-oldest-offset",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 12,
+      "y": 19
+    },
+    {
+      "h": 7,
+      "i": "w-partition-insync-replicas",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 26
+    },
+    {
+      "h": 7,
+      "i": "w-partition-leader",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 12,
+      "y": 26
+    },
+    {
+      "h": 2,
+      "i": "section-consumer",
+      "moved": false,
+      "static": false,
+      "w": 24,
+      "x": 0,
+      "y": 33
+    },
+    {
+      "h": 7,
+      "i": "w-consumer-group-lag",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 35
+    },
+    {
+      "h": 7,
+      "i": "w-consumer-group-lag-sum",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 12,
+      "y": 35
+    },
+    {
+      "h": 7,
+      "i": "w-consumer-group-offset",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 42
+    },
+    {
+      "h": 7,
+      "i": "w-consumer-group-members",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 12,
+      "y": 42
+    }
+  ],
+  "panelMap": {},
+  "tags": [
+    "kafka",
+    "messaging",
+    "otlp",
+    "broker",
+    "consumer"
+  ],
+  "title": "Kafka Server Monitoring",
+  "uploadedGrafana": false,
+  "variables": {
+    "deployment.environment": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "Deployment environment",
+      "id": "deployment.environment",
+      "key": "deployment.environment",
+      "multiSelect": false,
+      "name": "deployment.environment",
+      "order": 0,
+      "queryValue": "",
+      "selectedValue": "",
+      "showALL": false,
+      "sort": "DISABLED",
+      "tagAttribute": "deployment.environment",
+      "type": "QUERY"
+    },
+    "kafka.cluster.alias": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "Kafka cluster alias",
+      "id": "kafka.cluster.alias",
+      "key": "kafka.cluster.alias",
+      "multiSelect": false,
+      "name": "kafka.cluster.alias",
+      "order": 1,
+      "queryValue": "",
+      "selectedValue": "",
+      "showALL": false,
+      "sort": "DISABLED",
+      "tagAttribute": "kafka.cluster.alias",
+      "type": "QUERY"
+    }
+  },
+  "version": "v4",
+  "widgets": [
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "customLegendColors": {},
+      "description": "Broker Metrics",
+      "fillSpans": false,
+      "id": "section-broker",
+      "isLogScale": false,
+      "isStacked": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "row",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [],
+        "id": "",
+        "promql": [],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Broker Metrics",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "customLegendColors": {},
+      "description": "Total number of brokers in the Kafka cluster",
+      "fillSpans": false,
+      "id": "w-broker-count",
+      "isLogScale": false,
+      "isStacked": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "kafka.brokers--int64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "kafka.brokers",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "max",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "env-filter",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{deployment.environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Brokers",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "max",
+              "spaceAggregation": "max",
+              "stepInterval": 60,
+              "timeAggregation": "max"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "q-broker-count",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Number of Brokers",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "customLegendColors": {},
+      "description": "Total number of topics in the Kafka cluster",
+      "fillSpans": false,
+      "id": "w-topic-count",
+      "isLogScale": false,
+      "isStacked": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "kafka.topic.partitions--int64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "kafka.topic.partitions",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "count_distinct",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "env-filter",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{deployment.environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "kafka.topic--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "kafka.topic",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Topics",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "max",
+              "spaceAggregation": "count_distinct",
+              "stepInterval": 60,
+              "timeAggregation": "max"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "q-topic-count",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Number of Topics",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "customLegendColors": {},
+      "description": "Total number of partitions across all topics",
+      "fillSpans": false,
+      "id": "w-partition-count",
+      "isLogScale": false,
+      "isStacked": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "kafka.topic.partitions--int64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "kafka.topic.partitions",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "env-filter",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{deployment.environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Partitions",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "max"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "q-partition-count",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Partitions",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "customLegendColors": {},
+      "description": "Number of distinct consumer groups tracked",
+      "fillSpans": false,
+      "id": "w-consumer-group-count",
+      "isLogScale": false,
+      "isStacked": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "kafka.consumer_group.lag--int64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "kafka.consumer_group.lag",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "count_distinct",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "env-filter",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{deployment.environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "kafka.consumer_group--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "kafka.consumer_group",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Consumer Groups",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "max",
+              "spaceAggregation": "count_distinct",
+              "stepInterval": 60,
+              "timeAggregation": "max"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "q-consumer-group-count",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Consumer Groups",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "customLegendColors": {},
+      "description": "Topic Metrics",
+      "fillSpans": false,
+      "id": "section-topic",
+      "isLogScale": false,
+      "isStacked": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "row",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [],
+        "id": "",
+        "promql": [],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Topic Metrics",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "customLegendColors": {},
+      "description": "Number of partitions per Kafka topic",
+      "fillSpans": false,
+      "id": "w-topic-partitions",
+      "isLogScale": false,
+      "isStacked": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "kafka.topic.partitions--int64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "kafka.topic.partitions",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "max",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "env-filter",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{deployment.environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "kafka.topic--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "kafka.topic",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{kafka.topic}}",
+              "limit": 20,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "max",
+              "spaceAggregation": "max",
+              "stepInterval": 60,
+              "timeAggregation": "max"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "q-topic-partitions",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Partitions per Topic (top 20)",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "customLegendColors": {},
+      "description": "Total replicas for each topic across all partitions",
+      "fillSpans": false,
+      "id": "w-partition-replicas",
+      "isLogScale": false,
+      "isStacked": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "kafka.partition.replicas--int64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "kafka.partition.replicas",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "env-filter",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{deployment.environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "kafka.topic--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "kafka.topic",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{kafka.topic}}",
+              "limit": 20,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "max"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "q-partition-replicas",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Replicas per Topic (top 20)",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "customLegendColors": {},
+      "description": "Partition Metrics",
+      "fillSpans": false,
+      "id": "section-partition",
+      "isLogScale": false,
+      "isStacked": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "row",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [],
+        "id": "",
+        "promql": [],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Partition Metrics",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "customLegendColors": {},
+      "description": "Current offset (log-end offset) for each partition — shows how many messages have been produced",
+      "fillSpans": false,
+      "id": "w-partition-current-offset",
+      "isLogScale": false,
+      "isStacked": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "kafka.partition.current_offset--int64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "kafka.partition.current_offset",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "max",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "env-filter",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{deployment.environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "kafka.topic--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "kafka.topic",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "int64",
+                  "id": "kafka.partition--int64--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "kafka.partition",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{kafka.topic}}-{{kafka.partition}}",
+              "limit": 20,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "max",
+              "spaceAggregation": "max",
+              "stepInterval": 60,
+              "timeAggregation": "max"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "q-partition-current-offset",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Partition Current Offset (top 20)",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "customLegendColors": {},
+      "description": "Oldest offset (log-start offset) for each partition — shows retention boundary",
+      "fillSpans": false,
+      "id": "w-partition-oldest-offset",
+      "isLogScale": false,
+      "isStacked": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "kafka.partition.oldest_offset--int64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "kafka.partition.oldest_offset",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "max",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "env-filter",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{deployment.environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "kafka.topic--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "kafka.topic",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "int64",
+                  "id": "kafka.partition--int64--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "kafka.partition",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{kafka.topic}}-{{kafka.partition}}",
+              "limit": 20,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "max",
+              "spaceAggregation": "max",
+              "stepInterval": 60,
+              "timeAggregation": "max"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "q-partition-oldest-offset",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Partition Oldest Offset (top 20)",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "customLegendColors": {},
+      "description": "Number of in-sync replicas per partition — healthy when equal to replication factor",
+      "fillSpans": false,
+      "id": "w-partition-insync-replicas",
+      "isLogScale": false,
+      "isStacked": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "kafka.partition.replicas_in_sync--int64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "kafka.partition.replicas_in_sync",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "min",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "env-filter",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{deployment.environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "kafka.topic--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "kafka.topic",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "int64",
+                  "id": "kafka.partition--int64--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "kafka.partition",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{kafka.topic}}-{{kafka.partition}}",
+              "limit": 20,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "min",
+              "spaceAggregation": "min",
+              "stepInterval": 60,
+              "timeAggregation": "min"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "q-partition-insync-replicas",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "In-Sync Replicas per Partition (top 20)",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "customLegendColors": {},
+      "description": "Whether partition has an elected leader (1 = has leader, 0 = no leader / under election)",
+      "fillSpans": false,
+      "id": "w-partition-leader",
+      "isLogScale": false,
+      "isStacked": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "kafka.partition.leader--int64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "kafka.partition.leader",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "min",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "env-filter",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{deployment.environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "kafka.topic--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "kafka.topic",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "int64",
+                  "id": "kafka.partition--int64--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "kafka.partition",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{kafka.topic}}-{{kafka.partition}}",
+              "limit": 20,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "min",
+              "spaceAggregation": "min",
+              "stepInterval": 60,
+              "timeAggregation": "min"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "q-partition-leader",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Partition Leader Election Status (top 20)",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "customLegendColors": {},
+      "description": "Consumer Group Metrics",
+      "fillSpans": false,
+      "id": "section-consumer",
+      "isLogScale": false,
+      "isStacked": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "row",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [],
+        "id": "",
+        "promql": [],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Consumer Group Metrics",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "customLegendColors": {},
+      "description": "Per-partition consumer lag — number of messages not yet consumed. High values indicate slow consumers.",
+      "fillSpans": false,
+      "id": "w-consumer-group-lag",
+      "isLogScale": false,
+      "isStacked": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "kafka.consumer_group.lag--int64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "kafka.consumer_group.lag",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "max",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "env-filter",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{deployment.environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "kafka.consumer_group--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "kafka.consumer_group",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "kafka.topic--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "kafka.topic",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "int64",
+                  "id": "kafka.partition--int64--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "kafka.partition",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{kafka.consumer_group}} / {{kafka.topic}}-{{kafka.partition}}",
+              "limit": 20,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "max",
+              "spaceAggregation": "max",
+              "stepInterval": 60,
+              "timeAggregation": "max"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "q-consumer-group-lag",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Consumer Group Lag per Partition (top 20)",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "customLegendColors": {},
+      "description": "Total consumer lag per group summed across all partitions and topics",
+      "fillSpans": false,
+      "id": "w-consumer-group-lag-sum",
+      "isLogScale": false,
+      "isStacked": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "kafka.consumer_group.lag--int64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "kafka.consumer_group.lag",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "env-filter",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{deployment.environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "kafka.consumer_group--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "kafka.consumer_group",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{kafka.consumer_group}}",
+              "limit": 20,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "max"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "q-consumer-group-lag-sum",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Consumer Group Lag (top 20 groups)",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "customLegendColors": {},
+      "description": "Current consumer group offset per partition — shows progress through the topic",
+      "fillSpans": false,
+      "id": "w-consumer-group-offset",
+      "isLogScale": false,
+      "isStacked": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "kafka.consumer_group.offset--int64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "kafka.consumer_group.offset",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "max",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "env-filter",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{deployment.environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "kafka.consumer_group--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "kafka.consumer_group",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "kafka.topic--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "kafka.topic",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "int64",
+                  "id": "kafka.partition--int64--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "kafka.partition",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{kafka.consumer_group}} / {{kafka.topic}}-{{kafka.partition}}",
+              "limit": 20,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "max",
+              "spaceAggregation": "max",
+              "stepInterval": 60,
+              "timeAggregation": "max"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "q-consumer-group-offset",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Consumer Group Offset per Partition (top 20)",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "customLegendColors": {},
+      "description": "Number of members in each consumer group",
+      "fillSpans": false,
+      "id": "w-consumer-group-members",
+      "isLogScale": false,
+      "isStacked": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "kafka.consumer_group.members--int64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "kafka.consumer_group.members",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "max",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "env-filter",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{deployment.environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "kafka.consumer_group--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "kafka.consumer_group",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{kafka.consumer_group}}",
+              "limit": 20,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "max",
+              "spaceAggregation": "max",
+              "stepInterval": 60,
+              "timeAggregation": "max"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "q-consumer-group-members",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Consumer Group Members (top 20)",
+      "yAxisUnit": "none"
+    }
+  ],
+  "uuid": "kafka-server-monitoring-otlp-v1"
+}


### PR DESCRIPTION
/claim #6026

Adds Kafka Server Monitoring dashboard using OpenTelemetry kafkametricsreceiver. 18 panels: broker overview, topic metrics, partition health (offsets, ISR, leader election), consumer group lag. Resolves SigNoz/signoz#6026