### PR TITLE
feat(dashboard): Add Istio Service Mesh monitoring dashboard (Prometheus v1)

### DIFF
--- a/istio/README.md
+++ b/istio/README.md
@@ -1,0 +1,174 @@
+# Istio Service Mesh Dashboard for SigNoz
+
+SigNoz dashboard for monitoring Istio service mesh using Prometheus metrics from Envoy sidecars and the Istiod control plane.
+
+## Prerequisites
+
+- Istio installed with default telemetry (Envoy sidecar injection enabled)
+- SigNoz with OpenTelemetry Collector configured with a Prometheus receiver
+- Istio metrics exposed on the standard Envoy stats port (15090)
+
+## Setup: OTel Collector Prometheus Receiver
+
+Add the following to your OpenTelemetry Collector configuration to scrape Istio metrics:
+
+```yaml
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        # Scrape Envoy sidecar metrics from all mesh pods
+        - job_name: 'istio-mesh'
+          kubernetes_sd_configs:
+            - role: pod
+          relabel_configs:
+            - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+              action: keep
+              regex: 'true'
+            - source_labels: [__meta_kubernetes_pod_annotation_sidecar_istio_io_status]
+              action: keep
+              regex: '.+'
+            - source_labels: [__address__]
+              action: replace
+              regex: '([^:]+)(?::\d+)?'
+              replacement: '${1}:15090'
+              target_label: __address__
+            - action: labeldrop
+              regex: '__meta_kubernetes_pod_label_(.+)'
+          metric_relabel_configs:
+            - source_labels: [__name__]
+              regex: 'istio_.*'
+              action: keep
+
+        # Scrape Istiod control plane metrics
+        - job_name: 'istiod'
+          kubernetes_sd_configs:
+            - role: pod
+              namespaces:
+                names: ['istio-system']
+          relabel_configs:
+            - source_labels: [__meta_kubernetes_pod_label_app]
+              action: keep
+              regex: 'istiod'
+            - source_labels: [__address__]
+              action: replace
+              regex: '([^:]+)(?::\d+)?'
+              replacement: '${1}:15014'
+              target_label: __address__
+
+exporters:
+  otlp:
+    endpoint: "<signoz-otel-collector>:4317"
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      exporters: [otlp]
+```
+
+## Enabling Istio Metrics
+
+Istio emits Prometheus metrics by default. Verify with:
+
+```bash
+# Check sidecar stats
+kubectl exec <pod-with-sidecar> -c istio-proxy -- curl -s localhost:15090/stats/prometheus | head -50
+
+# Check Istiod metrics
+kubectl -n istio-system port-forward svc/istiod 15014:15014
+curl -s localhost:15014/metrics | grep pilot_
+```
+
+If metrics are missing, ensure the Istio `Telemetry` API is configured:
+
+```yaml
+apiVersion: telemetry.istio.io/v1alpha1
+kind: Telemetry
+metadata:
+  name: mesh-default
+  namespace: istio-system
+spec:
+  metrics:
+    - providers:
+        - name: prometheus
+```
+
+## Importing the Dashboard
+
+1. Open SigNoz UI
+2. Go to **Dashboards** > **New Dashboard** > **Import JSON**
+3. Upload or paste the contents of `istio-prometheus-v1.json`
+4. Save
+
+## Variables
+
+| Variable | Description | Source Metric |
+|---|---|---|
+| `namespace` | Kubernetes namespace filter. Multi-select, defaults to all. | `istio_requests_total` label `namespace` |
+| `destination_service` | Target service filter. Multi-select, defaults to all. | `istio_requests_total` label `destination_service` |
+| `deployment_environment` | Environment tag from OTel resource attributes (if present). | `istio_requests_total` label `deployment.environment` |
+
+## Panel Reference
+
+### General Overview
+
+| Panel | Type | Metric | Description |
+|---|---|---|---|
+| Total Requests | value | `istio_requests_total` | Aggregate request count across the mesh |
+| Request Rate by Service | graph | `istio_requests_total` sum_rate | Requests/sec grouped by `destination_service` |
+| Average Latency | graph | `istio_request_duration_milliseconds_sum` / `_count` | Mean latency via formula (duration sum rate / count rate) |
+| Error Rate % | graph | `istio_requests_total` (5xx / total) | Percentage of 5xx responses using formula `A*100/B` |
+
+### Traffic Management
+
+| Panel | Type | Metric | Description |
+|---|---|---|---|
+| Request Distribution by Service | graph (stacked) | `istio_requests_total` sum_rate | Traffic share per service |
+| Request Distribution by Response Code | graph (stacked) | `istio_requests_total` sum_rate | Traffic breakdown by HTTP status code |
+| TCP Connections Opened | graph | `istio_tcp_connections_opened_total` sum_rate | Rate of new TCP connections |
+
+### Performance Metrics
+
+| Panel | Type | Metric | Description |
+|---|---|---|---|
+| Latency P50 | graph | `istio_request_duration_milliseconds` p50 | Median request latency |
+| Latency P95 | graph | `istio_request_duration_milliseconds` p95 | 95th percentile latency |
+| Latency P99 | graph | `istio_request_duration_milliseconds` p99 | 99th percentile (tail) latency |
+| Throughput | graph | `istio_requests_total` sum_rate | Total requests/sec across the mesh |
+
+### Error Metrics
+
+| Panel | Type | Metric | Description |
+|---|---|---|---|
+| HTTP 5xx Error Rate by Service | graph | `istio_requests_total` (response_code 5xx) | Server error rate per destination service |
+| HTTP 4xx Rate | graph | `istio_requests_total` (response_code 4xx) | Client error rate |
+| gRPC Error Rate | graph | `istio_requests_total` (grpc_response_status != 0, protocol=grpc) | gRPC-specific error rate |
+
+### Control Plane
+
+| Panel | Type | Metric | Description |
+|---|---|---|---|
+| Connected Proxies | value | `pilot_xds` (Gauge, last) | Number of Envoy proxies connected to Istiod |
+| Config Push Rate by Type | graph (stacked) | `pilot_xds_pushes` sum_rate | xDS push rate grouped by config type (CDS, EDS, LDS, RDS) |
+| Certificate Signing Requests | graph | `citadel_server_csr_count` sum_rate | Rate of mTLS certificate requests |
+
+## Metrics Reference
+
+| Metric | Type | Source |
+|---|---|---|
+| `istio_requests_total` | Counter (Sum) | Envoy sidecar |
+| `istio_request_duration_milliseconds` | Histogram | Envoy sidecar |
+| `istio_request_bytes` | Histogram | Envoy sidecar |
+| `istio_response_bytes` | Histogram | Envoy sidecar |
+| `istio_tcp_connections_opened_total` | Counter (Sum) | Envoy sidecar |
+| `istio_tcp_connections_closed_total` | Counter (Sum) | Envoy sidecar |
+| `istio_tcp_sent_bytes_total` | Counter (Sum) | Envoy sidecar |
+| `istio_tcp_received_bytes_total` | Counter (Sum) | Envoy sidecar |
+| `pilot_xds_pushes` | Counter (Sum) | Istiod |
+| `pilot_xds` | Gauge | Istiod |
+| `pilot_proxy_convergence_time` | Histogram | Istiod |
+| `citadel_server_csr_count` | Counter (Sum) | Istiod (Citadel) |
+| `envoy_cluster_upstream_cx_active` | Gauge | Envoy sidecar |

--- a/istio/istio-prometheus-v1.json
+++ b/istio/istio-prometheus-v1.json
@@ -1,0 +1,1499 @@
+{
+  "description": "Monitor Istio service mesh health, traffic, latency, errors, and control plane metrics using Prometheus metrics from Envoy sidecars and Istiod.",
+  "image": "",
+  "layout": [
+    {"h": 1, "w": 12, "x": 0, "y": 0, "i": "d97209a6-063a-489c-981e-1b2fb142b3db", "moved": false, "static": false},
+    {"h": 3, "w": 3, "x": 0, "y": 1, "i": "818ae600-a9d0-4c1e-a1c2-a2c55758fbca", "moved": false, "static": false},
+    {"h": 3, "w": 3, "x": 3, "y": 1, "i": "126c4e42-3612-414e-9493-7ed94b6ca37f", "moved": false, "static": false},
+    {"h": 3, "w": 3, "x": 6, "y": 1, "i": "b8402900-4f12-4c82-8cf9-b7b6debc3c61", "moved": false, "static": false},
+    {"h": 3, "w": 3, "x": 9, "y": 1, "i": "7c08b460-9b3f-430e-a8b2-8f8f9374186a", "moved": false, "static": false},
+    {"h": 1, "w": 12, "x": 0, "y": 4, "i": "d01aa902-c9bf-48d3-ae45-a71a6f33956e", "moved": false, "static": false},
+    {"h": 3, "w": 4, "x": 0, "y": 5, "i": "dd28b37b-f6ee-4032-b4c8-6418feb03c09", "moved": false, "static": false},
+    {"h": 3, "w": 4, "x": 4, "y": 5, "i": "44e0f749-a08a-47f0-a69a-d13896b5d940", "moved": false, "static": false},
+    {"h": 3, "w": 4, "x": 8, "y": 5, "i": "4d0d3356-f8d5-46db-9987-cb4e0b9b5774", "moved": false, "static": false},
+    {"h": 1, "w": 12, "x": 0, "y": 8, "i": "2b9225db-1941-4f18-8b91-d1668696cfa0", "moved": false, "static": false},
+    {"h": 3, "w": 3, "x": 0, "y": 9, "i": "76a19610-073a-4f76-8de4-32671369ea00", "moved": false, "static": false},
+    {"h": 3, "w": 3, "x": 3, "y": 9, "i": "1e25ce7c-b32d-4789-8094-6f66a6971a6d", "moved": false, "static": false},
+    {"h": 3, "w": 3, "x": 6, "y": 9, "i": "e31650bc-29ed-41aa-81b6-634938b40542", "moved": false, "static": false},
+    {"h": 3, "w": 3, "x": 9, "y": 9, "i": "1180673b-80d0-4bc9-9ff1-3a611a21337c", "moved": false, "static": false},
+    {"h": 1, "w": 12, "x": 0, "y": 12, "i": "239a1091-a576-47d0-b14d-f2dc7a941d28", "moved": false, "static": false},
+    {"h": 3, "w": 4, "x": 0, "y": 13, "i": "dd2f33bc-f519-412f-b846-fa785e6d7b0e", "moved": false, "static": false},
+    {"h": 3, "w": 4, "x": 4, "y": 13, "i": "b0ef9564-5668-492f-8d29-2da0ef026ff3", "moved": false, "static": false},
+    {"h": 3, "w": 4, "x": 8, "y": 13, "i": "c91d937a-5f0c-4102-924d-5f716bbb9268", "moved": false, "static": false},
+    {"h": 1, "w": 12, "x": 0, "y": 16, "i": "5a4a4b84-009e-41d5-9127-e3e05e867a05", "moved": false, "static": false},
+    {"h": 3, "w": 4, "x": 0, "y": 17, "i": "1418f4cc-27a0-4d85-9a90-f5b9d45edae3", "moved": false, "static": false},
+    {"h": 3, "w": 4, "x": 4, "y": 17, "i": "e3ea27c5-3ee8-47e1-86d7-aaa7c816aa31", "moved": false, "static": false},
+    {"h": 3, "w": 4, "x": 8, "y": 17, "i": "7c1de646-9264-4132-b7fd-b3ad74f5401a", "moved": false, "static": false}
+  ],
+  "panelMap": {},
+  "tags": ["istio", "service-mesh", "envoy", "prometheus"],
+  "title": "Istio Service Mesh",
+  "uploadedGrafana": false,
+  "uuid": "d2435e65-36af-4851-a433-b6666e914922",
+  "variables": {
+    "90741dca-e5ed-44f9-8cf6-724ec2de789b": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Kubernetes namespace to filter Istio metrics",
+      "id": "90741dca-e5ed-44f9-8cf6-724ec2de789b",
+      "key": "90741dca-e5ed-44f9-8cf6-724ec2de789b",
+      "modificationUUID": "0b87a9f5-5bfd-4ab3-8e15-6032098f8648",
+      "multiSelect": true,
+      "name": "namespace",
+      "order": 0,
+      "queryValue": "SELECT JSONExtractString(labels, 'namespace') AS namespace\nFROM signoz_metrics.distributed_time_series_v4_1day\nWHERE metric_name = 'istio_requests_total'\nGROUP BY namespace",
+      "selectedValue": [""],
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "994df8bb-eb1b-41bd-b611-4a598c6951ce": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Destination service name for filtering traffic",
+      "id": "994df8bb-eb1b-41bd-b611-4a598c6951ce",
+      "key": "994df8bb-eb1b-41bd-b611-4a598c6951ce",
+      "modificationUUID": "8e969742-157a-4a54-8190-bf4f3e63f11a",
+      "multiSelect": true,
+      "name": "destination_service",
+      "order": 1,
+      "queryValue": "SELECT JSONExtractString(labels, 'destination_service') AS destination_service\nFROM signoz_metrics.distributed_time_series_v4_1day\nWHERE metric_name = 'istio_requests_total'\nGROUP BY destination_service",
+      "selectedValue": [""],
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "a97b509a-094d-4df0-afce-f637b3ad8881": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Deployment environment tag (if available via OTel resource attributes)",
+      "id": "a97b509a-094d-4df0-afce-f637b3ad8881",
+      "key": "a97b509a-094d-4df0-afce-f637b3ad8881",
+      "modificationUUID": "9a2d4b35-50e2-4c17-9497-99ec300779b7",
+      "multiSelect": true,
+      "name": "deployment_environment",
+      "order": 2,
+      "queryValue": "SELECT JSONExtractString(labels, 'deployment.environment') AS `deployment.environment`\nFROM signoz_metrics.distributed_time_series_v4_1day\nWHERE metric_name = 'istio_requests_total'\nGROUP BY `deployment.environment`",
+      "selectedValue": [""],
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "version": "v5",
+  "widgets": [
+    {
+      "id": "d97209a6-063a-489c-981e-1b2fb142b3db",
+      "panelTypes": "row",
+      "title": "General Overview",
+      "description": "High-level request volume, rate, latency, and error metrics across the mesh",
+      "collapsed": false
+    },
+    {
+      "description": "Total number of requests processed across the entire mesh",
+      "fillSpans": false,
+      "id": "818ae600-a9d0-4c1e-a1c2-a2c55758fbca",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "a1b2c3d4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.namespace}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Total Requests",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "1591f873-5a46-40dc-9e1e-3f087533199c",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Requests",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Rate of requests per second grouped by destination service",
+      "fillSpans": false,
+      "id": "126c4e42-3612-414e-9493-7ed94b6ca37f",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b2c3d4e5",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.namespace}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "destination_service--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "destination_service",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{destination_service}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "9144e6b9-0816-4ed9-ba7a-6ebb90bad5cd",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Rate by Service",
+      "yAxisUnit": "ops"
+    },
+    {
+      "description": "Average request latency computed as duration sum / duration count",
+      "fillSpans": false,
+      "id": "b8402900-4f12-4c82-8cf9-b7b6debc3c61",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_request_duration_milliseconds_sum--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_request_duration_milliseconds_sum",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "c3d4e5f6",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.namespace}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_request_duration_milliseconds_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_request_duration_milliseconds_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d4e5f6a7",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.namespace}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "A/B",
+              "legend": "Avg Latency",
+              "queryName": "F1"
+            }
+          ]
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "172e6421-5f9b-4cc8-bb85-e603641e5871",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Average Latency",
+      "yAxisUnit": "ms"
+    },
+    {
+      "description": "Percentage of 5xx errors out of total requests",
+      "fillSpans": false,
+      "id": "7c08b460-9b3f-430e-a8b2-8f8f9374186a",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "e5f6a7b8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.namespace}}"]
+                  },
+                  {
+                    "id": "f6a7b8c9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "response_code--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "response_code",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["500", "501", "502", "503", "504"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "a7b8c9d0",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.namespace}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "A*100/B",
+              "legend": "Error %",
+              "queryName": "F1"
+            }
+          ]
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "1a7d6a7b-89c6-44b4-9eac-cdf10db65102",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Error Rate %",
+      "yAxisUnit": "percent"
+    },
+    {
+      "id": "d01aa902-c9bf-48d3-ae45-a71a6f33956e",
+      "panelTypes": "row",
+      "title": "Traffic Management",
+      "description": "Request distribution across services, response codes, and TCP connections",
+      "collapsed": false
+    },
+    {
+      "description": "Request rate broken down by destination service",
+      "fillSpans": false,
+      "id": "dd28b37b-f6ee-4032-b4c8-6418feb03c09",
+      "isStacked": true,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b8c9d0e1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.namespace}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "destination_service--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "destination_service",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{destination_service}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "1db2b1e4-c1f3-43f1-a3e2-f6c026480dca",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Distribution by Service",
+      "yAxisUnit": "ops"
+    },
+    {
+      "description": "Request rate broken down by HTTP response code",
+      "fillSpans": false,
+      "id": "44e0f749-a08a-47f0-a69a-d13896b5d940",
+      "isStacked": true,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "c9d0e1f2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.namespace}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "response_code--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "response_code",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "HTTP {{response_code}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "45954557-e0b9-484b-bde7-30d5bf1e2e79",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Distribution by Response Code",
+      "yAxisUnit": "ops"
+    },
+    {
+      "description": "Rate of TCP connections opened across the mesh",
+      "fillSpans": false,
+      "id": "4d0d3356-f8d5-46db-9987-cb4e0b9b5774",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_tcp_connections_opened_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_tcp_connections_opened_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d0e1f2a3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.namespace}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "TCP Connections Opened",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "74547723-249d-444b-955d-e91eb429fdb2",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "TCP Connections Opened",
+      "yAxisUnit": "ops"
+    },
+    {
+      "id": "2b9225db-1941-4f18-8b91-d1668696cfa0",
+      "panelTypes": "row",
+      "title": "Performance Metrics",
+      "description": "Latency percentiles and throughput",
+      "collapsed": false
+    },
+    {
+      "description": "50th percentile (median) request latency",
+      "fillSpans": false,
+      "id": "76a19610-073a-4f76-8de4-32671369ea00",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_request_duration_milliseconds--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_request_duration_milliseconds",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p50",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "e1f2a3b4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.namespace}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "P50",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "p50"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "e69b83d9-b837-464c-9777-670ec8c3a4d7",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Latency P50",
+      "yAxisUnit": "ms"
+    },
+    {
+      "description": "95th percentile request latency",
+      "fillSpans": false,
+      "id": "1e25ce7c-b32d-4789-8094-6f66a6971a6d",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_request_duration_milliseconds--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_request_duration_milliseconds",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p95",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f2a3b4c5",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.namespace}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "P95",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "p95"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "80e9faa9-b150-42d1-80a2-4620c5a42b25",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Latency P95",
+      "yAxisUnit": "ms"
+    },
+    {
+      "description": "99th percentile request latency — tail latency indicator",
+      "fillSpans": false,
+      "id": "e31650bc-29ed-41aa-81b6-634938b40542",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_request_duration_milliseconds--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_request_duration_milliseconds",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p99",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "a3b4c5d6",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.namespace}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "P99",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "p99"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "0c99b8ff-010e-49ea-8dfc-74a5b152f1c4",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Latency P99",
+      "yAxisUnit": "ms"
+    },
+    {
+      "description": "Overall request throughput across the mesh",
+      "fillSpans": false,
+      "id": "1180673b-80d0-4bc9-9ff1-3a611a21337c",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b4c5d6e7",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.namespace}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Throughput",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "550ed974-0d4d-4f5d-ad8f-4dc76d418800",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Throughput",
+      "yAxisUnit": "ops"
+    },
+    {
+      "id": "239a1091-a576-47d0-b14d-f2dc7a941d28",
+      "panelTypes": "row",
+      "title": "Error Metrics",
+      "description": "HTTP 5xx, 4xx, and gRPC error rates",
+      "collapsed": false
+    },
+    {
+      "description": "Rate of HTTP 5xx errors grouped by destination service",
+      "fillSpans": false,
+      "id": "dd2f33bc-f519-412f-b846-fa785e6d7b0e",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "c5d6e7f8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.namespace}}"]
+                  },
+                  {
+                    "id": "d6e7f8a9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "response_code--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "response_code",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["500", "501", "502", "503", "504"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "destination_service--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "destination_service",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{destination_service}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "45324285-3f9e-4cf3-8d9a-944c5bcaa64d",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "HTTP 5xx Error Rate by Service",
+      "yAxisUnit": "ops"
+    },
+    {
+      "description": "Rate of HTTP 4xx client errors",
+      "fillSpans": false,
+      "id": "b0ef9564-5668-492f-8d29-2da0ef026ff3",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "e7f8a9b0",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.namespace}}"]
+                  },
+                  {
+                    "id": "f8a9b0c1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "response_code--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "response_code",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["400", "401", "403", "404", "405", "408", "429"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "HTTP 4xx",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "96a1b2c6-c7a3-4f8c-bf45-b65607f9e555",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "HTTP 4xx Rate",
+      "yAxisUnit": "ops"
+    },
+    {
+      "description": "Rate of gRPC errors (non-zero grpc_response_status)",
+      "fillSpans": false,
+      "id": "c91d937a-5f0c-4102-924d-5f716bbb9268",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "a9b0c1d2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.namespace}}"]
+                  },
+                  {
+                    "id": "b0c1d2e3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "grpc_response_status--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "grpc_response_status",
+                      "type": "tag"
+                    },
+                    "op": "nin",
+                    "value": ["0", ""]
+                  },
+                  {
+                    "id": "c1d2e3f4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "request_protocol--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "request_protocol",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["grpc"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "gRPC Errors",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "e66164c7-3d9a-49dc-a2ca-adf70ad69ac3",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "gRPC Error Rate",
+      "yAxisUnit": "ops"
+    },
+    {
+      "id": "5a4a4b84-009e-41d5-9127-e3e05e867a05",
+      "panelTypes": "row",
+      "title": "Control Plane",
+      "description": "Istiod (Pilot) and Citadel health metrics",
+      "collapsed": false
+    },
+    {
+      "description": "Number of Envoy proxies currently connected to Istiod",
+      "fillSpans": false,
+      "id": "1418f4cc-27a0-4d85-9a90-f5b9d45edae3",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "pilot_xds--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "pilot_xds",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "last",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Connected Proxies",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "a0e07ba4-3f43-437a-8f48-74453175e4c0",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Connected Proxies",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Rate of xDS configuration pushes from Istiod grouped by push type",
+      "fillSpans": false,
+      "id": "e3ea27c5-3ee8-47e1-86d7-aaa7c816aa31",
+      "isStacked": true,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "pilot_xds_pushes--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "pilot_xds_pushes",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "type--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "type",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{type}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "95b4d890-c3e2-416a-b8b0-ba5f33aba879",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Config Push Rate by Type",
+      "yAxisUnit": "ops"
+    },
+    {
+      "description": "Rate of certificate signing requests handled by Citadel",
+      "fillSpans": false,
+      "id": "7c1de646-9264-4132-b7fd-b3ad74f5401a",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "citadel_server_csr_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "citadel_server_csr_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "CSR Rate",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "97ece474-cb2d-4dd9-9041-d6e8dcbea39c",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Certificate Signing Requests",
+      "yAxisUnit": "ops"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a comprehensive Istio Service Mesh monitoring dashboard for SigNoz using Prometheus metrics from Envoy sidecars and the Istio control plane.

- **22 widgets** (17 metric panels + 5 section rows) across 5 sections
- **3 template variables**: `namespace`, `destination_service`, `deployment_environment`
- Formula panels for derived metrics (average latency from sum/count, error rate %)
- Histogram percentile panels (P50, P95, P99) for request duration

### Sections & Metrics

| Section | Panels | Key Metrics |
|---------|--------|-------------|
| General Overview | Total Requests, Request Rate, Avg Latency, Error Rate | `istio_requests_total`, `istio_request_duration_milliseconds` |
| Traffic Management | Distribution by Service, by Response Code, TCP Connections | `istio_requests_total`, `istio_tcp_connections_opened_total` |
| Performance Metrics | Latency P50/P95/P99, Throughput | `istio_request_duration_milliseconds` |
| Error Metrics | HTTP 5xx by Service, HTTP 4xx, gRPC Errors | `istio_requests_total` filtered by response codes |
| Control Plane | Connected Proxies, Config Pushes, Cert Requests | `pilot_xds`, `pilot_xds_pushes`, `citadel_server_csr_count` |

Closes SigNoz/signoz#6025

/claim #6025