### PR TITLE
feat(dashboard): Add ASP.NET Core Metrics dashboard (OTLP v1)

### DIFF
--- a/aspnetcore/README.md
+++ b/aspnetcore/README.md
@@ -1,0 +1,114 @@
+# ASP.NET Core Metrics Dashboard - OTLP
+
+## Metrics Ingestion
+
+This dashboard uses metrics from the OpenTelemetry .NET SDK automatic instrumentation. To collect ASP.NET Core metrics, configure your OpenTelemetry Collector with the OTLP receiver:
+
+### otel-config.yaml
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  otlp:
+    endpoint: "<signoz-endpoint>:4317"
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      exporters: [otlp]
+```
+
+### ASP.NET Core Application Setup
+
+Add the following NuGet packages to your application:
+
+```bash
+dotnet add package OpenTelemetry.Extensions.Hosting
+dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol
+dotnet add package OpenTelemetry.Instrumentation.AspNetCore
+dotnet add package OpenTelemetry.Instrumentation.Process
+dotnet add package OpenTelemetry.Instrumentation.Runtime
+```
+
+Configure OpenTelemetry in `Program.cs`:
+
+```csharp
+builder.Services.AddOpenTelemetry()
+    .WithMetrics(metrics =>
+    {
+        metrics
+            .AddAspNetCoreInstrumentation()
+            .AddProcessInstrumentation()
+            .AddRuntimeInstrumentation()
+            .AddOtlpExporter(opts =>
+            {
+                opts.Endpoint = new Uri("http://<otel-collector>:4317");
+            });
+    });
+```
+
+Set the service name and deployment environment via environment variables:
+
+```bash
+export OTEL_SERVICE_NAME=my-aspnetcore-app
+export OTEL_RESOURCE_ATTRIBUTES=deployment.environment=production
+```
+
+## Variables
+
+- `{{service_name}}`: The name of the ASP.NET Core service (from `service.name` resource attribute)
+- `{{deployment_environment}}`: Deployment environment (from `deployment.environment` resource attribute)
+
+## Dashboard Panels
+
+### Section: Application Performance
+
+| Panel | Metric | Description |
+|-------|--------|-------------|
+| CPU Usage | `process.cpu.time` | Rate of CPU time consumed by the application process |
+| Memory Usage | `process.memory.usage` | Current memory consumption in bytes |
+| Request Rate | `http.server.request.duration` | Incoming HTTP request rate per second, grouped by service |
+| Request Latency P95 | `http.server.request.duration` | 95th percentile request latency in nanoseconds |
+| Error Rate (%) | `http.server.request.duration` | Percentage of requests returning HTTP 4xx/5xx status codes |
+
+### Section: Request and Response
+
+| Panel | Metric | Description |
+|-------|--------|-------------|
+| Active Requests | `http.server.active_requests` | Number of HTTP requests currently being processed |
+| HTTP Request Rate by Status Code | `http.server.request.duration` | Request rate broken down by HTTP response status code |
+| Request Duration by Route (P95) | `http.server.request.duration` | 95th percentile latency per HTTP route |
+
+### Section: Process Metrics
+
+| Panel | Metric | Description |
+|-------|--------|-------------|
+| GC Collections Count | `process.runtime.dotnet.gc.collections.count` | Garbage collection count by generation (gen0, gen1, gen2) |
+| GC Heap Size | `process.runtime.dotnet.gc.heap.size` | Managed heap size in bytes |
+| Thread Pool Threads | `process.runtime.dotnet.thread_pool.threads.count` | Number of active thread pool threads |
+| Thread Pool Queue Length | `process.runtime.dotnet.thread_pool.queue.length` | Items queued for thread pool processing |
+| Exception Count | `process.runtime.dotnet.exceptions.count` | Total .NET exceptions thrown |
+
+### Section: Kestrel Server
+
+| Panel | Metric | Description |
+|-------|--------|-------------|
+| Kestrel Active Connections | `kestrel.active_connections` | Active connections to the Kestrel web server |
+| Kestrel Queue Length | `kestrel.queued_connections` | Connections queued waiting to be processed |
+| Kestrel Request Duration (P95) | `kestrel.request.duration` | 95th percentile Kestrel request processing time |
+
+## References
+
+- [OpenTelemetry .NET Metrics Instrumentation](https://opentelemetry.io/docs/zero-code/net/instrumentations/#metrics-instrumentations)
+- [OpenTelemetry .NET Runtime Instrumentation](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.Runtime)
+- [OpenTelemetry .NET Process Instrumentation](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.Process)

--- a/aspnetcore/aspnetcore-otlp-v1.json
+++ b/aspnetcore/aspnetcore-otlp-v1.json
@@ -1,0 +1,1601 @@
+{
+  "description": "Monitor ASP.NET Core application performance, HTTP requests, .NET runtime process metrics, and Kestrel server internals using OpenTelemetry instrumentation.",
+  "image": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0NTYgNDU2Ij48cmVjdCB3aWR0aD0iNDU2IiBoZWlnaHQ9IjQ1NiIgcng9IjUwIiByeT0iNTAiIGZpbGw9IiM1MTJCRDQiLz48cGF0aCBkPSJNMzgwLjIgMjgxLjNjLTEuNS0uMS0zLS4yLTQuNS0uMi03LjQgMC0xNC42IDEuNC0yMS4zIDQuMi0yLjIuOS00LjMgMS45LTYuMyAzLjEtMS43LTExLjgtNS4xLTIzLjEtMTEuNS0zMy4zLTEyLjItMTkuNC0zMC4yLTMzLjUtNTEuMy0zOS45IDIuNS0zLjMgNC44LTYuOCA2LjktMTAuNSA2LjEtMTAuNyAxMC41LTIyLjYgMTIuOC0zNS4yLjUtMi42LjgtNS4yIDEtNy45LjQtNC44LjUtOS43LjItMTQuNS0uNi0xMC4zLTMuMi0yMC4yLTguMi0yOC44LTEuNy0yLjktMy43LTUuNi01LjktOC4xLTE0LjgtMTYuNS0zNi41LTI0LjktNTkuMi0yNC45LTQ3LjQgMC04NS44IDM4LjQtODUuOCA4NS44IDAgMi4xLjEgNC4xLjIgNi4yLTQ1LjcgMTMuNC04MC4xIDU0LjQtODQuOSAxMDEuNS0uNCA0LS42IDgtLjYgMTIuMSAwIDUzLjUgNDMuNCA5Ni45IDk2LjkgOTYuOWgyMTEuN2MyLjUgMCA1LS4xIDcuNS0uNCAzMy42LTIuNiA1OS40LTMxLjIgNTcuOS02NC45LTEuNS0zMy43LTI4LjQtNTkuOS02Mi4zLTYyLjF6IiBmaWxsPSIjZmZmIi8+PC9zdmc+",
+  "layout": [
+    { "h": 1, "i": "row-app-perf", "moved": false, "static": false, "w": 12, "x": 0, "y": 0 },
+    { "h": 3, "i": "panel-cpu-usage", "moved": false, "static": false, "w": 6, "x": 0, "y": 1 },
+    { "h": 3, "i": "panel-memory-usage", "moved": false, "static": false, "w": 6, "x": 6, "y": 1 },
+    { "h": 9, "i": "panel-request-rate", "moved": false, "static": false, "w": 6, "x": 0, "y": 4 },
+    { "h": 9, "i": "panel-request-latency-p95", "moved": false, "static": false, "w": 6, "x": 6, "y": 4 },
+    { "h": 9, "i": "panel-error-rate", "moved": false, "static": false, "w": 12, "x": 0, "y": 13 },
+
+    { "h": 1, "i": "row-req-resp", "moved": false, "static": false, "w": 12, "x": 0, "y": 22 },
+    { "h": 3, "i": "panel-active-requests", "moved": false, "static": false, "w": 12, "x": 0, "y": 23 },
+    { "h": 9, "i": "panel-http-error-rate-by-status", "moved": false, "static": false, "w": 6, "x": 0, "y": 26 },
+    { "h": 9, "i": "panel-req-duration-by-route", "moved": false, "static": false, "w": 6, "x": 6, "y": 26 },
+
+    { "h": 1, "i": "row-process-metrics", "moved": false, "static": false, "w": 12, "x": 0, "y": 35 },
+    { "h": 9, "i": "panel-gc-collections", "moved": false, "static": false, "w": 6, "x": 0, "y": 36 },
+    { "h": 9, "i": "panel-gc-heap-size", "moved": false, "static": false, "w": 6, "x": 6, "y": 36 },
+    { "h": 9, "i": "panel-thread-pool-threads", "moved": false, "static": false, "w": 6, "x": 0, "y": 45 },
+    { "h": 9, "i": "panel-thread-pool-queue", "moved": false, "static": false, "w": 6, "x": 6, "y": 45 },
+    { "h": 9, "i": "panel-exception-count", "moved": false, "static": false, "w": 12, "x": 0, "y": 54 },
+
+    { "h": 1, "i": "row-kestrel", "moved": false, "static": false, "w": 12, "x": 0, "y": 63 },
+    { "h": 3, "i": "panel-kestrel-active-conns", "moved": false, "static": false, "w": 12, "x": 0, "y": 64 },
+    { "h": 9, "i": "panel-kestrel-queue-length", "moved": false, "static": false, "w": 6, "x": 0, "y": 67 },
+    { "h": 9, "i": "panel-kestrel-req-duration", "moved": false, "static": false, "w": 6, "x": 6, "y": 67 }
+  ],
+  "panelMap": {},
+  "tags": ["aspnetcore", "dotnet", "otel"],
+  "title": "ASP.NET Core",
+  "uploadedGrafana": false,
+  "uuid": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+  "variables": {
+    "d7a1f3e2-8b4c-4d5e-9f6a-1b2c3d4e5f6a": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Filter by service name",
+      "id": "d7a1f3e2-8b4c-4d5e-9f6a-1b2c3d4e5f6a",
+      "key": "d7a1f3e2-8b4c-4d5e-9f6a-1b2c3d4e5f6a",
+      "modificationUUID": "e8b2f4a3-9c5d-4e6f-a7b8-2c3d4e5f6a7b",
+      "multiSelect": true,
+      "name": "service_name",
+      "order": 0,
+      "queryValue": "SELECT JSONExtractString(labels, 'service.name') AS `service.name`\nFROM signoz_metrics.distributed_time_series_v4_1day\nWHERE metric_name = 'http.server.request.duration'\nGROUP BY `service.name`",
+      "selectedValue": [""],
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Filter by deployment environment",
+      "id": "c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f",
+      "key": "c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f",
+      "modificationUUID": "f9c3a5b4-0d6e-4f7a-b8c9-3d4e5f6a7b8c",
+      "multiSelect": true,
+      "name": "deployment_environment",
+      "order": 1,
+      "queryValue": "SELECT JSONExtractString(labels, 'deployment.environment') AS `deployment.environment`\nFROM signoz_metrics.distributed_time_series_v4_1day\nWHERE metric_name = 'http.server.request.duration'\nGROUP BY `deployment.environment`",
+      "selectedValue": [""],
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "version": "v5",
+  "widgets": [
+    {
+      "description": "",
+      "id": "row-app-perf",
+      "panelTypes": "row",
+      "title": "Application Performance",
+      "collapsed": false,
+      "query": {
+        "builder": { "queryData": [], "queryFormulas": [] },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "row-app-perf-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      }
+    },
+    {
+      "description": "Total CPU time consumed by the process, shown as a rate per second.",
+      "fillSpans": false,
+      "id": "panel-cpu-usage",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "process.cpu.time--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "process.cpu.time",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f1a1b1c1-d1e1-4f1a-b1c1-d1e1f1a1b1c1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "f1a1b1c1-d1e1-4f1a-b1c1-d1e1f1a1b1c2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "CPU Usage",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "panel-cpu-usage-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "CPU Usage",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Current process memory usage (resident set).",
+      "fillSpans": false,
+      "id": "panel-memory-usage",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "process.memory.usage--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "process.memory.usage",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "last",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f2a2b2c2-d2e2-4f2a-b2c2-d2e2f2a2b2c1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "f2a2b2c2-d2e2-4f2a-b2c2-d2e2f2a2b2c2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Memory",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "panel-memory-usage-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memory Usage",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "Rate of incoming HTTP requests per second, grouped by service name.",
+      "fillSpans": false,
+      "id": "panel-request-rate",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http.server.request.duration--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http.server.request.duration",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "count_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f3a3b3c3-d3e3-4f3a-b3c3-d3e3f3a3b3c1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "f3a3b3c3-d3e3-4f3a-b3c3-d3e3f3a3b3c2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "service.name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "service.name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{service.name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "panel-request-rate-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Rate",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "95th percentile HTTP server request latency.",
+      "fillSpans": false,
+      "id": "panel-request-latency-p95",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http.server.request.duration--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http.server.request.duration",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p95",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f4a4b4c4-d4e4-4f4a-b4c4-d4e4f4a4b4c1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "f4a4b4c4-d4e4-4f4a-b4c4-d4e4f4a4b4c2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "service.name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "service.name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{service.name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "panel-request-latency-p95-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Latency P95",
+      "yAxisUnit": "ns"
+    },
+    {
+      "description": "Percentage of HTTP requests resulting in 4xx or 5xx status codes. Computed as (error count / total count) * 100.",
+      "fillSpans": false,
+      "id": "panel-error-rate",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http.server.request.duration--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http.server.request.duration",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "count_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f5a5b5c5-d5e5-4f5a-b5c5-d5e5f5a5b5c1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "f5a5b5c5-d5e5-4f5a-b5c5-d5e5f5a5b5c2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  },
+                  {
+                    "id": "f5a5b5c5-d5e5-4f5a-b5c5-d5e5f5a5b5c3",
+                    "key": {
+                      "dataType": "int64",
+                      "id": "http.response.status_code--int64--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "http.response.status_code",
+                      "type": "tag"
+                    },
+                    "op": ">=",
+                    "value": "400"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Error Requests",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http.server.request.duration--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http.server.request.duration",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "count_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f5a5b5c5-d5e5-4f5a-b5c5-d5e5f5a5b5c4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "f5a5b5c5-d5e5-4f5a-b5c5-d5e5f5a5b5c5",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Total Requests",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "A * 100 / B",
+              "legend": "Error Rate %",
+              "queryName": "F1"
+            }
+          ]
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "panel-error-rate-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Error Rate (%)",
+      "yAxisUnit": "percent"
+    },
+
+    {
+      "description": "",
+      "id": "row-req-resp",
+      "panelTypes": "row",
+      "title": "Request and Response",
+      "collapsed": false,
+      "query": {
+        "builder": { "queryData": [], "queryFormulas": [] },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "row-req-resp-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      }
+    },
+    {
+      "description": "Number of HTTP requests currently being handled by the server.",
+      "fillSpans": false,
+      "id": "panel-active-requests",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http.server.active_requests--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http.server.active_requests",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "last",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f6a6b6c6-d6e6-4f6a-b6c6-d6e6f6a6b6c1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "f6a6b6c6-d6e6-4f6a-b6c6-d6e6f6a6b6c2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Active Requests",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "panel-active-requests-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Requests",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "HTTP request rate broken down by response status code to identify error patterns.",
+      "fillSpans": false,
+      "id": "panel-http-error-rate-by-status",
+      "isStacked": true,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http.server.request.duration--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http.server.request.duration",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "count_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f7a7b7c7-d7e7-4f7a-b7c7-d7e7f7a7b7c1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "f7a7b7c7-d7e7-4f7a-b7c7-d7e7f7a7b7c2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "int64",
+                  "id": "http.response.status_code--int64--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "http.response.status_code",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{http.response.status_code}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "panel-http-error-rate-by-status-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "HTTP Request Rate by Status Code",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "95th percentile request duration broken down by HTTP route.",
+      "fillSpans": false,
+      "id": "panel-req-duration-by-route",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http.server.request.duration--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http.server.request.duration",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p95",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f8a8b8c8-d8e8-4f8a-b8c8-d8e8f8a8b8c1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "f8a8b8c8-d8e8-4f8a-b8c8-d8e8f8a8b8c2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "http.route--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "http.route",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{http.route}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "panel-req-duration-by-route-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Duration by Route (P95)",
+      "yAxisUnit": "ns"
+    },
+
+    {
+      "description": "",
+      "id": "row-process-metrics",
+      "panelTypes": "row",
+      "title": "Process Metrics",
+      "collapsed": false,
+      "query": {
+        "builder": { "queryData": [], "queryFormulas": [] },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "row-process-metrics-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      }
+    },
+    {
+      "description": "Number of garbage collections per generation (Gen 0, Gen 1, Gen 2).",
+      "fillSpans": false,
+      "id": "panel-gc-collections",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "process.runtime.dotnet.gc.collections.count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "process.runtime.dotnet.gc.collections.count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f9a9b9c9-d9e9-4f9a-b9c9-d9e9f9a9b9c1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "f9a9b9c9-d9e9-4f9a-b9c9-d9e9f9a9b9c2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "generation--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "generation",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Gen {{generation}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "panel-gc-collections-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "GC Collections Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Size of the .NET garbage collector managed heap.",
+      "fillSpans": false,
+      "id": "panel-gc-heap-size",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "process.runtime.dotnet.gc.heap.size--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "process.runtime.dotnet.gc.heap.size",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "fa0ab0c0-d0e0-4f0a-b0c0-d0e0f0a0b0c1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "fa0ab0c0-d0e0-4f0a-b0c0-d0e0f0a0b0c2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Heap Size",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "panel-gc-heap-size-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "GC Heap Size",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "Number of thread pool threads currently active.",
+      "fillSpans": false,
+      "id": "panel-thread-pool-threads",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "process.runtime.dotnet.thread_pool.threads.count--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "process.runtime.dotnet.thread_pool.threads.count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "fb1ab1c1-d1e1-4f1b-b1c1-d1e1f1b1b1c1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "fb1ab1c1-d1e1-4f1b-b1c1-d1e1f1b1b1c2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Thread Count",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "panel-thread-pool-threads-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Thread Pool Threads",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Number of work items queued to the .NET thread pool.",
+      "fillSpans": false,
+      "id": "panel-thread-pool-queue",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "process.runtime.dotnet.thread_pool.queue.length--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "process.runtime.dotnet.thread_pool.queue.length",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "fc2ac2c2-d2e2-4f2c-b2c2-d2e2f2c2c2c1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "fc2ac2c2-d2e2-4f2c-b2c2-d2e2f2c2c2c2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Queue Length",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "panel-thread-pool-queue-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Thread Pool Queue Length",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Count of exceptions thrown by the .NET runtime.",
+      "fillSpans": false,
+      "id": "panel-exception-count",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "process.runtime.dotnet.exceptions.count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "process.runtime.dotnet.exceptions.count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "fd3ad3c3-d3e3-4f3d-b3c3-d3e3f3d3d3c1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "fd3ad3c3-d3e3-4f3d-b3c3-d3e3f3d3d3c2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Exceptions",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "panel-exception-count-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Exception Count",
+      "yAxisUnit": "none"
+    },
+
+    {
+      "description": "",
+      "id": "row-kestrel",
+      "panelTypes": "row",
+      "title": "Kestrel Server",
+      "collapsed": false,
+      "query": {
+        "builder": { "queryData": [], "queryFormulas": [] },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "row-kestrel-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      }
+    },
+    {
+      "description": "Number of active connections currently open on Kestrel.",
+      "fillSpans": false,
+      "id": "panel-kestrel-active-conns",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "kestrel.active_connections--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "kestrel.active_connections",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "last",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "fe4ae4c4-d4e4-4f4e-b4c4-d4e4f4e4e4c1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "fe4ae4c4-d4e4-4f4e-b4c4-d4e4f4e4e4c2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Active Connections",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "panel-kestrel-active-conns-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Kestrel Active Connections",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Number of connections waiting in the Kestrel connection queue.",
+      "fillSpans": false,
+      "id": "panel-kestrel-queue-length",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "kestrel.queued_connections--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "kestrel.queued_connections",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "ff5af5c5-d5e5-4f5f-b5c5-d5e5f5f5f5c1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "ff5af5c5-d5e5-4f5f-b5c5-d5e5f5f5f5c2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Queue Length",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "panel-kestrel-queue-length-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Kestrel Queue Length",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "95th percentile request processing duration on the Kestrel server.",
+      "fillSpans": false,
+      "id": "panel-kestrel-req-duration",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "kestrel.request.duration--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "kestrel.request.duration",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p95",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "a06ba6c6-d6e6-4f6a-b6c6-d6e6f6a6a6c1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "a06ba6c6-d6e6-4f6a-b6c6-d6e6f6a6a6c2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "P95 Duration",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "panel-kestrel-req-duration-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Kestrel Request Duration (P95)",
+      "yAxisUnit": "ns"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a comprehensive ASP.NET Core monitoring dashboard for SigNoz using OTLP metrics.

- **20 panels** across 4 sections: Application Performance, Request & Response, Process Metrics, Kestrel Server
- **2 template variables**: `service_name` and `deployment_environment`
- Covers all metrics from the [issue requirements](https://github.com/SigNoz/signoz/issues/5996): HTTP request rate, latency (P95), error rate, CPU, memory, GC, thread pool, exceptions, and Kestrel server metrics
- Follows SigNoz Query Builder format (no PromQL/ClickHouse SQL)
- Includes detailed README with setup instructions for OpenTelemetry .NET SDK

### Metrics Used

| Category | Metrics |
|----------|---------|
| HTTP Server | `http.server.request.duration`, `http.server.active_requests` |
| Process | `process.cpu.time`, `process.memory.usage` |
| .NET Runtime | `process.runtime.dotnet.gc.collections.count`, `process.runtime.dotnet.gc.heap.size`, `process.runtime.dotnet.thread_pool.threads.count`, `process.runtime.dotnet.thread_pool.queue.length`, `process.runtime.dotnet.exceptions.count` |
| Kestrel | `kestrel.active_connections`, `kestrel.queued_connections`, `kestrel.request.duration` |

Closes SigNoz/signoz#5996

/claim #5996