### PR TITLE
feat: add Istio monitoring dashboard (prometheus)

### DIFF
--- a/istio/README.md
+++ b/istio/README.md
@@ -1,0 +1,127 @@
+# Istio Monitoring Dashboard for SigNoz
+
+Comprehensive Istio service mesh monitoring dashboard covering traffic, performance, errors, resource usage, control plane, data plane, and security metrics.
+
+## Prerequisites
+
+- [Istio](https://istio.io/latest/docs/setup/install/) service mesh installed in your Kubernetes cluster
+- Istio configured to expose [Prometheus metrics](https://istio.io/latest/docs/reference/config/metrics/)
+- SigNoz collector running and accessible
+
+### 1. Deploy OpenTelemetry Collector with Prometheus Receiver
+
+Deploy the OTel Collector in your Kubernetes cluster to scrape Istio metrics and forward them to SigNoz:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-collector-config
+  namespace: istio-system
+data:
+  config.yaml: |
+    receivers:
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: 'istiod'
+              kubernetes_sd_configs:
+                - role: pod
+              relabel_configs:
+                - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app]
+                  action: keep
+                  regex: istio-system;istiod
+                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port]
+                  action: replace
+                  target_label: __address__
+                  regex: (.+)
+                  replacement: $1:15014
+            - job_name: 'envoy-stats'
+              metrics_path: /stats/prometheus
+              kubernetes_sd_configs:
+                - role: pod
+              relabel_configs:
+                - source_labels: [__meta_kubernetes_pod_container_name]
+                  action: keep
+                  regex: istio-proxy
+
+    processors:
+      batch:
+        timeout: 10s
+        send_batch_size: 1024
+
+    exporters:
+      otlp:
+        endpoint: "ingest.<region>.signoz.cloud:443"
+        tls:
+          insecure: false
+        headers:
+          signoz-ingestion-key: "<your-ingestion-key>"
+
+    service:
+      pipelines:
+        metrics:
+          receivers: [prometheus]
+          processors: [batch]
+          exporters: [otlp]
+```
+
+Replace the following:
+
+- `<region>`: Your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
+- `<your-ingestion-key>`: Your [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/)
+
+### 2. Enable Istio Telemetry
+
+Ensure Istio is configured to emit Prometheus metrics (enabled by default):
+
+```yaml
+apiVersion: telemetry.istio.io/v1
+kind: Telemetry
+metadata:
+  name: mesh-default
+  namespace: istio-system
+spec:
+  metrics:
+    - providers:
+        - name: prometheus
+```
+
+## Dashboard Sections
+
+| Section | Panels | Description |
+| --- | --- | --- |
+| **General Overview** | Total Requests, Avg Latency, Pod Restarts, Request Rate, Error Rate | High-level service mesh health |
+| **Traffic Management** | Request Distribution by Service, Retries | Traffic routing and retry behavior |
+| **Performance Metrics** | Latency P50/P95/P99, Throughput | Detailed latency percentiles and throughput |
+| **Error Metrics** | HTTP 4xx/5xx Errors, gRPC Errors | Error breakdown by type and protocol |
+| **Resource Usage** | CPU Usage, Memory Usage | Istio sidecar and control plane resource consumption |
+| **Control Plane** | Pilot xDS Pushes, Convergence Time | Istiod configuration distribution health |
+| **Data Plane** | TCP Connections, TCP Traffic | Envoy sidecar network activity |
+| **Security** | mTLS vs Plaintext Traffic | Connection security policy distribution |
+
+## Dashboard Variables
+
+| Variable                  | Description              |
+| ------------------------- | ------------------------ |
+| `$namespace`              | Kubernetes namespace     |
+| `$service.name`           | Service name             |
+| `$cluster`                | Cluster name             |
+| `$deployment_environment` | Deployment environment   |
+
+## Metrics Reference
+
+This dashboard uses standard [Istio metrics](https://istio.io/latest/docs/reference/config/metrics/):
+
+- `istio_requests_total` — Total request count
+- `istio_request_duration_milliseconds` — Request duration histogram
+- `istio_request_retries_total` — Request retry count
+- `istio_tcp_connections_opened_total` / `istio_tcp_connections_closed_total` — TCP connections
+- `istio_tcp_sent_bytes_total` / `istio_tcp_received_bytes_total` — TCP traffic
+- `pilot_xds_pushes` — Control plane xDS push count
+- `pilot_proxy_convergence_time_sum` — Proxy convergence time
+
+## Screenshot
+
+<!-- Dashboard screenshot placeholder -->
+![Istio Dashboard](assets/istio-dashboard-preview.png)

--- a/istio/istio-prometheus-v1.json
+++ b/istio/istio-prometheus-v1.json
@@ -1,0 +1,3272 @@
+{
+  "description": "Comprehensive Istio service mesh monitoring dashboard with traffic, performance, error, resource, control plane, data plane, and security metrics.",
+  "image": "",
+  "layout": [
+    {
+      "h": 1,
+      "i": "a8bbbff8-001f-4d10-a809-d07f7c337df7",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 6,
+      "i": "745d3cab-c83c-4780-8f9a-55a3cb7f97d8",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 1
+    },
+    {
+      "h": 6,
+      "i": "8589e5d2-6f72-4801-b66f-8b198ade017f",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 1
+    },
+    {
+      "h": 6,
+      "i": "43f6b5d1-fe7e-41a5-972a-d0eb8df82b42",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 1
+    },
+    {
+      "h": 6,
+      "i": "4882820e-f0b2-490a-8eae-9626e3d2ee5c",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 7
+    },
+    {
+      "h": 6,
+      "i": "29694c17-6276-4b68-a983-d2c63ef07850",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 7
+    },
+    {
+      "h": 1,
+      "i": "24808606-06fa-49ad-a8c0-7eec2782201f",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 13
+    },
+    {
+      "h": 6,
+      "i": "782bbc17-3f9b-4c78-96f3-1dd20efb8abe",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 14
+    },
+    {
+      "h": 6,
+      "i": "f0cd07da-8392-4005-91ce-58513bea0493",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 14
+    },
+    {
+      "h": 1,
+      "i": "fadecd9c-281d-4c3e-a52e-4d89bd5bee53",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 20
+    },
+    {
+      "h": 6,
+      "i": "a21e10eb-a293-433f-8b85-1bad68e8aaa0",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 21
+    },
+    {
+      "h": 6,
+      "i": "509116c9-a48f-4f02-bf34-9ddf9ad7b4d1",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 21
+    },
+    {
+      "h": 1,
+      "i": "2c002d64-8982-4799-8265-5d8767dca5e5",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 27
+    },
+    {
+      "h": 6,
+      "i": "5e5d2757-647a-4351-8930-7cf85896c8af",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 28
+    },
+    {
+      "h": 6,
+      "i": "2a108c23-0d20-40a5-9cc1-f3e41250b8e4",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 28
+    },
+    {
+      "h": 1,
+      "i": "3f68b444-cc52-44ee-a541-1b765dabd880",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 34
+    },
+    {
+      "h": 6,
+      "i": "bebc1199-fada-49d6-b740-da6a62e5ba7b",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 35
+    },
+    {
+      "h": 6,
+      "i": "78d917b6-8cdb-4cdb-bf3f-dbc12cbea7c8",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 35
+    },
+    {
+      "h": 1,
+      "i": "aba77c4a-2bb3-4aef-9ba2-d222c7a71477",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 41
+    },
+    {
+      "h": 6,
+      "i": "81d3240c-9423-4a36-9a4a-232e70e23132",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 42
+    },
+    {
+      "h": 6,
+      "i": "d7c01dce-6263-4d79-96c9-ecdfba8500b1",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 42
+    },
+    {
+      "h": 1,
+      "i": "17ffabfc-243b-4f84-93c9-074c88f4b5f4",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 48
+    },
+    {
+      "h": 6,
+      "i": "6d7ad40e-320b-4bf8-9c20-98deba3884a1",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 49
+    },
+    {
+      "h": 6,
+      "i": "686033b0-44ef-4305-9ff4-73b2e0a156f5",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 49
+    },
+    {
+      "h": 1,
+      "i": "fb18d3d9-92c2-477c-98af-29a8c85e8c6e",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 55
+    },
+    {
+      "h": 6,
+      "i": "edc514b7-2ffd-4c6b-afdb-20c95bbd1d25",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 56
+    }
+  ],
+  "panelMap": {
+    "a8bbbff8-001f-4d10-a809-d07f7c337df7": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "745d3cab-c83c-4780-8f9a-55a3cb7f97d8",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 0,
+          "y": 1
+        },
+        {
+          "h": 6,
+          "i": "8589e5d2-6f72-4801-b66f-8b198ade017f",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 4,
+          "y": 1
+        },
+        {
+          "h": 6,
+          "i": "43f6b5d1-fe7e-41a5-972a-d0eb8df82b42",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 8,
+          "y": 1
+        }
+      ]
+    },
+    "24808606-06fa-49ad-a8c0-7eec2782201f": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "782bbc17-3f9b-4c78-96f3-1dd20efb8abe",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 14
+        },
+        {
+          "h": 6,
+          "i": "f0cd07da-8392-4005-91ce-58513bea0493",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 14
+        }
+      ]
+    },
+    "fadecd9c-281d-4c3e-a52e-4d89bd5bee53": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "a21e10eb-a293-433f-8b85-1bad68e8aaa0",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 21
+        },
+        {
+          "h": 6,
+          "i": "509116c9-a48f-4f02-bf34-9ddf9ad7b4d1",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 21
+        }
+      ]
+    },
+    "2c002d64-8982-4799-8265-5d8767dca5e5": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "5e5d2757-647a-4351-8930-7cf85896c8af",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 28
+        },
+        {
+          "h": 6,
+          "i": "2a108c23-0d20-40a5-9cc1-f3e41250b8e4",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 28
+        }
+      ]
+    },
+    "3f68b444-cc52-44ee-a541-1b765dabd880": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "bebc1199-fada-49d6-b740-da6a62e5ba7b",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 35
+        },
+        {
+          "h": 6,
+          "i": "78d917b6-8cdb-4cdb-bf3f-dbc12cbea7c8",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 35
+        }
+      ]
+    },
+    "aba77c4a-2bb3-4aef-9ba2-d222c7a71477": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "81d3240c-9423-4a36-9a4a-232e70e23132",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 42
+        },
+        {
+          "h": 6,
+          "i": "d7c01dce-6263-4d79-96c9-ecdfba8500b1",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 42
+        }
+      ]
+    },
+    "17ffabfc-243b-4f84-93c9-074c88f4b5f4": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "6d7ad40e-320b-4bf8-9c20-98deba3884a1",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 49
+        },
+        {
+          "h": 6,
+          "i": "686033b0-44ef-4305-9ff4-73b2e0a156f5",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 49
+        }
+      ]
+    },
+    "fb18d3d9-92c2-477c-98af-29a8c85e8c6e": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "edc514b7-2ffd-4c6b-afdb-20c95bbd1d25",
+          "moved": false,
+          "static": false,
+          "w": 12,
+          "x": 0,
+          "y": 56
+        }
+      ]
+    }
+  },
+  "tags": [
+    "istio",
+    "service-mesh",
+    "prometheus"
+  ],
+  "title": "Istio Monitoring Dashboard",
+  "uploadedGrafana": false,
+  "variables": {
+    "6ec13ce5-0027-43c9-bd89-f408518e534c": {
+      "allSelected": false,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "K8s namespace",
+      "dynamicVariablesAttribute": "namespace",
+      "dynamicVariablesSource": "All telemetry",
+      "id": "6ec13ce5-0027-43c9-bd89-f408518e534c",
+      "modificationUUID": "51d7eafe-fa2d-46dd-b0fb-e612200386d6",
+      "multiSelect": false,
+      "name": "namespace",
+      "order": 0,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    },
+    "ba801848-884e-468c-bd95-d27dc53a934c": {
+      "allSelected": false,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Service name",
+      "dynamicVariablesAttribute": "service.name",
+      "dynamicVariablesSource": "All telemetry",
+      "haveCustomValuesSelected": false,
+      "id": "ba801848-884e-468c-bd95-d27dc53a934c",
+      "key": "ba801848-884e-468c-bd95-d27dc53a934c",
+      "modificationUUID": "f1a3f7a6-ba7c-4a18-a18c-1259db209f0e",
+      "multiSelect": false,
+      "name": "service.name",
+      "order": 1,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    },
+    "337ddd7a-647a-44d1-9182-b1edc4fcfc34": {
+      "allSelected": false,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Cluster name",
+      "dynamicVariablesAttribute": "cluster",
+      "dynamicVariablesSource": "All telemetry",
+      "id": "337ddd7a-647a-44d1-9182-b1edc4fcfc34",
+      "key": "337ddd7a-647a-44d1-9182-b1edc4fcfc34",
+      "modificationUUID": "dfe7284e-3cf9-482a-945d-eae699c7db82",
+      "multiSelect": false,
+      "name": "cluster",
+      "order": 2,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    },
+    "b285ac82-51c6-4424-9177-521ce06ebc6b": {
+      "allSelected": false,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Deployment environment",
+      "dynamicVariablesAttribute": "deployment_environment",
+      "dynamicVariablesSource": "All telemetry",
+      "id": "b285ac82-51c6-4424-9177-521ce06ebc6b",
+      "key": "b285ac82-51c6-4424-9177-521ce06ebc6b",
+      "modificationUUID": "8d7b8704-17df-4352-a71f-362c41993aea",
+      "multiSelect": false,
+      "name": "deployment_environment",
+      "order": 3,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    }
+  },
+  "version": "v5",
+  "widgets": [
+    {
+      "description": "",
+      "id": "a8bbbff8-001f-4d10-a809-d07f7c337df7",
+      "panelTypes": "row",
+      "title": "General Overview"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 0,
+      "description": "Total number of Istio HTTP requests",
+      "fillSpans": false,
+      "id": "745d3cab-c83c-4780-8f9a-55a3cb7f97d8",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "istio_requests_total",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": "namespace = $namespace AND cluster = $cluster AND deployment_environment = $deployment_environment AND service.name = $service.name"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "83ceb4b5-5c06-46f2-800c-c9dd43f5091e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Requests",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Average request latency in milliseconds",
+      "fillSpans": false,
+      "id": "8589e5d2-6f72-4801-b66f-8b198ade017f",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "istio_request_duration_milliseconds_sum",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "A",
+              "filter": {
+                "expression": "namespace = $namespace AND cluster = $cluster AND deployment_environment = $deployment_environment AND service.name = $service.name"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "istio_request_duration_milliseconds_count",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "B",
+              "filter": {
+                "expression": "namespace = $namespace AND cluster = $cluster AND deployment_environment = $deployment_environment AND service.name = $service.name"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "A / B",
+              "legend": "Avg latency (ms)",
+              "queryName": "F1"
+            }
+          ],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f12d1871-2498-40d8-9e5d-5cd363dcc0a9",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Average Latency",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 0,
+      "description": "Total pod restarts for Istio containers",
+      "fillSpans": false,
+      "id": "43f6b5d1-fe7e-41a5-972a-d0eb8df82b42",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "kube_pod_container_status_restarts_total",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": "namespace = $namespace AND cluster = $cluster AND deployment_environment = $deployment_environment AND container IN ('istio-proxy', 'discovery')"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a9f092c5-089e-4df9-80b3-1ad05d101c92",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Pod Restarts (Istio)",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "HTTP requests per second",
+      "fillSpans": false,
+      "id": "4882820e-f0b2-490a-8eae-9626e3d2ee5c",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "istio_requests_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": "namespace = $namespace AND cluster = $cluster AND deployment_environment = $deployment_environment AND service.name = $service.name"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Requests/sec",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ad28ffba-b690-4047-90dc-0c51ff272075",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Rate",
+      "yAxisUnit": "{req}/s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Percentage of 5xx errors over total requests",
+      "fillSpans": false,
+      "id": "29694c17-6276-4b68-a983-d2c63ef07850",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "istio_requests_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "A",
+              "filter": {
+                "expression": "namespace = $namespace AND cluster = $cluster AND deployment_environment = $deployment_environment AND service.name = $service.name AND response_code LIKE '5%'"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "istio_requests_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "B",
+              "filter": {
+                "expression": "namespace = $namespace AND cluster = $cluster AND deployment_environment = $deployment_environment AND service.name = $service.name"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "A / B * 100",
+              "legend": "Error Rate %",
+              "queryName": "F1"
+            }
+          ],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "cb8639fb-9d9c-43b1-ae63-872e8ca9e6c7",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Error Rate (%)",
+      "yAxisUnit": "percent"
+    },
+    {
+      "description": "",
+      "id": "24808606-06fa-49ad-a8c0-7eec2782201f",
+      "panelTypes": "row",
+      "title": "Traffic Management"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Request rate grouped by destination service",
+      "fillSpans": false,
+      "id": "782bbc17-3f9b-4c78-96f3-1dd20efb8abe",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "istio_requests_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": "namespace = $namespace AND cluster = $cluster AND deployment_environment = $deployment_environment"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "destination_service--string--tag",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "destination_service",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{destination_service}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "3fed6a8e-deae-458f-97f4-7a57f8a4f772",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Distribution by Service",
+      "yAxisUnit": "{req}/s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Rate of request retries",
+      "fillSpans": false,
+      "id": "f0cd07da-8392-4005-91ce-58513bea0493",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "istio_request_retries_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": "namespace = $namespace AND cluster = $cluster AND deployment_environment = $deployment_environment AND service.name = $service.name"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Retries/sec",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f20956db-3345-4e5f-b93c-55fbcffdbd0c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Retries",
+      "yAxisUnit": "{req}/s"
+    },
+    {
+      "description": "",
+      "id": "fadecd9c-281d-4c3e-a52e-4d89bd5bee53",
+      "panelTypes": "row",
+      "title": "Performance Metrics"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Request duration percentiles",
+      "fillSpans": false,
+      "id": "a21e10eb-a293-433f-8b85-1bad68e8aaa0",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "istio_request_duration_milliseconds_bucket",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": "namespace = $namespace AND cluster = $cluster AND deployment_environment = $deployment_environment AND service.name = $service.name"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "5bca6618-1764-4118-bee6-1a8bfec58c6c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "P50",
+            "name": "A",
+            "query": "histogram_quantile(0.50, sum(rate(istio_request_duration_milliseconds_bucket{namespace=~\"$namespace\", cluster=~\"$cluster\", deployment_environment=~\"$deployment_environment\"}[5m])) by (le))"
+          },
+          {
+            "disabled": false,
+            "legend": "P95",
+            "name": "B",
+            "query": "histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{namespace=~\"$namespace\", cluster=~\"$cluster\", deployment_environment=~\"$deployment_environment\"}[5m])) by (le))"
+          },
+          {
+            "disabled": false,
+            "legend": "P99",
+            "name": "C",
+            "query": "histogram_quantile(0.99, sum(rate(istio_request_duration_milliseconds_bucket{namespace=~\"$namespace\", cluster=~\"$cluster\", deployment_environment=~\"$deployment_environment\"}[5m])) by (le))"
+          }
+        ],
+        "queryType": "promql",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Latency (P50/P95/P99)",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Total request throughput across all services",
+      "fillSpans": false,
+      "id": "509116c9-a48f-4f02-bf34-9ddf9ad7b4d1",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "istio_requests_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": "namespace = $namespace AND cluster = $cluster AND deployment_environment = $deployment_environment"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Throughput",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d27c6321-bccd-489f-85c1-78221659f9bb",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Throughput",
+      "yAxisUnit": "{req}/s"
+    },
+    {
+      "description": "",
+      "id": "2c002d64-8982-4799-8265-5d8767dca5e5",
+      "panelTypes": "row",
+      "title": "Error Metrics"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Rate of HTTP 4xx and 5xx errors",
+      "fillSpans": false,
+      "id": "5e5d2757-647a-4351-8930-7cf85896c8af",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "istio_requests_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": "namespace = $namespace AND cluster = $cluster AND deployment_environment = $deployment_environment AND service.name = $service.name AND response_code LIKE '4%'"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "response_code--string--tag",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "response_code",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "4xx - {{response_code}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "istio_requests_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filter": {
+                "expression": "namespace = $namespace AND cluster = $cluster AND deployment_environment = $deployment_environment AND service.name = $service.name AND response_code LIKE '5%'"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "response_code--string--tag",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "response_code",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "5xx - {{response_code}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8c191132-d766-4a7a-bc7f-21b9d02b1274",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "HTTP Error Rates (4xx/5xx)",
+      "yAxisUnit": "{errors}/s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Rate of gRPC errors by status code",
+      "fillSpans": false,
+      "id": "2a108c23-0d20-40a5-9cc1-f3e41250b8e4",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "istio_requests_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": "namespace = $namespace AND cluster = $cluster AND deployment_environment = $deployment_environment AND service.name = $service.name AND grpc_response_status != '0' AND request_protocol = 'grpc'"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "grpc_response_status--string--tag",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "grpc_response_status",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "gRPC {{grpc_response_status}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "5b109491-866a-46f9-8dca-9debb0254b52",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "gRPC Error Rate",
+      "yAxisUnit": "{errors}/s"
+    },
+    {
+      "description": "",
+      "id": "3f68b444-cc52-44ee-a541-1b765dabd880",
+      "panelTypes": "row",
+      "title": "Resource Usage"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "CPU usage for Istio proxy and control plane containers",
+      "fillSpans": false,
+      "id": "bebc1199-fada-49d6-b740-da6a62e5ba7b",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "container_cpu_usage_seconds_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": "namespace = $namespace AND cluster = $cluster AND deployment_environment = $deployment_environment AND container IN ('istio-proxy', 'discovery')"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "pod--string--tag",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "pod",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "container--string--tag",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "container",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{pod}} / {{container}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "1c5d630e-010b-4320-893b-d519e4e1ac7d",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "CPU Usage (Istio Containers)",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Memory working set for Istio proxy and control plane containers",
+      "fillSpans": false,
+      "id": "78d917b6-8cdb-4cdb-bf3f-dbc12cbea7c8",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "container_memory_working_set_bytes",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": "namespace = $namespace AND cluster = $cluster AND deployment_environment = $deployment_environment AND container IN ('istio-proxy', 'discovery')"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "pod--string--tag",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "pod",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "container--string--tag",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "container",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{pod}} / {{container}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "3230bd69-18ee-416a-a7b7-c8965935d24f",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memory Usage (Istio Containers)",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "",
+      "id": "aba77c4a-2bb3-4aef-9ba2-d222c7a71477",
+      "panelTypes": "row",
+      "title": "Control Plane"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Rate of xDS configuration pushes by type",
+      "fillSpans": false,
+      "id": "81d3240c-9423-4a36-9a4a-232e70e23132",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "pilot_xds_pushes",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": "namespace = $namespace AND cluster = $cluster AND deployment_environment = $deployment_environment"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "type--string--tag",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "type",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{type}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "847cf5b7-4726-423c-bca6-88ed6ed7160e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Pilot xDS Pushes",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Time for proxy configuration to converge",
+      "fillSpans": false,
+      "id": "d7c01dce-6263-4d79-96c9-ecdfba8500b1",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "pilot_proxy_convergence_time_sum",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": "namespace = $namespace AND cluster = $cluster AND deployment_environment = $deployment_environment"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Convergence time",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9b185ee5-db2a-46c6-9581-235e76ca8da9",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Pilot Proxy Convergence Time",
+      "yAxisUnit": "s"
+    },
+    {
+      "description": "",
+      "id": "17ffabfc-243b-4f84-93c9-074c88f4b5f4",
+      "panelTypes": "row",
+      "title": "Data Plane"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Rate of TCP connections opened and closed",
+      "fillSpans": false,
+      "id": "6d7ad40e-320b-4bf8-9c20-98deba3884a1",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "istio_tcp_connections_opened_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": "namespace = $namespace AND cluster = $cluster AND deployment_environment = $deployment_environment AND service.name = $service.name"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Opened",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "istio_tcp_connections_closed_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filter": {
+                "expression": "namespace = $namespace AND cluster = $cluster AND deployment_environment = $deployment_environment AND service.name = $service.name"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Closed",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0c4ef1a0-03fe-429c-8ba5-fee60bbec6a1",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "TCP Connections",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Rate of TCP bytes sent and received",
+      "fillSpans": false,
+      "id": "686033b0-44ef-4305-9ff4-73b2e0a156f5",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "istio_tcp_sent_bytes_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": "namespace = $namespace AND cluster = $cluster AND deployment_environment = $deployment_environment AND service.name = $service.name"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Sent",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "istio_tcp_received_bytes_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filter": {
+                "expression": "namespace = $namespace AND cluster = $cluster AND deployment_environment = $deployment_environment AND service.name = $service.name"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Received",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "e64ba62a-0747-452c-ad44-aa9ee31234d4",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "TCP Traffic (Sent/Received)",
+      "yAxisUnit": "binBps"
+    },
+    {
+      "description": "",
+      "id": "fb18d3d9-92c2-477c-98af-29a8c85e8c6e",
+      "panelTypes": "row",
+      "title": "Security"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Request rate by connection security policy",
+      "fillSpans": false,
+      "id": "edc514b7-2ffd-4c6b-afdb-20c95bbd1d25",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "istio_requests_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": "namespace = $namespace AND cluster = $cluster AND deployment_environment = $deployment_environment AND connection_security_policy = 'mutual_tls'"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "destination_service--string--tag",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "destination_service",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "mTLS: {{destination_service}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "istio_requests_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filter": {
+                "expression": "namespace = $namespace AND cluster = $cluster AND deployment_environment = $deployment_environment AND connection_security_policy != 'mutual_tls'"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "destination_service--string--tag",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "destination_service",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Plain: {{destination_service}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "bcf724e5-eafb-4c15-b2cd-b68bfb28f9b7",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "mTLS vs Plaintext Traffic",
+      "yAxisUnit": "{req}/s"
+    }
+  ],
+  "uuid": "019d5e57-1aad-739b-9a38-b8c7f41cf638"
+}


### PR DESCRIPTION
## Summary

Adds a comprehensive Istio service mesh monitoring dashboard for SigNoz, using Istio's standard Prometheus metrics.

Closes https://github.com/SigNoz/signoz/issues/6025

### Dashboard Sections (18 panels across 8 sections)

| Section | Panels |
|---------|--------|
| **General Overview** | Total Requests, Average Latency, Pod Restarts, Request Rate, Error Rate |
| **Traffic Management** | Request Distribution by Service, Request Retries |
| **Performance Metrics** | Latency P50/P95/P99, Throughput |
| **Error Metrics** | HTTP Error Rates (4xx/5xx), gRPC Error Rate |
| **Resource Usage** | CPU Usage (Istio Containers), Memory Usage (Istio Containers) |
| **Control Plane** | Pilot xDS Pushes, Pilot Proxy Convergence Time |
| **Data Plane** | TCP Connections, TCP Traffic (Sent/Received) |
| **Security** | mTLS vs Plaintext Traffic |

### Metrics Used

Standard [Istio Prometheus metrics](https://istio.io/latest/docs/reference/config/metrics/):
- `istio_requests_total`, `istio_request_duration_milliseconds_*`
- `istio_request_retries_total`
- `istio_tcp_connections_opened_total`, `istio_tcp_connections_closed_total`
- `istio_tcp_sent_bytes_total`, `istio_tcp_received_bytes_total`
- `pilot_xds_pushes`, `pilot_proxy_convergence_time_sum`
- `container_cpu_usage_seconds_total`, `container_memory_working_set_bytes`
- `kube_pod_container_status_restarts_total`

### Variables

- `$namespace` -- K8s namespace
- `$service.name` -- Service name
- `$cluster` -- Cluster name
- `$deployment_environment` -- Deployment environment

### Files

- `istio/istio-prometheus-v1.json` -- Dashboard JSON (SigNoz query builder format, v5)
- `istio/README.md` -- Setup instructions with OTel Collector config for Istio

## Test plan

- [ ] Import `istio/istio-prometheus-v1.json` into SigNoz
- [ ] Verify all 18 panels render with Istio metrics
- [ ] Verify dashboard variables filter correctly
- [ ] Verify layout has no overlapping panels

/claim #6025