### PR TITLE
feat(gcp): add GCP Cloud Load Balancer monitoring dashboard (OTLP v1)

### DIFF
--- a/gcp/cloud-load-balancer/README.md
+++ b/gcp/cloud-load-balancer/README.md
@@ -1,0 +1,56 @@
+# GCP Cloud Load Balancer Monitoring Dashboard
+
+Monitors Google Cloud HTTP/S Load Balancing using OpenTelemetry metrics.
+
+## Dashboard Details
+
+**File:** `gcp-cloud-load-balancer-otlp-v1.json`
+**Format:** SigNoz v3 OTLP
+**Panels:** 7 panels across 3 sections
+
+## Sections
+
+| Section | Panels |
+|---------|--------|
+| Traffic | Request count, backend request count, request bytes, response bytes |
+| Latency | Total latency, backend latency (avg) |
+| Response Status | Response count by HTTP status code class |
+
+## Variables
+
+| Variable | Description |
+|----------|-------------|
+| `deployment.environment` | Environment filter |
+| `project_id` | GCP Project ID |
+| `forwarding_rule_name` | Load balancer forwarding rule name |
+
+## Metrics Covered
+
+| Metric | Description |
+|--------|-------------|
+| `loadbalancing.googleapis.com/https/request_count` | Total requests (delta) |
+| `loadbalancing.googleapis.com/https/backend_request_count` | Backend requests (delta) |
+| `loadbalancing.googleapis.com/https/backend_request_bytes_count` | Request bytes (delta) |
+| `loadbalancing.googleapis.com/https/backend_response_bytes_count` | Response bytes (delta) |
+| `loadbalancing.googleapis.com/https/total_latencies` | End-to-end latency distribution (ms) |
+| `loadbalancing.googleapis.com/https/backend_latencies` | Proxy-to-backend latency (ms) |
+| `loadbalancing.googleapis.com/https/response_count` | Response count by status code class |
+
+## Setup
+
+```yaml
+receivers:
+  googlecloudmonitoring:
+    project_id: your-gcp-project-id
+    collection_interval: 60s
+    metric_prefixes:
+      - "loadbalancing.googleapis.com"
+
+exporters:
+  otlp:
+    endpoint: "your-signoz-host:4317"
+```
+
+## Related Issues
+
+- [SigNoz/signoz#6386](https://github.com/SigNoz/signoz/issues/6386) — GCP Cloud Load Balancer Dashboard Request

--- a/gcp/cloud-load-balancer/gcp-cloud-load-balancer-otlp-v1.json
+++ b/gcp/cloud-load-balancer/gcp-cloud-load-balancer-otlp-v1.json
@@ -1,0 +1,1048 @@
+{
+  "description": "Monitoring dashboard for GCP Cloud Load Balancing. Covers HTTP/S request rates, byte throughput, total and backend latencies, and response code distribution.",
+  "image": "",
+  "layout": [
+    {
+      "h": 1,
+      "i": "4cbfe890-3af0-458b-8fa0-62f3b2e701b5",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 6,
+      "i": "4c53c16a-4735-46d5-bf6f-4690c2c35347",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 0,
+      "y": 1
+    },
+    {
+      "h": 6,
+      "i": "93b0275c-c1af-424b-a883-22a544552f1e",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 3,
+      "y": 1
+    },
+    {
+      "h": 6,
+      "i": "6f97c7e0-c165-4e72-a1c7-8de0730e1c18",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 6,
+      "y": 1
+    },
+    {
+      "h": 6,
+      "i": "3e7954ae-1860-416f-a1c8-ee1d958ef4aa",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 9,
+      "y": 1
+    },
+    {
+      "h": 1,
+      "i": "bfb9e1a7-2501-4058-8b29-a078d3fad832",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 7
+    },
+    {
+      "h": 6,
+      "i": "0b3c31eb-a2ff-4f50-9e11-2d01f3b22bc7",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 8
+    },
+    {
+      "h": 6,
+      "i": "b1cb1b2a-3dbd-43a7-a6a4-6a5fd47e56e7",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 8
+    },
+    {
+      "h": 1,
+      "i": "56992938-4655-4e70-95cd-96e1f40419d2",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 14
+    },
+    {
+      "h": 6,
+      "i": "c4edab73-ff9a-45b8-b9d6-c09d5b2fb7ca",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 15
+    }
+  ],
+  "panelMap": {},
+  "tags": [
+    "gcp",
+    "load-balancer",
+    "https-lb",
+    "cloud-load-balancing"
+  ],
+  "title": "GCP Cloud Load Balancer Monitoring",
+  "uploadedGrafana": false,
+  "variables": {
+    "5d3b3a8c-77e4-4b2c-86fb-34b50a8d82e3": {
+      "customValue": "",
+      "description": "Deployment environment",
+      "id": "5d3b3a8c-77e4-4b2c-86fb-34b50a8d82e3",
+      "key": "5d3b3a8c-77e4-4b2c-86fb-34b50a8d82e3",
+      "modificationUUID": "cfd42da9-a6f5-4539-945f-d2cafde11e58",
+      "multiSelect": false,
+      "name": "deployment.environment",
+      "order": 0,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'deployment.environment'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name like '%loadbalancing%'",
+      "showALLOption": false,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "affd5ad5-c61e-4b41-bc8b-4d4fdc7a5270": {
+      "customValue": "",
+      "description": "GCP Project ID",
+      "id": "affd5ad5-c61e-4b41-bc8b-4d4fdc7a5270",
+      "modificationUUID": "2286e80c-05ee-4945-839b-4a2980df0511",
+      "multiSelect": false,
+      "name": "project_id",
+      "order": 1,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'project_id'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name like '%loadbalancing%'",
+      "showALLOption": false,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "91282b0a-f4ea-481c-9f93-67c1e9eee0c9": {
+      "customValue": "",
+      "description": "Forwarding Rule Name",
+      "id": "91282b0a-f4ea-481c-9f93-67c1e9eee0c9",
+      "modificationUUID": "1badc28c-3436-4bf5-abd9-57e7e9da71e5",
+      "multiSelect": false,
+      "name": "forwarding_rule_name",
+      "order": 2,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'forwarding_rule_name'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name like '%loadbalancing%'",
+      "showALLOption": false,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "version": "v3",
+  "widgets": [
+    {
+      "description": "Request rate and byte throughput",
+      "id": "4cbfe890-3af0-458b-8fa0-62f3b2e701b5",
+      "panelTypes": "row",
+      "title": "Traffic"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Delta count of requests served by the load balancer per forwarding rule.",
+      "fillSpans": false,
+      "id": "4c53c16a-4735-46d5-bf6f-4690c2c35347",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "loadbalancing.googleapis.com/https/request_count--int64--Delta--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "loadbalancing.googleapis.com/https/request_count",
+                "type": "Delta"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "769192ea",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "6b7ae709",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "58513da9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "forwarding_rule_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "forwarding_rule_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.forwarding_rule_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "forwarding_rule_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "forwarding_rule_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{forwarding_rule_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0554df89-3404-4238-a93a-5c852085f9e9",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "thresholds": [],
+      "timePreference": "GLOBAL_TIME",
+      "title": "Request Count",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Delta count of requests served by the load balancer backend.",
+      "fillSpans": false,
+      "id": "93b0275c-c1af-424b-a883-22a544552f1e",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "loadbalancing.googleapis.com/https/backend_request_count--int64--Delta--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "loadbalancing.googleapis.com/https/backend_request_count",
+                "type": "Delta"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "769192ea",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "6b7ae709",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "58513da9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "forwarding_rule_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "forwarding_rule_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.forwarding_rule_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "forwarding_rule_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "forwarding_rule_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{forwarding_rule_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "2fcac6f6-3f95-4446-b16d-6d3ef43ef92f",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "thresholds": [],
+      "timePreference": "GLOBAL_TIME",
+      "title": "Backend Request Count",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Delta count of bytes sent as requests from clients to load balancer backends.",
+      "fillSpans": false,
+      "id": "6f97c7e0-c165-4e72-a1c7-8de0730e1c18",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "loadbalancing.googleapis.com/https/backend_request_bytes_count--int64--Delta--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "loadbalancing.googleapis.com/https/backend_request_bytes_count",
+                "type": "Delta"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "769192ea",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "6b7ae709",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "58513da9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "forwarding_rule_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "forwarding_rule_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.forwarding_rule_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "forwarding_rule_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "forwarding_rule_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{forwarding_rule_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "339e78a2-c983-4400-a0d8-77f2aa96dd3a",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "thresholds": [],
+      "timePreference": "GLOBAL_TIME",
+      "title": "Request Bytes",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Delta count of bytes sent as responses from backends to clients.",
+      "fillSpans": false,
+      "id": "3e7954ae-1860-416f-a1c8-ee1d958ef4aa",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "loadbalancing.googleapis.com/https/backend_response_bytes_count--int64--Delta--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "loadbalancing.googleapis.com/https/backend_response_bytes_count",
+                "type": "Delta"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "769192ea",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "6b7ae709",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "58513da9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "forwarding_rule_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "forwarding_rule_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.forwarding_rule_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "forwarding_rule_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "forwarding_rule_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{forwarding_rule_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ccd496bb-d095-4e0e-9ef2-11676b1b0f9e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "thresholds": [],
+      "timePreference": "GLOBAL_TIME",
+      "title": "Response Bytes",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "Request and backend latency distribution",
+      "id": "bfb9e1a7-2501-4058-8b29-a078d3fad832",
+      "panelTypes": "row",
+      "title": "Latency"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Distribution of latency for HTTPS requests from clients, in milliseconds.",
+      "fillSpans": false,
+      "id": "0b3c31eb-a2ff-4f50-9e11-2d01f3b22bc7",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "loadbalancing.googleapis.com/https/total_latencies--float64--Distribution--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "loadbalancing.googleapis.com/https/total_latencies",
+                "type": "Distribution"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "769192ea",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "6b7ae709",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "58513da9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "forwarding_rule_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "forwarding_rule_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.forwarding_rule_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "forwarding_rule_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "forwarding_rule_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{forwarding_rule_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a87d1bb3-d2ce-4987-82c1-a12f84399c57",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "thresholds": [],
+      "timePreference": "GLOBAL_TIME",
+      "title": "Total Latency (avg)",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Distribution of latency from proxy to backends, in milliseconds.",
+      "fillSpans": false,
+      "id": "b1cb1b2a-3dbd-43a7-a6a4-6a5fd47e56e7",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "loadbalancing.googleapis.com/https/backend_latencies--float64--Distribution--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "loadbalancing.googleapis.com/https/backend_latencies",
+                "type": "Distribution"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "769192ea",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "6b7ae709",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "58513da9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "forwarding_rule_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "forwarding_rule_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.forwarding_rule_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "forwarding_rule_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "forwarding_rule_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{forwarding_rule_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "79e8b4e4-f631-411e-831a-44d924f1a887",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "thresholds": [],
+      "timePreference": "GLOBAL_TIME",
+      "title": "Backend Latency (avg)",
+      "yAxisUnit": "ms"
+    },
+    {
+      "description": "HTTP response code breakdown",
+      "id": "56992938-4655-4e70-95cd-96e1f40419d2",
+      "panelTypes": "row",
+      "title": "Response Status"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Delta count of responses from backends grouped by response code class.",
+      "fillSpans": false,
+      "id": "c4edab73-ff9a-45b8-b9d6-c09d5b2fb7ca",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "int64",
+                "id": "loadbalancing.googleapis.com/https/response_count--int64--Delta--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "loadbalancing.googleapis.com/https/response_count",
+                "type": "Delta"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "769192ea",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "6b7ae709",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "58513da9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "forwarding_rule_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "forwarding_rule_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.forwarding_rule_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "response_code_class--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "response_code_class",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{response_code_class}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "5b03d234-e941-4e92-8cb1-fa0aba74e798",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "thresholds": [],
+      "timePreference": "GLOBAL_TIME",
+      "title": "Response Count by Status",
+      "yAxisUnit": "short"
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Adds a GCP Cloud Load Balancer monitoring dashboard for SigNoz.

Closes SigNoz/signoz#6386 (GCP Cloud Load Balancer Dashboard Request)

## Dashboard Details

**File:** `gcp/cloud-load-balancer/gcp-cloud-load-balancer-otlp-v1.json`
**Format:** SigNoz v3 OTLP
**Panels:** 7 panels across 3 sections

## Sections

| Section | Panels |
|---------|--------|
| Traffic | Request count, backend requests, request/response bytes |
| Latency | Total latency, backend latency (avg) |
| Response Status | Response count by HTTP status code class |

## Variables

- `deployment.environment` — environment filter
- `project_id` — GCP Project ID
- `forwarding_rule_name` — load balancer forwarding rule

## Metric Namespace

`loadbalancing.googleapis.com/https/*` via GCP monitoring OTel receiver.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>