### PR TITLE
feat(kong): add Kong Gateway dashboard template (Prometheus)

### DIFF
--- a/kong/README.md
+++ b/kong/README.md
@@ -1,0 +1,58 @@
+# Kong API Gateway Monitoring Dashboard
+
+Comprehensive monitoring for Kong API Gateway using the Kong Prometheus plugin.
+
+## Sections
+
+| # | Section | Covers |
+|---|---------|--------|
+| 1 | General Overview | Request rate, error rate, p99 upstream latency, p95 total latency |
+| 2 | Traffic Management | Request distribution by service, bandwidth in/out, connections |
+| 3 | Upstream Health | Healthy/unhealthy targets, DNS latency, circuit breaker events |
+| 4 | Node & Nginx | Datastore reachability, Nginx metric errors |
+
+## Setup
+
+### Enable Kong Prometheus Plugin
+
+```bash
+# Enable globally
+curl -X POST http://localhost:8001/plugins \
+  --data "name=prometheus" \
+  --data "config.per_consumer=false"
+```
+
+### OTel Collector Configuration
+
+```yaml
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: 'kong'
+          static_configs:
+            - targets: ['kong-admin:8001']
+          metrics_path: '/metrics'
+```
+
+## Dashboard Variables
+
+| Variable | Description |
+|----------|-------------|
+| `kong_job` | Prometheus job name for Kong (default: `kong.*`) |
+
+## Key Metrics
+
+| Metric | Description |
+|--------|-------------|
+| `kong_http_requests_total` | Total HTTP requests by service, route, code |
+| `kong_latency_ms_bucket` | Request/upstream latency histogram |
+| `kong_bandwidth_bytes_total` | Bandwidth by direction (ingress/egress) |
+| `kong_nginx_connections_total` | Nginx connection states |
+| `kong_upstream_target_health` | Upstream target health state |
+| `kong_datastore_reachable` | Datastore reachability (1=up) |
+
+## References
+
+- [Kong Prometheus Plugin](https://docs.konghq.com/hub/kong-inc/prometheus/)
+- [Kong Prometheus Metrics](https://docs.konghq.com/gateway/latest/production/monitoring/prometheus/)

--- a/kong/kong-prometheus-v1.json
+++ b/kong/kong-prometheus-v1.json
@@ -1,0 +1,1461 @@
+{
+  "description": "Comprehensive Kong API Gateway monitoring using the Kong Prometheus plugin. Covers request traffic, latency percentiles, upstream health, bandwidth, and Nginx worker metrics.",
+  "image": "",
+  "layout": [
+    {
+      "h": 1,
+      "i": "6b143db1-8c6c-48e0-8a40-44835703a285",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 6,
+      "i": "8e053e25-fc12-4f6f-bf38-31123c5ff577",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 1
+    },
+    {
+      "h": 6,
+      "i": "10fa9f2c-b024-4e03-be23-568d6935dd74",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 1
+    },
+    {
+      "h": 6,
+      "i": "bc03f54c-a89b-49be-81db-f955515667a0",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 7
+    },
+    {
+      "h": 6,
+      "i": "e6bd0341-cad8-4302-b33a-7520108d3f2c",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 7
+    },
+    {
+      "h": 1,
+      "i": "9adbc4b8-ceee-41fc-a214-aef2e6aad2d5",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 13
+    },
+    {
+      "h": 6,
+      "i": "c10ccaf5-d389-4421-9272-9b33e44b1939",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 14
+    },
+    {
+      "h": 6,
+      "i": "9c170e1d-eea3-4bb4-8475-843f744fef83",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 14
+    },
+    {
+      "h": 6,
+      "i": "2a5812cf-0a8f-4f27-86fb-d8b0aacd61ad",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 20
+    },
+    {
+      "h": 6,
+      "i": "c4b09f8c-b3c1-4946-a4ac-e21d64b980a2",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 20
+    },
+    {
+      "h": 1,
+      "i": "c726e9d8-2167-4a95-91f1-b8712ccb35d7",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 26
+    },
+    {
+      "h": 6,
+      "i": "44482313-db02-4cc2-be95-1f0745be0121",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 27
+    },
+    {
+      "h": 6,
+      "i": "cb7596e5-f1ab-4729-9daf-2384fe0f98a1",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 27
+    },
+    {
+      "h": 6,
+      "i": "ecfdd0ed-b5dc-472c-a97b-402cf1dd3821",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 33
+    },
+    {
+      "h": 6,
+      "i": "433ce64c-9976-4657-b899-87de5dbcd311",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 33
+    },
+    {
+      "h": 1,
+      "i": "e82a778b-7b78-485c-b137-99350fc1fee4",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 39
+    },
+    {
+      "h": 6,
+      "i": "1f4ff337-cd2b-4280-8863-c0db363f6400",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 40
+    },
+    {
+      "h": 6,
+      "i": "33e061f2-ebf5-4a47-a9f9-d95090cb516d",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 40
+    }
+  ],
+  "panelMap": {
+    "6b143db1-8c6c-48e0-8a40-44835703a285": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "8e053e25-fc12-4f6f-bf38-31123c5ff577",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 1
+        },
+        {
+          "h": 6,
+          "i": "10fa9f2c-b024-4e03-be23-568d6935dd74",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 1
+        },
+        {
+          "h": 6,
+          "i": "bc03f54c-a89b-49be-81db-f955515667a0",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 7
+        },
+        {
+          "h": 6,
+          "i": "e6bd0341-cad8-4302-b33a-7520108d3f2c",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 7
+        }
+      ]
+    },
+    "9adbc4b8-ceee-41fc-a214-aef2e6aad2d5": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "c10ccaf5-d389-4421-9272-9b33e44b1939",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 14
+        },
+        {
+          "h": 6,
+          "i": "9c170e1d-eea3-4bb4-8475-843f744fef83",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 14
+        },
+        {
+          "h": 6,
+          "i": "2a5812cf-0a8f-4f27-86fb-d8b0aacd61ad",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 20
+        },
+        {
+          "h": 6,
+          "i": "c4b09f8c-b3c1-4946-a4ac-e21d64b980a2",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 20
+        }
+      ]
+    },
+    "c726e9d8-2167-4a95-91f1-b8712ccb35d7": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "44482313-db02-4cc2-be95-1f0745be0121",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 27
+        },
+        {
+          "h": 6,
+          "i": "cb7596e5-f1ab-4729-9daf-2384fe0f98a1",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 27
+        },
+        {
+          "h": 6,
+          "i": "ecfdd0ed-b5dc-472c-a97b-402cf1dd3821",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 33
+        },
+        {
+          "h": 6,
+          "i": "433ce64c-9976-4657-b899-87de5dbcd311",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 33
+        }
+      ]
+    },
+    "e82a778b-7b78-485c-b137-99350fc1fee4": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "1f4ff337-cd2b-4280-8863-c0db363f6400",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 40
+        },
+        {
+          "h": 6,
+          "i": "33e061f2-ebf5-4a47-a9f9-d95090cb516d",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 40
+        }
+      ]
+    }
+  },
+  "tags": [
+    "kong",
+    "api-gateway",
+    "prometheus",
+    "nginx"
+  ],
+  "title": "Kong API Gateway Monitoring",
+  "uploadedGrafana": false,
+  "variables": {
+    "87dbb1d2-d5e8-4ff1-a072-6fa0688a6d56": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Kong Prometheus job name",
+      "id": "87dbb1d2-d5e8-4ff1-a072-6fa0688a6d56",
+      "key": "87dbb1d2-d5e8-4ff1-a072-6fa0688a6d56",
+      "modificationUUID": "84bfe28c-fc1c-475f-be74-50983e2a6ab7",
+      "multiSelect": false,
+      "name": "kong_job",
+      "order": 0,
+      "queryValue": "",
+      "selectedValue": "",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "kong.*",
+      "type": "TEXTBOX"
+    }
+  },
+  "version": "v5",
+  "widgets": [
+    {
+      "description": "",
+      "id": "6b143db1-8c6c-48e0-8a40-44835703a285",
+      "panelTypes": "row",
+      "title": "General Overview"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Total HTTP request rate through Kong gateway",
+      "fillSpans": false,
+      "id": "8e053e25-fc12-4f6f-bf38-31123c5ff577",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{service}} / {{route}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": null,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "7a7200f3-49df-4a24-acd1-19466e044469",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{service}} / {{route}}",
+            "name": "A",
+            "query": "sum(rate(kong_http_requests_total{job=~\"$kong_job\"}[1m])) by (service, route)"
+          }
+        ],
+        "queryType": "promql",
+        "unit": "reqps"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "HTTP Request Rate",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Rate of 4xx/5xx HTTP errors through Kong",
+      "fillSpans": false,
+      "id": "10fa9f2c-b024-4e03-be23-568d6935dd74",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{service}} {{code}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": null,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9aadde93-f8ac-41f1-a1af-75f74246e33b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{service}} {{code}}",
+            "name": "A",
+            "query": "sum(rate(kong_http_requests_total{job=~\"$kong_job\",code=~\"4..|5..\"}[1m])) by (service, code)"
+          }
+        ],
+        "queryType": "promql",
+        "unit": "reqps"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "HTTP Error Rate",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "99th percentile upstream latency",
+      "fillSpans": false,
+      "id": "bc03f54c-a89b-49be-81db-f955515667a0",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{service}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": null,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "62cb629f-ba4c-4814-b27b-13b33b4cbad8",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{service}}",
+            "name": "A",
+            "query": "histogram_quantile(0.99, sum(rate(kong_latency_ms_bucket{job=~\"$kong_job\",type=\"upstream\"}[5m])) by (le, service))"
+          }
+        ],
+        "queryType": "promql",
+        "unit": "ms"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "P99 Latency (upstream)",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "95th percentile total request latency (Kong + upstream)",
+      "fillSpans": false,
+      "id": "e6bd0341-cad8-4302-b33a-7520108d3f2c",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{service}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": null,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "aa558bf7-1446-4055-9b29-4d0929bd0a23",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{service}}",
+            "name": "A",
+            "query": "histogram_quantile(0.95, sum(rate(kong_latency_ms_bucket{job=~\"$kong_job\",type=\"request\"}[5m])) by (le, service))"
+          }
+        ],
+        "queryType": "promql",
+        "unit": "ms"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "P95 Latency (total)",
+      "yAxisUnit": "ms"
+    },
+    {
+      "description": "",
+      "id": "9adbc4b8-ceee-41fc-a214-aef2e6aad2d5",
+      "panelTypes": "row",
+      "title": "Traffic Management"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Request rate per Kong service",
+      "fillSpans": false,
+      "id": "c10ccaf5-d389-4421-9272-9b33e44b1939",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{service}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": null,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "3ecfac83-fccd-4de7-b858-ac57fdf7a2ec",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{service}}",
+            "name": "A",
+            "query": "sum(rate(kong_http_requests_total{job=~\"$kong_job\"}[1m])) by (service)"
+          }
+        ],
+        "queryType": "promql",
+        "unit": "reqps"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Distribution by Service",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Kong bandwidth usage",
+      "fillSpans": false,
+      "id": "9c170e1d-eea3-4bb4-8475-843f744fef83",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{direction}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": null,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "952c162d-8bcc-4410-ad43-0d48bb5d174e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{direction}}",
+            "name": "A",
+            "query": "sum(rate(kong_bandwidth_bytes_total{job=~\"$kong_job\"}[1m])) by (direction)"
+          }
+        ],
+        "queryType": "promql",
+        "unit": "bytes/s"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Bandwidth In/Out",
+      "yAxisUnit": "bytes/s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Rate of connections accepted by Kong",
+      "fillSpans": false,
+      "id": "2a5812cf-0a8f-4f27-86fb-d8b0aacd61ad",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Accepted",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": null,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "50c8a3c4-47bd-40ec-aece-1c036ba03a79",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Accepted",
+            "name": "A",
+            "query": "sum(rate(kong_nginx_connections_total{job=~\"$kong_job\",state=\"accepted\"}[1m]))"
+          }
+        ],
+        "queryType": "promql",
+        "unit": "none"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Connections Accepted",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Current active connections to Kong",
+      "fillSpans": false,
+      "id": "c4b09f8c-b3c1-4946-a4ac-e21d64b980a2",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Active",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": null,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d450f2a3-4a03-46c3-a7b6-07e7c1988462",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Active",
+            "name": "A",
+            "query": "sum(kong_nginx_connections_total{job=~\"$kong_job\",state=\"active\"})"
+          }
+        ],
+        "queryType": "promql",
+        "unit": "none"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Connections",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "id": "c726e9d8-2167-4a95-91f1-b8712ccb35d7",
+      "panelTypes": "row",
+      "title": "Upstream Health"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Number of healthy upstream targets",
+      "fillSpans": false,
+      "id": "44482313-db02-4cc2-be95-1f0745be0121",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{upstream}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": null,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "e0ae1e9f-f0ed-466d-ab54-7f5401f48c81",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{upstream}}",
+            "name": "A",
+            "query": "sum(kong_upstream_target_health{job=~\"$kong_job\",state=\"healthy\"}) by (upstream)"
+          }
+        ],
+        "queryType": "promql",
+        "unit": "none"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Upstream Healthy Nodes",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Number of unhealthy upstream targets",
+      "fillSpans": false,
+      "id": "cb7596e5-f1ab-4729-9daf-2384fe0f98a1",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{upstream}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": null,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "62e2ce1a-90f3-4492-a93b-6abbf8cb94fe",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{upstream}}",
+            "name": "A",
+            "query": "sum(kong_upstream_target_health{job=~\"$kong_job\",state=\"unhealthy\"}) by (upstream)"
+          }
+        ],
+        "queryType": "promql",
+        "unit": "none"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Upstream Unhealthy Nodes",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "DNS resolution latency for upstreams",
+      "fillSpans": false,
+      "id": "ecfdd0ed-b5dc-472c-a97b-402cf1dd3821",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{service}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": null,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "e5d13e88-a4ec-4ad1-8568-97efb952983c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{service}}",
+            "name": "A",
+            "query": "histogram_quantile(0.95, sum(rate(kong_upstream_latency_ms_bucket{job=~\"$kong_job\"}[5m])) by (le, service))"
+          }
+        ],
+        "queryType": "promql",
+        "unit": "ms"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Upstream DNS Latency",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Upstream circuit breaker state changes",
+      "fillSpans": false,
+      "id": "433ce64c-9976-4657-b899-87de5dbcd311",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{upstream}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": null,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "460958f0-9214-4f43-96b0-ad5a7b664d26",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{upstream}}",
+            "name": "A",
+            "query": "sum(changes(kong_upstream_target_health{job=~\"$kong_job\",state=~\"unhealthy|dns_error\"}[5m])) by (upstream)"
+          }
+        ],
+        "queryType": "promql",
+        "unit": "none"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Circuit Breaker Events",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "id": "e82a778b-7b78-485c-b137-99350fc1fee4",
+      "panelTypes": "row",
+      "title": "Node & Nginx Metrics"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Number of nginx worker processes",
+      "fillSpans": false,
+      "id": "1f4ff337-cd2b-4280-8863-c0db363f6400",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Workers",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": null,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "294a1c0d-5bcb-450d-ba72-ac7b48abce58",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Workers",
+            "name": "A",
+            "query": "kong_nginx_metric_errors_total{job=~\"$kong_job\"}"
+          }
+        ],
+        "queryType": "promql",
+        "unit": "none"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Nginx Workers Utilization",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Kong datastore (DB) reachability (1=up, 0=down)",
+      "fillSpans": false,
+      "id": "33e061f2-ebf5-4a47-a9f9-d95090cb516d",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": null,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0c79ac7b-f0f3-4c9f-b9da-5e91e60134c3",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "kong_datastore_reachable{job=~\"$kong_job\"}"
+          }
+        ],
+        "queryType": "promql",
+        "unit": "none"
+      },
+      "selectedLogFields": [],
+      "selectedTracesFields": [],
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Datastore Reachability",
+      "yAxisUnit": "none"
+    }
+  ],
+  "uuid": "37a6352e-9801-4ba9-b015-e6813311f906"
+}


### PR DESCRIPTION
/claim #6028

Implements a production-ready Kong Gateway dashboard template for SigNoz.

### What's included
- Added `kong/kong-prometheus-v1.json` with panel coverage for:
  - Traffic/request throughput
  - Latency and upstream latency
  - Error rates and status code visibility
  - Resource and connection health signals
- Added `kong/README.md` with ingestion and usage guidance.

### Validation
- JSON structure validated locally (`python3 -m json.tool kong/kong-prometheus-v1.json`).
- File layout matches repository template conventions (`<integration>/README.md` + dashboard JSON).

Closes the dashboard request tracked in SigNoz/signoz#6028.