### PR TITLE
feat(dashboard): Add cert-manager Monitoring dashboard

### DIFF
--- a/cert-manager/README.md
+++ b/cert-manager/README.md
@@ -1,0 +1,62 @@
+# cert-manager Monitoring Dashboard
+
+Comprehensive monitoring for cert-manager using native Prometheus metrics.
+
+## Sections
+
+| # | Section | Covers |
+|---|---------|--------|
+| 1 | General Overview | Ready vs not-ready certificates, expiry countdown, expiring soon count |
+| 2 | Certificate Issuance | Request status by issuer, p95 issuance duration, renewal errors |
+| 3 | ACME & Challenges | ACME client request rate, ACME errors by status code |
+| 4 | Resource Usage | cert-manager CPU and memory per pod |
+| 5 | Controller Health | Sync error rate per controller, work queue depth |
+
+## Setup
+
+### Enable Prometheus Metrics
+
+cert-manager exposes Prometheus metrics on port 9402 by default. Configure your OTel collector:
+
+```yaml
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: 'cert-manager'
+          kubernetes_sd_configs:
+            - role: pod
+              namespaces:
+                names: ['cert-manager']
+          relabel_configs:
+            - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+              regex: cert-manager
+              action: keep
+            - source_labels: [__address__]
+              action: replace
+              regex: (.+)(?::d+)?
+              replacement: ${1}:9402
+              target_label: __address__
+```
+
+## Dashboard Variables
+
+| Variable | Description |
+|----------|-------------|
+| `namespace` | Kubernetes namespace where cert-manager is deployed |
+
+## Key Metrics
+
+| Metric | Description |
+|--------|-------------|
+| `certmanager_certificate_ready_status` | Certificate ready condition (True/False) |
+| `certmanager_certificate_expiration_timestamp_seconds` | Certificate expiry timestamp |
+| `certmanager_certificaterequest_ready_status` | Certificate request ready condition |
+| `certmanager_certificate_issuance_duration_seconds` | Issuance duration histogram |
+| `certmanager_controller_sync_error_count` | Controller sync error count |
+| `certmanager_http_acme_client_request_count` | ACME HTTP request count |
+
+## References
+
+- [cert-manager Prometheus Metrics](https://cert-manager.io/docs/devops-tips/prometheus-metrics/)
+- [Sample Grafana Dashboard](https://grafana.com/grafana/dashboards/11001-cert-manager)

--- a/cert-manager/cert-manager-prometheus-v1.json
+++ b/cert-manager/cert-manager-prometheus-v1.json
@@ -1,0 +1,1485 @@
+{
+  "description": "Comprehensive cert-manager monitoring: certificate readiness, expiry, ACME challenges, issuance latency, renewal errors, and controller health.",
+  "image": "",
+  "layout": [
+    {
+      "h": 1,
+      "i": "19fe1fd8-52f4-401b-a34d-0d0352c6020c",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 6,
+      "i": "2f2e70f2-7e62-4445-8817-f253aa02655d",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 1
+    },
+    {
+      "h": 6,
+      "i": "d51c3e3a-1440-4c9c-95e7-1196505fabd3",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 1
+    },
+    {
+      "h": 6,
+      "i": "98132f91-958c-42d7-a69f-8390ec337725",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 7
+    },
+    {
+      "h": 6,
+      "i": "ad2c2080-888b-4479-89e9-a6694929fa7f",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 7
+    },
+    {
+      "h": 1,
+      "i": "c58aea07-ac49-44b7-b3d9-2938c08a092f",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 13
+    },
+    {
+      "h": 6,
+      "i": "5f9df55b-a479-41a1-a2ea-08e0f3af1e20",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 14
+    },
+    {
+      "h": 6,
+      "i": "92774e72-5dd6-47ad-9226-8ac0f551e80b",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 14
+    },
+    {
+      "h": 6,
+      "i": "e4188362-6719-49e7-8df5-e5c1ac8d02ba",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 20
+    },
+    {
+      "h": 6,
+      "i": "0ac812b8-0fb6-4d6e-ae9d-c856ae3c11f6",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 20
+    },
+    {
+      "h": 1,
+      "i": "a6a70cc0-514a-4499-96d9-cc397308c9c9",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 26
+    },
+    {
+      "h": 6,
+      "i": "2104f9bc-fc8c-43ea-9e5b-16991d9aed2f",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 27
+    },
+    {
+      "h": 6,
+      "i": "14687ebf-f863-4e06-99ed-7106b82f84de",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 27
+    },
+    {
+      "h": 1,
+      "i": "ded52c83-6b5f-4175-a26f-882dc7bc582d",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 33
+    },
+    {
+      "h": 6,
+      "i": "00a6c56f-9ee9-4379-acee-7909673fca31",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 34
+    },
+    {
+      "h": 6,
+      "i": "ee27059c-af61-4262-ac64-7089939b9f60",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 34
+    },
+    {
+      "h": 1,
+      "i": "82a163cc-5c43-48df-94e3-7e2159b4a3d8",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 40
+    },
+    {
+      "h": 6,
+      "i": "f435b504-d2d0-4cfa-806d-3d91c9e6cc54",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 41
+    },
+    {
+      "h": 6,
+      "i": "86fd4d47-de6e-483f-ae68-3f43be04de94",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 41
+    }
+  ],
+  "panelMap": {
+    "19fe1fd8-52f4-401b-a34d-0d0352c6020c": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "2f2e70f2-7e62-4445-8817-f253aa02655d",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 1
+        },
+        {
+          "h": 6,
+          "i": "d51c3e3a-1440-4c9c-95e7-1196505fabd3",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 1
+        },
+        {
+          "h": 6,
+          "i": "98132f91-958c-42d7-a69f-8390ec337725",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 7
+        },
+        {
+          "h": 6,
+          "i": "ad2c2080-888b-4479-89e9-a6694929fa7f",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 7
+        }
+      ]
+    },
+    "c58aea07-ac49-44b7-b3d9-2938c08a092f": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "5f9df55b-a479-41a1-a2ea-08e0f3af1e20",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 14
+        },
+        {
+          "h": 6,
+          "i": "92774e72-5dd6-47ad-9226-8ac0f551e80b",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 14
+        },
+        {
+          "h": 6,
+          "i": "e4188362-6719-49e7-8df5-e5c1ac8d02ba",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 20
+        },
+        {
+          "h": 6,
+          "i": "0ac812b8-0fb6-4d6e-ae9d-c856ae3c11f6",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 20
+        }
+      ]
+    },
+    "a6a70cc0-514a-4499-96d9-cc397308c9c9": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "2104f9bc-fc8c-43ea-9e5b-16991d9aed2f",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 27
+        },
+        {
+          "h": 6,
+          "i": "14687ebf-f863-4e06-99ed-7106b82f84de",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 27
+        }
+      ]
+    },
+    "ded52c83-6b5f-4175-a26f-882dc7bc582d": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "00a6c56f-9ee9-4379-acee-7909673fca31",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 34
+        },
+        {
+          "h": 6,
+          "i": "ee27059c-af61-4262-ac64-7089939b9f60",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 34
+        }
+      ]
+    },
+    "82a163cc-5c43-48df-94e3-7e2159b4a3d8": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "f435b504-d2d0-4cfa-806d-3d91c9e6cc54",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 41
+        },
+        {
+          "h": 6,
+          "i": "86fd4d47-de6e-483f-ae68-3f43be04de94",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 41
+        }
+      ]
+    }
+  },
+  "tags": [
+    "cert-manager",
+    "tls",
+    "certificates",
+    "kubernetes",
+    "prometheus"
+  ],
+  "title": "cert-manager Monitoring Dashboard",
+  "uploadedGrafana": false,
+  "variables": {
+    "3428e0c2-d28e-4c43-aa3c-1ece8ed43cb8": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Kubernetes namespace where cert-manager is deployed",
+      "id": "3428e0c2-d28e-4c43-aa3c-1ece8ed43cb8",
+      "key": "3428e0c2-d28e-4c43-aa3c-1ece8ed43cb8",
+      "modificationUUID": "8fd3e1c8-3cbb-4bc4-a829-4f9bd2a88bbf",
+      "multiSelect": true,
+      "name": "namespace",
+      "order": 0,
+      "queryValue": "",
+      "selectedValue": "",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": ".*",
+      "type": "TEXTBOX"
+    }
+  },
+  "version": "v5",
+  "widgets": [
+    {
+      "description": "",
+      "id": "19fe1fd8-52f4-401b-a34d-0d0352c6020c",
+      "panelTypes": "row",
+      "title": "General Overview"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Number of certificates in Ready state",
+      "fillSpans": false,
+      "id": "2f2e70f2-7e62-4445-8817-f253aa02655d",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Ready",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": null,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c0060c3a-53b5-4f5d-a50c-04f639298bb6",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Ready",
+            "name": "A",
+            "query": "sum(certmanager_certificate_ready_status{condition=\"True\",namespace=~\"$namespace\"})"
+          }
+        ],
+        "queryType": "promql",
+        "unit": "none"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Ready Certificates",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Certificates expiring within 30 days",
+      "fillSpans": false,
+      "id": "d51c3e3a-1440-4c9c-95e7-1196505fabd3",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Expiring Soon",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": null,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "77866c2f-24d8-47b1-b630-d7a0ab08b5a4",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Expiring Soon",
+            "name": "A",
+            "query": "count(certmanager_certificate_expiration_timestamp_seconds{namespace=~\"$namespace\"} - time() < 30*24*3600)"
+          }
+        ],
+        "queryType": "promql",
+        "unit": "none"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Expiring Soon (< 30 days)",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Certificates NOT in Ready state",
+      "fillSpans": false,
+      "id": "98132f91-958c-42d7-a69f-8390ec337725",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Not Ready",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": null,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "5d1d7c05-9019-473c-a6b0-b2941119ca22",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Not Ready",
+            "name": "A",
+            "query": "sum(certmanager_certificate_ready_status{condition=\"False\",namespace=~\"$namespace\"})"
+          }
+        ],
+        "queryType": "promql",
+        "unit": "none"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Not Ready Certificates",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Time remaining until certificate expiration (days)",
+      "fillSpans": false,
+      "id": "ad2c2080-888b-4479-89e9-a6694929fa7f",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": null,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "df8657d1-4f05-450f-9132-92f2ea345a67",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{name}}",
+            "name": "A",
+            "query": "(certmanager_certificate_expiration_timestamp_seconds{namespace=~\"$namespace\"} - time()) / 86400"
+          }
+        ],
+        "queryType": "promql",
+        "unit": "none"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Certificate Expiry Timeline",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "id": "c58aea07-ac49-44b7-b3d9-2938c08a092f",
+      "panelTypes": "row",
+      "title": "Certificate Issuance"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Certificate requests in Ready condition",
+      "fillSpans": false,
+      "id": "5f9df55b-a479-41a1-a2ea-08e0f3af1e20",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{issuer_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": null,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "201d51d3-9764-4bd5-b17f-e18fffd704cb",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{issuer_name}}",
+            "name": "A",
+            "query": "sum(certmanager_certificaterequest_ready_status{condition=\"True\",namespace=~\"$namespace\"}) by (issuer_name)"
+          }
+        ],
+        "queryType": "promql",
+        "unit": "none"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Certificate Requests Ready",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Failed certificate requests by issuer",
+      "fillSpans": false,
+      "id": "92774e72-5dd6-47ad-9226-8ac0f551e80b",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{issuer_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": null,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b4059ff4-e1a8-4943-b4a0-4209a7609574",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{issuer_name}}",
+            "name": "A",
+            "query": "sum(certmanager_certificaterequest_ready_status{condition=\"False\",namespace=~\"$namespace\"}) by (issuer_name)"
+          }
+        ],
+        "queryType": "promql",
+        "unit": "none"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Certificate Requests Failed",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "95th percentile time to issue certificates",
+      "fillSpans": false,
+      "id": "e4188362-6719-49e7-8df5-e5c1ac8d02ba",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{issuer_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": null,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "806d0914-d493-4b97-9454-e6a53abcf2f9",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{issuer_name}}",
+            "name": "A",
+            "query": "histogram_quantile(0.95, sum(rate(certmanager_certificate_issuance_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])) by (le, issuer_name))"
+          }
+        ],
+        "queryType": "promql",
+        "unit": "s"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Issuance Duration (p95)",
+      "yAxisUnit": "s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Rate of certificate renewal errors",
+      "fillSpans": false,
+      "id": "0ac812b8-0fb6-4d6e-ae9d-c856ae3c11f6",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{error}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": null,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "988fb070-ad64-4239-8736-33d5fd033c9c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{error}}",
+            "name": "A",
+            "query": "sum(rate(certmanager_controller_sync_error_count{controller=\"certificate-trigger\",namespace=~\"$namespace\"}[5m])) by (error)"
+          }
+        ],
+        "queryType": "promql",
+        "unit": "none"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Renewal Errors",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "id": "a6a70cc0-514a-4499-96d9-cc397308c9c9",
+      "panelTypes": "row",
+      "title": "ACME & Challenges"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Rate of ACME client HTTP requests",
+      "fillSpans": false,
+      "id": "2104f9bc-fc8c-43ea-9e5b-16991d9aed2f",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{method}} {{status}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": null,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "e0158620-e138-408d-a5cc-ef499faf5ddc",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{method}} {{status}}",
+            "name": "A",
+            "query": "sum(rate(certmanager_http_acme_client_request_count{namespace=~\"$namespace\"}[1m])) by (method, status)"
+          }
+        ],
+        "queryType": "promql",
+        "unit": "reqps"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "ACME Client Requests",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "ACME HTTP requests returning non-2xx",
+      "fillSpans": false,
+      "id": "14687ebf-f863-4e06-99ed-7106b82f84de",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{status}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": null,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "19a1849d-f617-49ef-a3bb-90f6dd89dd2d",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{status}}",
+            "name": "A",
+            "query": "sum(rate(certmanager_http_acme_client_request_count{namespace=~\"$namespace\",status!~\"2..\"}[1m])) by (status)"
+          }
+        ],
+        "queryType": "promql",
+        "unit": "reqps"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "ACME Request Errors",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "ded52c83-6b5f-4175-a26f-882dc7bc582d",
+      "panelTypes": "row",
+      "title": "Resource Usage"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "CPU usage by cert-manager pods",
+      "fillSpans": false,
+      "id": "00a6c56f-9ee9-4379-acee-7909673fca31",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{pod}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": null,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9f86ba7b-fd41-4a60-8197-6ff22eca3ed5",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "sum(rate(process_cpu_seconds_total{job=~\"cert-manager.*\",namespace=~\"$namespace\"}[1m])) by (pod)"
+          }
+        ],
+        "queryType": "promql",
+        "unit": "s"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "cert-manager CPU Usage",
+      "yAxisUnit": "s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Memory (RSS) used by cert-manager pods",
+      "fillSpans": false,
+      "id": "ee27059c-af61-4262-ac64-7089939b9f60",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{pod}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": null,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a9325129-38b0-4008-a0ce-70df13a1c156",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "sum(process_resident_memory_bytes{job=~\"cert-manager.*\",namespace=~\"$namespace\"}) by (pod)"
+          }
+        ],
+        "queryType": "promql",
+        "unit": "bytes"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "cert-manager Memory Usage",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "",
+      "id": "82a163cc-5c43-48df-94e3-7e2159b4a3d8",
+      "panelTypes": "row",
+      "title": "Controller Health"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Error rate per controller",
+      "fillSpans": false,
+      "id": "f435b504-d2d0-4cfa-806d-3d91c9e6cc54",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{controller}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": null,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8cc7452c-c084-4e6b-a4e1-8ee931f60684",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{controller}}",
+            "name": "A",
+            "query": "sum(rate(certmanager_controller_sync_error_count{namespace=~\"$namespace\"}[5m])) by (controller)"
+          }
+        ],
+        "queryType": "promql",
+        "unit": "none"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Controller Sync Errors",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Work queue depth per controller",
+      "fillSpans": false,
+      "id": "86fd4d47-de6e-483f-ae68-3f43be04de94",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{controller}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": null,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "572590f3-153d-495b-b615-df678357caf1",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{controller}}",
+            "name": "A",
+            "query": "sum(certmanager_controller_queue_depth{namespace=~\"$namespace\"}) by (controller)"
+          }
+        ],
+        "queryType": "promql",
+        "unit": "none"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Queue Depth",
+      "yAxisUnit": "none"
+    }
+  ],
+  "uuid": "208ad47e-925e-4075-b226-0127486c4000"
+}


### PR DESCRIPTION
/claim #6023

14-panel cert-manager monitoring using Prometheus metrics. Sections: General Overview (ready/not-ready certs, expiry countdown, expiring soon), Certificate Issuance (requests by issuer, p95 duration, renewal errors), ACME & Challenges, Resource Usage (CPU/memory per pod), Controller Health (sync errors, queue depth). Resolves SigNoz/signoz#6023