### PR TITLE
feat(gcp): add GCP Cloud Storage (GCS) monitoring dashboard (OTLP v1)

### DIFF
--- a/gcp/cloud-sql/README.md
+++ b/gcp/cloud-sql/README.md
@@ -1,0 +1,114 @@
+# GCP Cloud SQL Monitoring Dashboard
+
+This dashboard provides comprehensive monitoring for Google Cloud Platform Cloud SQL instances. It covers both PostgreSQL and MySQL engine variants using OpenTelemetry metrics exported from GCP.
+
+## Overview
+
+The dashboard includes 5 sections and 15 metric panels:
+
+| Section | Panels | Description |
+|---------|--------|-------------|
+| Overview | CPU, Memory, Disk Utilization, Disk Bytes | Instance-level resource consumption |
+| Network | Bytes Received, Bytes Sent, Active Connections | Network throughput and connection monitoring |
+| PostgreSQL Metrics | Backends, Blocks Read, Cache Hits, Transactions | PostgreSQL-specific performance indicators |
+| MySQL Metrics | Queries/sec, InnoDB Pages, Replication Lag | MySQL-specific performance indicators |
+| Replication | Replica Byte Lag | Cross-engine replication health |
+
+## Prerequisites
+
+### 1. Enable GCP Cloud SQL Export
+
+Export Cloud SQL metrics to Google Cloud Monitoring (formerly Stackdriver), then forward them to your OpenTelemetry collector using the [GoogleCloud exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlecloudexporter) or the [GCP receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/googlecloudmonitoringreceiver).
+
+### 2. OTel Collector Configuration
+
+Configure the GCP receiver in your `otel-collector-config.yaml`:
+
+```yaml
+receivers:
+  googlecloudmonitoring:
+    project_id: your-gcp-project-id
+    collection_interval: 60s
+    metric_prefixes:
+      - "cloudsql.googleapis.com"
+
+processors:
+  resourcedetection:
+    detectors: [gcp]
+  batch:
+    timeout: 30s
+
+exporters:
+  otlp:
+    endpoint: "your-signoz-host:4317"
+
+service:
+  pipelines:
+    metrics:
+      receivers: [googlecloudmonitoring]
+      processors: [resourcedetection, batch]
+      exporters: [otlp]
+```
+
+## Variables
+
+| Variable | Description |
+|----------|-------------|
+| `deployment.environment` | Filter by environment (production, staging, etc.) |
+| `project_id` | GCP Project ID |
+| `database_id` | Cloud SQL instance identifier (format: `project:region:instance`) |
+
+## Metrics Covered
+
+### Overview Metrics
+
+| Metric | Description |
+|--------|-------------|
+| `cloudsql.googleapis.com/database/cpu/utilization` | CPU utilization fraction (0.0–1.0) |
+| `cloudsql.googleapis.com/database/memory/utilization` | Memory utilization fraction (0.0–1.0) |
+| `cloudsql.googleapis.com/database/disk/utilization` | Disk quota utilization fraction (0.0–1.0) |
+| `cloudsql.googleapis.com/database/disk/bytes_used` | Disk space used in bytes |
+
+### Network Metrics
+
+| Metric | Description |
+|--------|-------------|
+| `cloudsql.googleapis.com/database/network/received_bytes_count` | Delta bytes received per interval |
+| `cloudsql.googleapis.com/database/network/sent_bytes_count` | Delta bytes sent per interval |
+| `cloudsql.googleapis.com/database/network/connections` | Number of active connections |
+
+### PostgreSQL-Specific Metrics
+
+| Metric | Description |
+|--------|-------------|
+| `cloudsql.googleapis.com/database/postgresql/num_backends` | Active backend connections |
+| `cloudsql.googleapis.com/database/postgresql/blks_read_count` | Disk blocks read (delta) |
+| `cloudsql.googleapis.com/database/postgresql/blks_hit_count` | Buffer cache hits (delta) |
+| `cloudsql.googleapis.com/database/postgresql/transaction_count` | Committed transactions (delta) |
+
+### MySQL-Specific Metrics
+
+| Metric | Description |
+|--------|-------------|
+| `cloudsql.googleapis.com/database/mysql/queries` | Statement executions (delta) |
+| `cloudsql.googleapis.com/database/mysql/innodb_pages_read` | InnoDB pages read (delta) |
+| `cloudsql.googleapis.com/database/mysql/replication/seconds_behind_master` | Seconds replica is behind primary |
+
+### Replication
+
+| Metric | Description |
+|--------|-------------|
+| `cloudsql.googleapis.com/database/replication/replica_byte_lag` | Byte lag of read replica behind primary |
+
+## Import Instructions
+
+1. Open SigNoz UI and navigate to **Dashboards**
+2. Click **New Dashboard** → **Import JSON**
+3. Upload `gcp-cloud-sql-otlp-v1.json`
+4. Set the `project_id` and `database_id` variables to match your GCP environment
+
+## Related Dashboards
+
+- [GCP Compute Engine](../compute-engine/) — VM instance metrics
+- [PostgreSQL](../../postgresql/) — Self-hosted PostgreSQL metrics
+- [MySQL](../../mysql/) — Self-hosted MySQL metrics (if available)

--- a/gcp/cloud-sql/gcp-cloud-sql-otlp-v1.json
+++ b/gcp/cloud-sql/gcp-cloud-sql-otlp-v1.json
@@ -1,0 +1,2150 @@
+{
+  "description": "Comprehensive monitoring dashboard for GCP Cloud SQL instances. Covers CPU, memory, disk utilization, network throughput, active connections, and database-engine-specific metrics for both PostgreSQL and MySQL.",
+  "image": "",
+  "layout": [
+    {
+      "h": 1,
+      "i": "9a1b5d58-618b-4dab-a383-e1e05dcab97c",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 6,
+      "i": "771f9221-1e82-4ddb-b831-eae11ec0fcbd",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 0,
+      "y": 1
+    },
+    {
+      "h": 6,
+      "i": "bbbac9e3-0c2b-4593-84ab-444811f5c85f",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 3,
+      "y": 1
+    },
+    {
+      "h": 6,
+      "i": "2756c334-eadb-4d3b-9ab5-b48c2e6e704e",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 6,
+      "y": 1
+    },
+    {
+      "h": 6,
+      "i": "479e72e1-1fc3-411a-93ce-f8594e095093",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 9,
+      "y": 1
+    },
+    {
+      "h": 1,
+      "i": "587595f0-fdd2-4047-9348-d6da5255f146",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 7
+    },
+    {
+      "h": 6,
+      "i": "c4154364-f82c-462b-bf3a-56cb6b0143e3",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 8
+    },
+    {
+      "h": 6,
+      "i": "043a8f7f-58d5-492c-8e26-1a2d39e02093",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 8
+    },
+    {
+      "h": 6,
+      "i": "734e89e4-1e81-4724-927c-8641f31b8574",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 8
+    },
+    {
+      "h": 1,
+      "i": "396c8f55-b0da-4176-9069-440fe9f8d7ef",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 14
+    },
+    {
+      "h": 6,
+      "i": "8c564ca0-a427-42ca-9c41-8e6d252f1133",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 0,
+      "y": 15
+    },
+    {
+      "h": 6,
+      "i": "885f2ca2-23ea-40ce-93c9-38dfad76978a",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 3,
+      "y": 15
+    },
+    {
+      "h": 6,
+      "i": "ed61ed85-a841-41c5-8a89-8b76a42f3bc8",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 6,
+      "y": 15
+    },
+    {
+      "h": 6,
+      "i": "d74eb6cc-6837-4a06-a080-8c32d7ba158a",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 9,
+      "y": 15
+    },
+    {
+      "h": 1,
+      "i": "343ec9e6-8804-4cdb-9b19-f04a4d9d5aae",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 21
+    },
+    {
+      "h": 6,
+      "i": "3981c7b6-a066-42bb-b3c1-23e201864956",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 22
+    },
+    {
+      "h": 6,
+      "i": "8905474b-76e9-4914-8588-cfe9e9e3c261",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 22
+    },
+    {
+      "h": 6,
+      "i": "b7cb2962-bfbe-4b4e-b016-8a91ab467f96",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 22
+    },
+    {
+      "h": 1,
+      "i": "bf5572ca-5549-4868-a655-773babc559ff",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 28
+    },
+    {
+      "h": 6,
+      "i": "f02b5cfc-b423-4848-ad92-1e879d0b51ed",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 29
+    }
+  ],
+  "panelMap": {},
+  "tags": [
+    "gcp",
+    "cloud-sql",
+    "postgresql",
+    "mysql",
+    "database",
+    "gcp-cloud-sql"
+  ],
+  "title": "GCP Cloud SQL Monitoring",
+  "uploadedGrafana": false,
+  "variables": {
+    "2ddefb36-32ac-4574-97b3-e4e314b3c7c8": {
+      "customValue": "",
+      "description": "The deployment environment for the service.",
+      "id": "2ddefb36-32ac-4574-97b3-e4e314b3c7c8",
+      "key": "2ddefb36-32ac-4574-97b3-e4e314b3c7c8",
+      "modificationUUID": "89fd0edf-a3b0-4424-b654-f758753cc224",
+      "multiSelect": false,
+      "name": "deployment.environment",
+      "order": 0,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'deployment.environment'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name like '%cloudsql%'",
+      "showALLOption": false,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "645d5726-9aca-4a45-9ddf-fee984bd9b77": {
+      "customValue": "",
+      "description": "GCP Project ID",
+      "id": "645d5726-9aca-4a45-9ddf-fee984bd9b77",
+      "modificationUUID": "74b90f64-449f-4b2e-89d2-db9d1d9ea648",
+      "multiSelect": false,
+      "name": "project_id",
+      "order": 1,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'project_id'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name like '%cloudsql%'",
+      "showALLOption": false,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "0f8ba495-b9f3-4a7c-9f64-bbf43881b1ea": {
+      "customValue": "",
+      "description": "Cloud SQL Database Instance ID",
+      "id": "0f8ba495-b9f3-4a7c-9f64-bbf43881b1ea",
+      "modificationUUID": "d59056b0-cc02-426e-9a2a-ed20591fa503",
+      "multiSelect": false,
+      "name": "database_id",
+      "order": 2,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'database_id'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name like '%cloudsql%'",
+      "showALLOption": false,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "version": "v3",
+  "widgets": [
+    {
+      "description": "High-level Cloud SQL instance metrics",
+      "id": "9a1b5d58-618b-4dab-a383-e1e05dcab97c",
+      "panelTypes": "row",
+      "title": "Overview"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "The fraction of the reserved CPU that is currently in use on the database instance.",
+      "fillSpans": false,
+      "id": "771f9221-1e82-4ddb-b831-eae11ec0fcbd",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cloudsql.googleapis.com/database/cpu/utilization--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cloudsql.googleapis.com/database/cpu/utilization",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d51104d1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "7082e9f2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "97fe4d58",
+                    "key": {
+                      "dataType": "string",
+                      "id": "database_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "database_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.database_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "database_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "database_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{database_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "7e454e97-079b-4601-aaba-fa2969891f16",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "thresholds": [],
+      "timePreference": "GLOBAL_TIME",
+      "title": "CPU Utilization",
+      "yAxisUnit": "percentunit"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "The fraction of the memory quota that is currently in use on the database instance.",
+      "fillSpans": false,
+      "id": "bbbac9e3-0c2b-4593-84ab-444811f5c85f",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cloudsql.googleapis.com/database/memory/utilization--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cloudsql.googleapis.com/database/memory/utilization",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d51104d1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "7082e9f2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "97fe4d58",
+                    "key": {
+                      "dataType": "string",
+                      "id": "database_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "database_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.database_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "database_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "database_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{database_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d2925e56-9535-4df6-adab-42ecfc7522fe",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "thresholds": [],
+      "timePreference": "GLOBAL_TIME",
+      "title": "Memory Utilization",
+      "yAxisUnit": "percentunit"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "The fraction of the disk quota that is currently in use on the database instance.",
+      "fillSpans": false,
+      "id": "2756c334-eadb-4d3b-9ab5-b48c2e6e704e",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cloudsql.googleapis.com/database/disk/utilization--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cloudsql.googleapis.com/database/disk/utilization",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d51104d1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "7082e9f2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "97fe4d58",
+                    "key": {
+                      "dataType": "string",
+                      "id": "database_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "database_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.database_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "database_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "database_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{database_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9a672b76-4230-46e6-8a53-3543594f2b89",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "thresholds": [],
+      "timePreference": "GLOBAL_TIME",
+      "title": "Disk Utilization",
+      "yAxisUnit": "percentunit"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Data utilization in bytes.",
+      "fillSpans": false,
+      "id": "479e72e1-1fc3-411a-93ce-f8594e095093",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "cloudsql.googleapis.com/database/disk/bytes_used--int64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cloudsql.googleapis.com/database/disk/bytes_used",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d51104d1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "7082e9f2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "97fe4d58",
+                    "key": {
+                      "dataType": "string",
+                      "id": "database_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "database_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.database_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "database_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "database_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{database_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "fbd3874a-d677-4908-8e62-12f05640e622",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "thresholds": [],
+      "timePreference": "GLOBAL_TIME",
+      "title": "Disk Used Bytes",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "Network throughput metrics for Cloud SQL",
+      "id": "587595f0-fdd2-4047-9348-d6da5255f146",
+      "panelTypes": "row",
+      "title": "Network"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Delta count of bytes received through the network on the database server.",
+      "fillSpans": false,
+      "id": "c4154364-f82c-462b-bf3a-56cb6b0143e3",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "cloudsql.googleapis.com/database/network/received_bytes_count--int64--Delta--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cloudsql.googleapis.com/database/network/received_bytes_count",
+                "type": "Delta"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d51104d1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "7082e9f2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "97fe4d58",
+                    "key": {
+                      "dataType": "string",
+                      "id": "database_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "database_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.database_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "database_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "database_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{database_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f09cd28a-a1c1-4678-a97d-aaff79766ad2",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "thresholds": [],
+      "timePreference": "GLOBAL_TIME",
+      "title": "Network Bytes Received",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Delta count of bytes sent through the network on the database server.",
+      "fillSpans": false,
+      "id": "043a8f7f-58d5-492c-8e26-1a2d39e02093",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "cloudsql.googleapis.com/database/network/sent_bytes_count--int64--Delta--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cloudsql.googleapis.com/database/network/sent_bytes_count",
+                "type": "Delta"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d51104d1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "7082e9f2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "97fe4d58",
+                    "key": {
+                      "dataType": "string",
+                      "id": "database_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "database_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.database_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "database_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "database_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{database_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "df5fe1cd-6816-47fb-9bfd-1199283db109",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "thresholds": [],
+      "timePreference": "GLOBAL_TIME",
+      "title": "Network Bytes Sent",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of connections to databases on the Cloud SQL instance.",
+      "fillSpans": false,
+      "id": "734e89e4-1e81-4724-927c-8641f31b8574",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "cloudsql.googleapis.com/database/network/connections--int64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cloudsql.googleapis.com/database/network/connections",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d51104d1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "7082e9f2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "97fe4d58",
+                    "key": {
+                      "dataType": "string",
+                      "id": "database_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "database_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.database_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "database_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "database_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{database_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ee89dbe1-03a7-4e12-a0ae-2cc9e1a06705",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "thresholds": [],
+      "timePreference": "GLOBAL_TIME",
+      "title": "Active Connections",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "Metrics specific to Cloud SQL PostgreSQL instances",
+      "id": "396c8f55-b0da-4176-9069-440fe9f8d7ef",
+      "panelTypes": "row",
+      "title": "PostgreSQL Metrics"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of connections that are active in backends of the PostgreSQL instance.",
+      "fillSpans": false,
+      "id": "8c564ca0-a427-42ca-9c41-8e6d252f1133",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "cloudsql.googleapis.com/database/postgresql/num_backends--int64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cloudsql.googleapis.com/database/postgresql/num_backends",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d51104d1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "7082e9f2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "97fe4d58",
+                    "key": {
+                      "dataType": "string",
+                      "id": "database_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "database_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.database_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "database_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "database_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{database_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "40af70a2-aa8b-4f53-91c6-02eeeff58818",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "thresholds": [],
+      "timePreference": "GLOBAL_TIME",
+      "title": "PostgreSQL Active Backends",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Delta count of disk blocks read per second for this database.",
+      "fillSpans": false,
+      "id": "885f2ca2-23ea-40ce-93c9-38dfad76978a",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "cloudsql.googleapis.com/database/postgresql/blks_read_count--int64--Delta--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cloudsql.googleapis.com/database/postgresql/blks_read_count",
+                "type": "Delta"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d51104d1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "7082e9f2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "97fe4d58",
+                    "key": {
+                      "dataType": "string",
+                      "id": "database_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "database_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.database_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "database_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "database_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{database_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a89f93f5-e637-43bf-8db8-83ccba62628b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "thresholds": [],
+      "timePreference": "GLOBAL_TIME",
+      "title": "PostgreSQL Disk Blocks Read",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Delta count of times disk blocks were found already in the buffer cache for this database.",
+      "fillSpans": false,
+      "id": "ed61ed85-a841-41c5-8a89-8b76a42f3bc8",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "cloudsql.googleapis.com/database/postgresql/blks_hit_count--int64--Delta--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cloudsql.googleapis.com/database/postgresql/blks_hit_count",
+                "type": "Delta"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d51104d1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "7082e9f2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "97fe4d58",
+                    "key": {
+                      "dataType": "string",
+                      "id": "database_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "database_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.database_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "database_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "database_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{database_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "5a91c109-b0d2-4389-aacc-1be8cb0438d2",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "thresholds": [],
+      "timePreference": "GLOBAL_TIME",
+      "title": "PostgreSQL Buffer Cache Hits",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Delta count of transactions in this database that have been committed.",
+      "fillSpans": false,
+      "id": "d74eb6cc-6837-4a06-a080-8c32d7ba158a",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "cloudsql.googleapis.com/database/postgresql/transaction_count--int64--Delta--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cloudsql.googleapis.com/database/postgresql/transaction_count",
+                "type": "Delta"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d51104d1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "7082e9f2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "97fe4d58",
+                    "key": {
+                      "dataType": "string",
+                      "id": "database_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "database_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.database_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "database_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "database_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{database_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6edfaa65-ad64-4bd7-8b35-2a6a0260c025",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "thresholds": [],
+      "timePreference": "GLOBAL_TIME",
+      "title": "PostgreSQL Transactions Committed",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "Metrics specific to Cloud SQL MySQL instances",
+      "id": "343ec9e6-8804-4cdb-9b19-f04a4d9d5aae",
+      "panelTypes": "row",
+      "title": "MySQL Metrics"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Delta count of statements executed by the MySQL server.",
+      "fillSpans": false,
+      "id": "3981c7b6-a066-42bb-b3c1-23e201864956",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "cloudsql.googleapis.com/database/mysql/queries--int64--Delta--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cloudsql.googleapis.com/database/mysql/queries",
+                "type": "Delta"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d51104d1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "7082e9f2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "97fe4d58",
+                    "key": {
+                      "dataType": "string",
+                      "id": "database_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "database_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.database_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "database_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "database_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{database_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "5794346e-85b6-494b-a05d-60104b2198f7",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "thresholds": [],
+      "timePreference": "GLOBAL_TIME",
+      "title": "MySQL Queries per Second",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Delta count of InnoDB pages read.",
+      "fillSpans": false,
+      "id": "8905474b-76e9-4914-8588-cfe9e9e3c261",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "cloudsql.googleapis.com/database/mysql/innodb_pages_read--int64--Delta--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cloudsql.googleapis.com/database/mysql/innodb_pages_read",
+                "type": "Delta"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d51104d1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "7082e9f2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "97fe4d58",
+                    "key": {
+                      "dataType": "string",
+                      "id": "database_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "database_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.database_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "database_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "database_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{database_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "bd530155-59a6-4c7e-8ea4-46c089f1850b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "thresholds": [],
+      "timePreference": "GLOBAL_TIME",
+      "title": "MySQL InnoDB Pages Read",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of seconds the read replica is behind its primary.",
+      "fillSpans": false,
+      "id": "b7cb2962-bfbe-4b4e-b016-8a91ab467f96",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "cloudsql.googleapis.com/database/mysql/replication/seconds_behind_master--int64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cloudsql.googleapis.com/database/mysql/replication/seconds_behind_master",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d51104d1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "7082e9f2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "97fe4d58",
+                    "key": {
+                      "dataType": "string",
+                      "id": "database_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "database_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.database_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "database_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "database_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{database_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "889b7b29-44e1-47e1-853b-6af68d25fbc0",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "thresholds": [],
+      "timePreference": "GLOBAL_TIME",
+      "title": "MySQL Replication Lag",
+      "yAxisUnit": "s"
+    },
+    {
+      "description": "Replica lag and replication health",
+      "id": "bf5572ca-5549-4868-a655-773babc559ff",
+      "panelTypes": "row",
+      "title": "Replication"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Approximation of the number of bytes the read replica is behind its primary.",
+      "fillSpans": false,
+      "id": "f02b5cfc-b423-4848-ad92-1e879d0b51ed",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "cloudsql.googleapis.com/database/replication/replica_byte_lag--int64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cloudsql.googleapis.com/database/replication/replica_byte_lag",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d51104d1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "7082e9f2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "97fe4d58",
+                    "key": {
+                      "dataType": "string",
+                      "id": "database_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "database_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.database_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "database_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "database_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{database_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "13a7988e-a29b-4cea-8a38-a766a670e1d6",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "thresholds": [],
+      "timePreference": "GLOBAL_TIME",
+      "title": "Replica Lag",
+      "yAxisUnit": "bytes"
+    }
+  ]
+}

--- a/gcp/cloud-storage/README.md
+++ b/gcp/cloud-storage/README.md
@@ -1,0 +1,62 @@
+# GCP Cloud Storage Monitoring Dashboard
+
+This dashboard monitors Google Cloud Storage (GCS) bucket activity using OpenTelemetry metrics from the GCP monitoring receiver.
+
+## Dashboard Details
+
+**File:** `gcp-cloud-storage-otlp-v1.json`
+**Format:** SigNoz v3 OTLP
+**Panels:** 5 panels across 3 sections
+
+## Sections
+
+| Section | Panels |
+|---------|--------|
+| Storage | Total bytes stored, Object count |
+| Requests | API request count by method/response code |
+| Network | Bytes received, Bytes sent |
+
+## Variables
+
+| Variable | Description |
+|----------|-------------|
+| `deployment.environment` | Filter by environment |
+| `project_id` | GCP Project ID |
+| `bucket_name` | GCS Bucket name to monitor |
+
+## Metrics Covered
+
+| Metric | Description |
+|--------|-------------|
+| `storage.googleapis.com/storage/total_bytes` | Total bytes stored in bucket |
+| `storage.googleapis.com/storage/object_count` | Total objects in bucket |
+| `storage.googleapis.com/storage/api/request_count` | API requests (delta) |
+| `storage.googleapis.com/storage/network/received_bytes_count` | Bytes received (delta) |
+| `storage.googleapis.com/storage/network/sent_bytes_count` | Bytes sent (delta) |
+
+## Setup
+
+Configure the GCP monitoring receiver in your OTel collector:
+
+```yaml
+receivers:
+  googlecloudmonitoring:
+    project_id: your-gcp-project-id
+    collection_interval: 60s
+    metric_prefixes:
+      - "storage.googleapis.com"
+
+exporters:
+  otlp:
+    endpoint: "your-signoz-host:4317"
+
+service:
+  pipelines:
+    metrics:
+      receivers: [googlecloudmonitoring]
+      exporters: [otlp]
+```
+
+## Related Issues
+
+- [SigNoz/signoz#6385](https://github.com/SigNoz/signoz/issues/6385) — GCP Cloud Storage Dashboard Request

--- a/gcp/cloud-storage/gcp-cloud-storage-otlp-v1.json
+++ b/gcp/cloud-storage/gcp-cloud-storage-otlp-v1.json
@@ -1,0 +1,783 @@
+{
+  "description": "Monitoring dashboard for Google Cloud Storage (GCS) buckets. Covers storage utilization, object counts, API request rates, and network throughput per bucket.",
+  "image": "",
+  "layout": [
+    {
+      "h": 1,
+      "i": "ee5f5bff-a9ea-456d-9a03-f358e2182397",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 6,
+      "i": "3955bed6-520e-45de-bc73-59ccb3fbece2",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 1
+    },
+    {
+      "h": 6,
+      "i": "7073f2b3-4b84-41b7-ac97-d9e3cf1e6012",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 1
+    },
+    {
+      "h": 1,
+      "i": "fa8ab62d-d57a-4579-9246-7b1c4262441b",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 7
+    },
+    {
+      "h": 6,
+      "i": "38a2ec5f-1e70-443a-a50d-32cbfe0079c3",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 8
+    },
+    {
+      "h": 1,
+      "i": "f064cffd-f585-45d7-ab27-764b702da65d",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 14
+    },
+    {
+      "h": 6,
+      "i": "c5b0dd00-e7cc-4849-8c3e-fb74d61636c2",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 15
+    },
+    {
+      "h": 6,
+      "i": "c17c5918-2df5-43e3-b4c5-9759a1c4456c",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 15
+    }
+  ],
+  "panelMap": {},
+  "tags": [
+    "gcp",
+    "cloud-storage",
+    "gcs",
+    "bucket",
+    "object-storage"
+  ],
+  "title": "GCP Cloud Storage Monitoring",
+  "uploadedGrafana": false,
+  "variables": {
+    "e73f02df-f42b-42a4-957e-46023a907b3f": {
+      "customValue": "",
+      "description": "The deployment environment.",
+      "id": "e73f02df-f42b-42a4-957e-46023a907b3f",
+      "key": "e73f02df-f42b-42a4-957e-46023a907b3f",
+      "modificationUUID": "94723ba1-7400-48c3-bbed-6cdf93bc08e2",
+      "multiSelect": false,
+      "name": "deployment.environment",
+      "order": 0,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'deployment.environment'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name like '%storage%'",
+      "showALLOption": false,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "af1c4fb5-5cc6-429a-b704-2d6c7ae4ca0e": {
+      "customValue": "",
+      "description": "GCP Project ID",
+      "id": "af1c4fb5-5cc6-429a-b704-2d6c7ae4ca0e",
+      "modificationUUID": "18f4c2bf-f4d8-4a50-ad0a-b2140ca96f3a",
+      "multiSelect": false,
+      "name": "project_id",
+      "order": 1,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'project_id'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name like '%storage%'",
+      "showALLOption": false,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "9bab3146-1908-4c16-ab5e-a912e7d9d271": {
+      "customValue": "",
+      "description": "GCS Bucket Name",
+      "id": "9bab3146-1908-4c16-ab5e-a912e7d9d271",
+      "modificationUUID": "4cda58d5-e26f-4abd-913c-9724093d535c",
+      "multiSelect": false,
+      "name": "bucket_name",
+      "order": 2,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'bucket_name'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name like '%storage%'",
+      "showALLOption": false,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "version": "v3",
+  "widgets": [
+    {
+      "description": "Bucket storage utilization metrics",
+      "id": "ee5f5bff-a9ea-456d-9a03-f358e2182397",
+      "panelTypes": "row",
+      "title": "Storage"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total bytes of data stored in the bucket, grouped by storage class.",
+      "fillSpans": false,
+      "id": "3955bed6-520e-45de-bc73-59ccb3fbece2",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "storage.googleapis.com/storage/total_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "storage.googleapis.com/storage/total_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d653d795",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "a0ff047e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "ec27288a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "bucket_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "bucket_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.bucket_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "bucket_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "bucket_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{bucket_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "3edec0c3-d8fe-431f-a9bd-a1f3b4065881",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "thresholds": [],
+      "timePreference": "GLOBAL_TIME",
+      "title": "Total Bytes Stored",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total number of objects in the bucket, grouped by storage class.",
+      "fillSpans": false,
+      "id": "7073f2b3-4b84-41b7-ac97-d9e3cf1e6012",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "storage.googleapis.com/storage/object_count--int64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "storage.googleapis.com/storage/object_count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d653d795",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "a0ff047e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "ec27288a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "bucket_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "bucket_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.bucket_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "bucket_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "bucket_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{bucket_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "e3750002-b88a-4e6d-8895-ed5b33abd8af",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "thresholds": [],
+      "timePreference": "GLOBAL_TIME",
+      "title": "Total Object Count",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "API request metrics per bucket",
+      "id": "fa8ab62d-d57a-4579-9246-7b1c4262441b",
+      "panelTypes": "row",
+      "title": "Requests"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Delta count of API calls on the bucket, grouped by method and response code.",
+      "fillSpans": false,
+      "id": "38a2ec5f-1e70-443a-a50d-32cbfe0079c3",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "storage.googleapis.com/storage/api/request_count--int64--Delta--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "storage.googleapis.com/storage/api/request_count",
+                "type": "Delta"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d653d795",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "a0ff047e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "ec27288a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "bucket_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "bucket_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.bucket_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "bucket_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "bucket_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{bucket_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "3cb755ff-ab51-4cdf-b6e9-5d597d9de9f3",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "thresholds": [],
+      "timePreference": "GLOBAL_TIME",
+      "title": "Request Count",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "Data transfer metrics for the bucket",
+      "id": "f064cffd-f585-45d7-ab27-764b702da65d",
+      "panelTypes": "row",
+      "title": "Network"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Delta bytes of data received, including metadata, by Google Cloud Storage.",
+      "fillSpans": false,
+      "id": "c5b0dd00-e7cc-4849-8c3e-fb74d61636c2",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "storage.googleapis.com/storage/network/received_bytes_count--int64--Delta--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "storage.googleapis.com/storage/network/received_bytes_count",
+                "type": "Delta"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d653d795",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "a0ff047e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "ec27288a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "bucket_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "bucket_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.bucket_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "bucket_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "bucket_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{bucket_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "1bd6e00f-0f58-4269-a128-26a4c149c18a",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "thresholds": [],
+      "timePreference": "GLOBAL_TIME",
+      "title": "Bytes Received",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Delta bytes of data sent from Google Cloud Storage to the client.",
+      "fillSpans": false,
+      "id": "c17c5918-2df5-43e3-b4c5-9759a1c4456c",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "storage.googleapis.com/storage/network/sent_bytes_count--int64--Delta--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "storage.googleapis.com/storage/network/sent_bytes_count",
+                "type": "Delta"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d653d795",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "a0ff047e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "ec27288a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "bucket_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "bucket_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.bucket_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "bucket_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "bucket_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{bucket_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b0705ab9-b577-4e70-915d-32353b430e93",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "thresholds": [],
+      "timePreference": "GLOBAL_TIME",
+      "title": "Bytes Sent",
+      "yAxisUnit": "bytes"
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Adds a GCP Cloud Storage bucket monitoring dashboard for SigNoz.

Closes SigNoz/signoz#6385 (GCP Cloud Storage Dashboard Request)

## Dashboard Details

**File:** `gcp/cloud-storage/gcp-cloud-storage-otlp-v1.json`
**Format:** SigNoz v3 OTLP
**Panels:** 5 panels across 3 sections

## Sections

| Section | Panels |
|---------|--------|
| Storage | Total bytes stored, object count |
| Requests | API request count (delta) |
| Network | Bytes received, bytes sent |

## Variables

- `deployment.environment` — environment filter
- `project_id` — GCP Project ID
- `bucket_name` — GCS bucket name

## Metric Namespace

`storage.googleapis.com/storage/*` collected via GCP monitoring OTel receiver.

## Changes

- `gcp/cloud-storage/gcp-cloud-storage-otlp-v1.json` — SigNoz v3 dashboard JSON
- `gcp/cloud-storage/README.md` — OTel collector config + metric reference

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>