### PR TITLE
feat(dashboard): Add CloudNativePG cluster monitoring dashboard (Prometheus v1)

### DIFF
--- a/cloudnativepg/README.md
+++ b/cloudnativepg/README.md
@@ -1,0 +1,251 @@
+# CloudNativePG Dashboard - Prometheus
+
+Comprehensive monitoring dashboard for [CloudNativePG](https://cloudnative-pg.io/) (CNPG) PostgreSQL clusters running on Kubernetes. This dashboard provides visibility into cluster health, replication, WAL archiving, database activity, storage, checkpoints, buffer cache, locks, backups, PgBouncer connection pooling, and Kubernetes resource usage.
+
+## Metrics Ingestion
+
+CloudNativePG exposes Prometheus metrics natively via its built-in monitoring exporter. To collect these metrics in SigNoz, configure the OpenTelemetry Collector with a Prometheus receiver.
+
+### 1. Enable Monitoring in CloudNativePG
+
+Ensure your CNPG `Cluster` resource has monitoring enabled:
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: my-cluster
+  namespace: cnpg-system
+spec:
+  instances: 3
+  monitoring:
+    enablePodMonitor: true
+    customQueriesConfigMap:
+      - name: cnpg-default-monitoring
+        key: queries
+```
+
+### 2. Configure OpenTelemetry Collector
+
+Add the following receiver to your `otel-collector-config.yaml`:
+
+```yaml
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: 'cloudnativepg'
+          scrape_interval: 30s
+          kubernetes_sd_configs:
+            - role: pod
+          relabel_configs:
+            - source_labels: [__meta_kubernetes_pod_label_cnpg_io_cluster]
+              action: keep
+              regex: .+
+            - source_labels: [__meta_kubernetes_namespace]
+              target_label: namespace
+            - source_labels: [__meta_kubernetes_pod_name]
+              target_label: pod
+            - source_labels: [__meta_kubernetes_pod_label_cnpg_io_cluster]
+              target_label: cluster
+            - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port]
+              action: replace
+              target_label: __address__
+              regex: (.+)
+              replacement: ${1}:9187
+
+exporters:
+  otlp:
+    endpoint: "<signoz-otel-collector-endpoint>:4317"
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      exporters: [otlp]
+```
+
+Replace `<signoz-otel-collector-endpoint>` with your SigNoz OTel Collector address (e.g., `signoz-otel-collector.signoz.svc.cluster.local`).
+
+### 3. PgBouncer Metrics (Optional)
+
+If you use PgBouncer with CNPG, enable it in your cluster spec:
+
+```yaml
+spec:
+  monitoring:
+    enablePodMonitor: true
+  postgresql:
+    pg_hba:
+      - host all all 0.0.0.0/0 md5
+  managed:
+    roles: []
+  # PgBouncer pooler
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Pooler
+metadata:
+  name: my-cluster-pooler
+spec:
+  cluster:
+    name: my-cluster
+  instances: 2
+  type: rw
+  pgbouncer:
+    poolMode: transaction
+    monitoring:
+      enablePodMonitor: true
+```
+
+### 4. Kubernetes Resource Metrics (Optional)
+
+For CPU, memory, and PVC metrics panels, ensure you have the following collectors configured:
+
+```yaml
+receivers:
+  kubeletstats:
+    collection_interval: 30s
+    auth_type: serviceAccount
+    endpoint: "https://${K8S_NODE_NAME}:10250"
+    insecure_skip_verify: true
+    metric_groups:
+      - container
+      - pod
+      - volume
+```
+
+## Variables
+
+- `{{namespace}}` - Kubernetes namespace where CloudNativePG clusters are deployed
+- `{{cluster}}` - CloudNativePG cluster name (maps to the `cnpg.io/cluster` label)
+- `{{instance}}` - CloudNativePG pod/instance name (supports multi-select)
+
+## Dashboard Panels
+
+### Cluster Overview
+| Panel | Type | Description | Key Metrics |
+|-------|------|-------------|-------------|
+| Total Instances | Value | Total CNPG instances | `cnpg_collector_up` |
+| Ready Instances | Value | Instances that are up and serving | `cnpg_collector_up == 1` |
+| Not Ready Instances | Value | Instances that are down (threshold alert if > 0) | `cnpg_collector_up == 0` |
+| Current Primary | Value | Identifies the current primary instance | `cnpg_pg_replication_in_recovery == 0` |
+| Collector Up Status | Graph | Instance availability over time | `cnpg_collector_up` |
+| Instance Roles | Graph | Primary vs replica role per instance | `cnpg_pg_replication_in_recovery` |
+| PostgreSQL Up | Graph | PostgreSQL postmaster availability | `cnpg_pg_postmaster_start_time` |
+| Switchover Count | Value | Failover/switchover events in last hour | `changes(cnpg_pg_replication_in_recovery[1h])` |
+
+### Replication & WAL
+| Panel | Type | Description | Key Metrics |
+|-------|------|-------------|-------------|
+| Replication Lag (bytes) | Graph | Byte lag between primary and replicas | `cnpg_pg_replication_lag` |
+| Replication Lag (seconds) | Graph | Write, flush, and replay lag in seconds | `cnpg_pg_replication_replay_lag_seconds`, `write_lag`, `flush_lag` |
+| WAL Sent vs Received | Graph | LSN positions for sent/written/replayed WAL | `cnpg_pg_replication_sent_lsn`, `write_lsn`, `replay_lsn` |
+| WAL Archiving Rate | Graph | Archive success/failure rate | `cnpg_pg_stat_archiver_archived_count`, `failed_count` |
+| WAL Files Archived | Graph | Cumulative archived WAL files | `cnpg_pg_stat_archiver_archived_count` |
+| WAL Archiving Failures | Graph | Cumulative failed archival attempts | `cnpg_pg_stat_archiver_failed_count` |
+| Seconds Since Last Archival | Graph | Time since last successful archival | `cnpg_pg_stat_archiver_last_archived_time` |
+| Current WAL LSN | Graph | Current and insert WAL positions | `cnpg_pg_wal_current_lsn`, `insert_lsn` |
+| Streaming Replication Connected | Graph | Active streaming replication connections | `cnpg_pg_replication_streaming_replicas` |
+| Replication Slots | Graph | Active and inactive replication slots | `cnpg_pg_replication_slots_active`, `inactive` |
+
+### Database Activity
+| Panel | Type | Description | Key Metrics |
+|-------|------|-------------|-------------|
+| Active Connections | Graph | Currently active connections | `cnpg_pg_stat_activity_connections{state="active"}` |
+| Connections by State | Graph | Stacked view of all connection states | `cnpg_pg_stat_activity_connections` |
+| Max Connections | Graph | Max allowed vs current connections | `cnpg_pg_settings_setting{name="max_connections"}` |
+| Transactions Per Second | Graph | Commit and rollback rates | `cnpg_pg_stat_database_xact_commit`, `xact_rollback` |
+| Transactions Committed | Graph | Cumulative committed transactions | `cnpg_pg_stat_database_xact_commit` |
+| Transactions Rolled Back | Graph | Cumulative rolled-back transactions | `cnpg_pg_stat_database_xact_rollback` |
+| Waiting Connections | Graph | Connections waiting for locks | `cnpg_pg_stat_activity_connections{state="waiting"}` |
+| Idle in Transaction | Graph | Idle-in-transaction connections | `cnpg_pg_stat_activity_connections{state="idle in transaction"}` |
+
+### Database Size & Storage
+| Panel | Type | Description | Key Metrics |
+|-------|------|-------------|-------------|
+| Database Size | Graph | Size per database per instance | `cnpg_pg_database_size_bytes` |
+| Database Size Growth Rate | Graph | Rate of size growth per hour | `deriv(cnpg_pg_database_size_bytes[1h])` |
+| Total Database Size | Value | Sum of all databases per instance | `sum(cnpg_pg_database_size_bytes)` |
+| Table Bloat Estimate | Graph | Dead-to-live tuple ratio per table | `n_dead_tup / (n_live_tup + 1)` |
+| Disk Usage by Tablespace | Graph | Size per tablespace | `cnpg_pg_tablespace_size_bytes` |
+| Temporary File Size | Graph | Temp file bytes per database | `cnpg_pg_stat_database_temp_bytes` |
+| Temporary Files Created Rate | Graph | Rate of temp file creation | `cnpg_pg_stat_database_temp_files` |
+
+### Checkpoint & Maintenance
+| Panel | Type | Description | Key Metrics |
+|-------|------|-------------|-------------|
+| Checkpoints Requested vs Timed | Graph | Forced vs scheduled checkpoints | `cnpg_pg_stat_bgwriter_checkpoints_timed`, `checkpoints_req` |
+| Checkpoint Write Time | Graph | Milliseconds spent writing in checkpoints | `cnpg_pg_stat_bgwriter_checkpoint_write_time` |
+| Checkpoint Sync Time | Graph | Milliseconds spent syncing in checkpoints | `cnpg_pg_stat_bgwriter_checkpoint_sync_time` |
+| Buffers Written by Checkpoint | Graph | Buffers written by checkpoint, backend, bgwriter | `buffers_checkpoint`, `buffers_backend`, `buffers_clean` |
+| Autovacuum Workers Active | Graph | Currently running autovacuum workers | `cnpg_pg_stat_activity_connections{backend_type="autovacuum worker"}` |
+| Dead Tuples by Table | Graph | Top 10 tables by dead tuple count | `cnpg_pg_stat_user_tables_n_dead_tup` |
+| Last Autovacuum Time | Graph | Seconds since last autovacuum per table | `cnpg_pg_stat_user_tables_last_autovacuum` |
+| Last Autoanalyze Time | Graph | Seconds since last autoanalyze per table | `cnpg_pg_stat_user_tables_last_autoanalyze` |
+
+### Buffer Cache & I/O Performance
+| Panel | Type | Description | Key Metrics |
+|-------|------|-------------|-------------|
+| Cache Hit Ratio | Graph | Buffer cache hit % (target: >99%) | `blks_hit / (blks_hit + blks_read)` |
+| Blocks Read vs Hit | Graph | Disk reads vs buffer hits rate | `cnpg_pg_stat_database_blks_read`, `blks_hit` |
+| Backend Buffers Written | Graph | Buffers written directly by backends | `cnpg_pg_stat_bgwriter_buffers_backend` |
+| Backend Fsync Count | Graph | Fsyncs by backends (should be 0) | `cnpg_pg_stat_bgwriter_buffers_backend_fsync` |
+| Rows Fetched Rate | Graph | Rows returned by queries | `cnpg_pg_stat_database_tup_fetched` |
+| Rows Inserted Rate | Graph | Row insert rate per database | `cnpg_pg_stat_database_tup_inserted` |
+| Rows Updated Rate | Graph | Row update rate per database | `cnpg_pg_stat_database_tup_updated` |
+| Rows Deleted Rate | Graph | Row delete rate per database | `cnpg_pg_stat_database_tup_deleted` |
+
+### Locks & Conflicts
+| Panel | Type | Description | Key Metrics |
+|-------|------|-------------|-------------|
+| Locks by Mode | Graph | Stacked lock count per mode | `cnpg_pg_locks_count` |
+| Exclusive Locks | Graph | AccessExclusive and Exclusive locks | `cnpg_pg_locks_count{mode=~".*Exclusive.*"}` |
+| Deadlocks | Graph | Deadlock detection rate | `cnpg_pg_stat_database_deadlocks` |
+| Conflicts | Graph | Query cancellations from recovery conflicts | `cnpg_pg_stat_database_conflicts` |
+| Waiting Queries | Graph | Queries blocked on lock waits | `cnpg_pg_stat_activity_connections{wait_event_type="Lock"}` |
+| Long Running Queries | Graph | Queries running > 5 minutes | `cnpg_pg_long_running_queries` |
+
+### Backup & Recovery
+| Panel | Type | Description | Key Metrics |
+|-------|------|-------------|-------------|
+| Last Backup Duration | Value | Duration of most recent backup | `cnpg_pg_last_backup_duration_seconds` |
+| Time Since Last Backup | Graph | Seconds since last successful backup | `cnpg_pg_last_backup_timestamp` |
+| Backup Size | Value | Size of most recent backup | `cnpg_pg_last_backup_size_bytes` |
+| WAL Segment Size | Value | WAL segment file size | `cnpg_pg_wal_segment_size_bytes` |
+| Last Backup Success | Graph | Backup success/failure status | `cnpg_pg_last_backup_success` |
+| Backup History Timeline | Graph | Historical backup durations | `cnpg_pg_last_backup_duration_seconds` |
+
+### PgBouncer Connection Pooling
+| Panel | Type | Description | Key Metrics |
+|-------|------|-------------|-------------|
+| PgBouncer Active Connections | Graph | Active server connections in pools | `cnpg_pgbouncer_pool_server_active_connections` |
+| PgBouncer Client Connections | Graph | Client active and waiting connections | `cnpg_pgbouncer_pool_client_active_connections`, `waiting` |
+| PgBouncer Server Idle | Graph | Idle server connections available | `cnpg_pgbouncer_pool_server_idle_connections` |
+| PgBouncer Max Wait Time | Graph | Maximum client wait time for a connection | `cnpg_pgbouncer_pool_max_wait_seconds` |
+| PgBouncer Total Queries | Graph | Query throughput via PgBouncer | `cnpg_pgbouncer_stats_queries_total` |
+| PgBouncer Query Duration | Graph | Average query duration | `cnpg_pgbouncer_stats_query_avg_duration_seconds` |
+| PgBouncer Bytes In/Out | Graph | Data throughput via PgBouncer | `cnpg_pgbouncer_stats_received_bytes_total`, `sent_bytes` |
+| PgBouncer Login Connections | Graph | Connections in login phase | `cnpg_pgbouncer_pool_server_login_connections` |
+
+### Resource Usage (Kubernetes)
+| Panel | Type | Description | Key Metrics |
+|-------|------|-------------|-------------|
+| CPU Usage by Pod | Graph | Per-pod CPU consumption | `container_cpu_usage_seconds_total` |
+| Memory Usage by Pod | Graph | Per-pod RSS memory | `container_memory_rss` |
+| Memory Working Set | Graph | Working set memory (OOM trigger) | `container_memory_working_set_bytes` |
+| PVC Usage | Graph | Persistent volume used bytes | `kubelet_volume_stats_used_bytes` |
+| PVC Available Space | Graph | Available PVC space | `kubelet_volume_stats_available_bytes` |
+| PVC Capacity | Graph | Total capacity vs used | `kubelet_volume_stats_capacity_bytes` |
+| Network Receive Rate | Graph | Pod network ingress | `container_network_receive_bytes_total` |
+| Network Transmit Rate | Graph | Pod network egress | `container_network_transmit_bytes_total` |
+
+## References
+
+- [CloudNativePG Documentation](https://cloudnative-pg.io/documentation/)
+- [CloudNativePG Monitoring](https://cloudnative-pg.io/documentation/current/monitoring/)
+- [CloudNativePG Grafana Dashboard](https://github.com/cloudnative-pg/grafana-dashboards)
+- [CNPG Prometheus Metrics Reference](https://cloudnative-pg.io/documentation/current/metrics_reference/)
+- [SigNoz Documentation](https://signoz.io/docs/)
+- [OpenTelemetry Collector Prometheus Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver)

--- a/cloudnativepg/cloudnativepg-prometheus-v1.json
+++ b/cloudnativepg/cloudnativepg-prometheus-v1.json
@@ -1,0 +1,11420 @@
+{
+  "description": "Comprehensive monitoring dashboard for CloudNativePG (CNPG) PostgreSQL clusters running on Kubernetes. Covers cluster health, replication, WAL archiving, database activity, storage, checkpoints, buffer cache, locks, backups, PgBouncer connection pooling, and Kubernetes resource usage.",
+  "layout": [
+    {
+      "h": 1,
+      "i": "ec794f95-5926-4736-9d4d-6e902f50b3a0",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 3,
+      "i": "85b2ff91-3fca-4cfe-9f9a-eda11ef04b2e",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 0,
+      "y": 1
+    },
+    {
+      "h": 3,
+      "i": "1daf4820-aa29-498d-ba95-297abc0d3f88",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 3,
+      "y": 1
+    },
+    {
+      "h": 3,
+      "i": "cdbf0e7e-54f5-4aab-adad-aeee15b860fb",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 6,
+      "y": 1
+    },
+    {
+      "h": 3,
+      "i": "1eb3e28c-88ed-495c-ba6e-1931ae1e0750",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 9,
+      "y": 1
+    },
+    {
+      "h": 6,
+      "i": "3d04cda1-7ede-4662-b0c7-d60beed784f2",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 13
+    },
+    {
+      "h": 6,
+      "i": "c4b22c12-6279-44dc-8708-65b5b8151c49",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 13
+    },
+    {
+      "h": 6,
+      "i": "7f640a55-0665-4583-97c7-9856f8f7bd9b",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 19
+    },
+    {
+      "h": 3,
+      "i": "ea75eb6a-12f2-4e71-80a1-9df2d61ead3b",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 9,
+      "y": 4
+    },
+    {
+      "h": 1,
+      "i": "657957b5-d7fc-4548-abf9-65a46c44d1ac",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 25
+    },
+    {
+      "h": 6,
+      "i": "b1916acb-a04d-4bbc-b17c-902ff4c986b6",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 26
+    },
+    {
+      "h": 6,
+      "i": "be766670-74b7-4f6d-828c-3a9a20a764dc",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 26
+    },
+    {
+      "h": 6,
+      "i": "aecff297-c475-405b-9714-dda835278f96",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 32
+    },
+    {
+      "h": 6,
+      "i": "85f1f6ea-e0f2-4cda-8e34-05ee0c492fe8",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 32
+    },
+    {
+      "h": 6,
+      "i": "e6f6c1a8-f8f5-480c-8ccd-b7d542dafe38",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 38
+    },
+    {
+      "h": 6,
+      "i": "50447006-9c59-4234-b8b0-63b047af0822",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 38
+    },
+    {
+      "h": 6,
+      "i": "6dd73c85-4bc3-4a96-8902-e38e0b9e49be",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 44
+    },
+    {
+      "h": 6,
+      "i": "708758e5-cdfe-478b-9db8-d5065bea1879",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 44
+    },
+    {
+      "h": 6,
+      "i": "78ae2637-49bc-4a24-a4e6-4e7993637601",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 50
+    },
+    {
+      "h": 6,
+      "i": "27e90fda-025f-4648-9442-269e6da29f37",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 50
+    },
+    {
+      "h": 1,
+      "i": "454f079f-6c73-487d-b3cb-c067696f2022",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 56
+    },
+    {
+      "h": 6,
+      "i": "8a15104b-515c-45d7-9a0c-f75373eb6fd4",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 57
+    },
+    {
+      "h": 6,
+      "i": "e45a121d-4ee4-48ee-b114-a888e03232ab",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 57
+    },
+    {
+      "h": 6,
+      "i": "8cf043cf-1e97-46df-9175-9ff6d7f4834a",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 63
+    },
+    {
+      "h": 6,
+      "i": "4bba74e2-b54c-488c-98d7-0ad89992effd",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 63
+    },
+    {
+      "h": 6,
+      "i": "8af7399d-1183-4418-bcba-a6346812358f",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 69
+    },
+    {
+      "h": 6,
+      "i": "3d7b25c5-479b-4d1a-a404-7708e3a76ec8",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 69
+    },
+    {
+      "h": 6,
+      "i": "ff080d88-1dca-46ac-a868-9bce77745d8f",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 75
+    },
+    {
+      "h": 6,
+      "i": "cbf51a83-9814-435d-828c-3878af0d570d",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 75
+    },
+    {
+      "h": 1,
+      "i": "cb93490c-0ec7-487b-9326-a06b112a14f6",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 81
+    },
+    {
+      "h": 6,
+      "i": "d6e549a2-c381-4ea6-a2b6-33037edaabeb",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 82
+    },
+    {
+      "h": 6,
+      "i": "c912f3ff-55f4-4437-8732-0ff9bc03161d",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 82
+    },
+    {
+      "h": 3,
+      "i": "c50d9e19-e017-478f-82bd-7576f3d72ec5",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 6,
+      "y": 82
+    },
+    {
+      "h": 6,
+      "i": "1a686d96-585c-4630-bc69-b480310ed685",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 88
+    },
+    {
+      "h": 6,
+      "i": "d3c7a549-8baf-4775-b3f9-b771df2b4241",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 94
+    },
+    {
+      "h": 6,
+      "i": "36ca341a-e3dd-4f9f-a56b-f920c2065108",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 94
+    },
+    {
+      "h": 6,
+      "i": "6937b6d2-b82a-4e64-8c3c-d6f9de8289b4",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 100
+    },
+    {
+      "h": 1,
+      "i": "457300fc-9628-48f3-9717-2a848611e2b3",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 106
+    },
+    {
+      "h": 6,
+      "i": "52de2366-b03d-4e07-a36f-bfb37be1c4ae",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 107
+    },
+    {
+      "h": 6,
+      "i": "d0c7908c-4a59-4686-a361-9bf78052665c",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 107
+    },
+    {
+      "h": 6,
+      "i": "ff7f3415-5cb2-4725-9f40-18f5d821f4db",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 113
+    },
+    {
+      "h": 6,
+      "i": "f2da45aa-b605-42bb-a802-d98d9626b969",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 113
+    },
+    {
+      "h": 6,
+      "i": "59892847-83d5-45b6-8091-1cfb8f860ba4",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 119
+    },
+    {
+      "h": 6,
+      "i": "11604442-257f-4f75-bc92-c2cc6c827ef9",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 119
+    },
+    {
+      "h": 6,
+      "i": "10dbc7e7-a993-4e1c-99ab-c227794f1a48",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 125
+    },
+    {
+      "h": 6,
+      "i": "6f0a714e-4770-4c90-99ad-5a8a9e14fdf9",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 125
+    },
+    {
+      "h": 1,
+      "i": "4bf3dd87-edef-4283-862d-573c8a05888f",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 131
+    },
+    {
+      "h": 6,
+      "i": "21157659-1ee3-41eb-ba3d-79773842815a",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 132
+    },
+    {
+      "h": 6,
+      "i": "4e0c9096-868e-4db0-85c3-890380f0bfb6",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 132
+    },
+    {
+      "h": 6,
+      "i": "32be7b13-d726-40b0-942f-e604676a8f22",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 138
+    },
+    {
+      "h": 6,
+      "i": "ab9a6d41-6056-4223-827b-55342b5121ec",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 138
+    },
+    {
+      "h": 6,
+      "i": "15966807-72cb-4d08-a13d-4c673af6c6ac",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 144
+    },
+    {
+      "h": 6,
+      "i": "970eb46b-818f-41f8-8335-bd6485ff9d31",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 144
+    },
+    {
+      "h": 6,
+      "i": "37ab121c-c622-44ce-a0bb-383cdc3cb3e2",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 150
+    },
+    {
+      "h": 6,
+      "i": "9e46f559-743b-4abf-9439-be6cd4b9fdb6",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 150
+    },
+    {
+      "h": 1,
+      "i": "4b3b7da6-a10f-4fd8-95bc-8dd6b77e05ca",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 156
+    },
+    {
+      "h": 6,
+      "i": "23293a81-4088-42f0-8e8e-64bf43ac84e4",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 157
+    },
+    {
+      "h": 6,
+      "i": "11da5a13-f8c6-4f46-8923-ea622884b496",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 157
+    },
+    {
+      "h": 6,
+      "i": "6190deb5-c4fb-4e0b-a16d-b36e55b06a2e",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 163
+    },
+    {
+      "h": 6,
+      "i": "5cdbbe78-1c04-4097-8908-e00fa324ef8d",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 163
+    },
+    {
+      "h": 6,
+      "i": "0595d09b-c6ed-49a7-93df-b1a85ba3b6df",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 169
+    },
+    {
+      "h": 6,
+      "i": "c63759e3-9712-40d9-8517-9d9241354f6c",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 169
+    },
+    {
+      "h": 1,
+      "i": "b7194674-d25e-45d9-9f29-5c1f3d50b444",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 175
+    },
+    {
+      "h": 3,
+      "i": "98637a27-aed6-4943-8142-c8d0024dd13f",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 0,
+      "y": 176
+    },
+    {
+      "h": 6,
+      "i": "c21597ac-4f65-4ceb-8dab-52ff84268dc1",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 176
+    },
+    {
+      "h": 3,
+      "i": "420c433b-546f-458b-abdf-6eb67e9d1e30",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 6,
+      "y": 176
+    },
+    {
+      "h": 3,
+      "i": "3cade2b6-8a52-494a-a030-19c3c3683775",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 9,
+      "y": 176
+    },
+    {
+      "h": 6,
+      "i": "e8f75f9a-ec72-41a3-9897-f2bd10ff34c3",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 188
+    },
+    {
+      "h": 6,
+      "i": "88d0321b-a823-4ebd-a98f-ead154226198",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 188
+    },
+    {
+      "h": 1,
+      "i": "6701f545-4cac-4c66-8c9c-dc7164324d72",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 194
+    },
+    {
+      "h": 6,
+      "i": "48e8c011-05b2-4080-b9d9-37c873d0148b",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 195
+    },
+    {
+      "h": 6,
+      "i": "368457d0-fa94-4c33-9934-65f883868293",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 195
+    },
+    {
+      "h": 6,
+      "i": "47d9732e-49af-4042-8ad1-a489c9d69b4f",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 201
+    },
+    {
+      "h": 6,
+      "i": "66f85824-d244-440e-b9cb-ad8fa927dede",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 201
+    },
+    {
+      "h": 6,
+      "i": "7ad39707-4aa2-45e8-97d6-4fe9a64a9416",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 207
+    },
+    {
+      "h": 6,
+      "i": "85220bd5-6036-4dac-834e-8b7b38867b39",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 207
+    },
+    {
+      "h": 6,
+      "i": "6484ceba-73df-4538-975e-b2355de27168",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 213
+    },
+    {
+      "h": 6,
+      "i": "055ce9e2-e320-4ed9-82a4-1c0fcc63befa",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 213
+    },
+    {
+      "h": 1,
+      "i": "63f3db70-33db-450a-96a4-340df385af6f",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 219
+    },
+    {
+      "h": 6,
+      "i": "9bf263ba-4b45-4e15-8048-a1971e6b2436",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 220
+    },
+    {
+      "h": 6,
+      "i": "86a857cf-9b2c-48d3-ab19-79f15850a7b8",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 220
+    },
+    {
+      "h": 6,
+      "i": "a2bb7fba-ceba-4d1b-8860-1fcd9bc32884",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 226
+    },
+    {
+      "h": 6,
+      "i": "dc8f83a6-1f4f-45ae-ab39-2861aa7552de",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 226
+    },
+    {
+      "h": 6,
+      "i": "1ab41017-cc4d-40d7-abcd-41f4a5cf85c1",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 232
+    },
+    {
+      "h": 6,
+      "i": "d6cbd7fb-5f4c-4f99-81c3-be0a73e9ef2c",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 232
+    },
+    {
+      "h": 6,
+      "i": "a77d261f-2d9d-4420-8812-bb4016b9c2eb",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 238
+    },
+    {
+      "h": 6,
+      "i": "e30160fc-15ed-401b-8b25-5fc94dae763f",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 238
+    }
+  ],
+  "panelMap": {
+    "ec794f95-5926-4736-9d4d-6e902f50b3a0": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 3,
+          "i": "85b2ff91-3fca-4cfe-9f9a-eda11ef04b2e",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 0,
+          "y": 1
+        },
+        {
+          "h": 3,
+          "i": "1daf4820-aa29-498d-ba95-297abc0d3f88",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 3,
+          "y": 1
+        },
+        {
+          "h": 3,
+          "i": "cdbf0e7e-54f5-4aab-adad-aeee15b860fb",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 6,
+          "y": 1
+        },
+        {
+          "h": 3,
+          "i": "1eb3e28c-88ed-495c-ba6e-1931ae1e0750",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 9,
+          "y": 1
+        },
+        {
+          "h": 6,
+          "i": "3d04cda1-7ede-4662-b0c7-d60beed784f2",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 13
+        },
+        {
+          "h": 6,
+          "i": "c4b22c12-6279-44dc-8708-65b5b8151c49",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 13
+        },
+        {
+          "h": 6,
+          "i": "7f640a55-0665-4583-97c7-9856f8f7bd9b",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 19
+        },
+        {
+          "h": 3,
+          "i": "ea75eb6a-12f2-4e71-80a1-9df2d61ead3b",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 9,
+          "y": 4
+        }
+      ]
+    },
+    "657957b5-d7fc-4548-abf9-65a46c44d1ac": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "b1916acb-a04d-4bbc-b17c-902ff4c986b6",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 26
+        },
+        {
+          "h": 6,
+          "i": "be766670-74b7-4f6d-828c-3a9a20a764dc",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 26
+        },
+        {
+          "h": 6,
+          "i": "aecff297-c475-405b-9714-dda835278f96",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 32
+        },
+        {
+          "h": 6,
+          "i": "85f1f6ea-e0f2-4cda-8e34-05ee0c492fe8",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 32
+        },
+        {
+          "h": 6,
+          "i": "e6f6c1a8-f8f5-480c-8ccd-b7d542dafe38",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 38
+        },
+        {
+          "h": 6,
+          "i": "50447006-9c59-4234-b8b0-63b047af0822",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 38
+        },
+        {
+          "h": 6,
+          "i": "6dd73c85-4bc3-4a96-8902-e38e0b9e49be",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 44
+        },
+        {
+          "h": 6,
+          "i": "708758e5-cdfe-478b-9db8-d5065bea1879",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 44
+        },
+        {
+          "h": 6,
+          "i": "78ae2637-49bc-4a24-a4e6-4e7993637601",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 50
+        },
+        {
+          "h": 6,
+          "i": "27e90fda-025f-4648-9442-269e6da29f37",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 50
+        }
+      ]
+    },
+    "454f079f-6c73-487d-b3cb-c067696f2022": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "8a15104b-515c-45d7-9a0c-f75373eb6fd4",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 57
+        },
+        {
+          "h": 6,
+          "i": "e45a121d-4ee4-48ee-b114-a888e03232ab",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 57
+        },
+        {
+          "h": 6,
+          "i": "8cf043cf-1e97-46df-9175-9ff6d7f4834a",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 63
+        },
+        {
+          "h": 6,
+          "i": "4bba74e2-b54c-488c-98d7-0ad89992effd",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 63
+        },
+        {
+          "h": 6,
+          "i": "8af7399d-1183-4418-bcba-a6346812358f",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 69
+        },
+        {
+          "h": 6,
+          "i": "3d7b25c5-479b-4d1a-a404-7708e3a76ec8",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 69
+        },
+        {
+          "h": 6,
+          "i": "ff080d88-1dca-46ac-a868-9bce77745d8f",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 75
+        },
+        {
+          "h": 6,
+          "i": "cbf51a83-9814-435d-828c-3878af0d570d",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 75
+        }
+      ]
+    },
+    "cb93490c-0ec7-487b-9326-a06b112a14f6": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "d6e549a2-c381-4ea6-a2b6-33037edaabeb",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 82
+        },
+        {
+          "h": 6,
+          "i": "c912f3ff-55f4-4437-8732-0ff9bc03161d",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 82
+        },
+        {
+          "h": 3,
+          "i": "c50d9e19-e017-478f-82bd-7576f3d72ec5",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 6,
+          "y": 82
+        },
+        {
+          "h": 6,
+          "i": "1a686d96-585c-4630-bc69-b480310ed685",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 88
+        },
+        {
+          "h": 6,
+          "i": "d3c7a549-8baf-4775-b3f9-b771df2b4241",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 94
+        },
+        {
+          "h": 6,
+          "i": "36ca341a-e3dd-4f9f-a56b-f920c2065108",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 94
+        },
+        {
+          "h": 6,
+          "i": "6937b6d2-b82a-4e64-8c3c-d6f9de8289b4",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 100
+        }
+      ]
+    },
+    "457300fc-9628-48f3-9717-2a848611e2b3": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "52de2366-b03d-4e07-a36f-bfb37be1c4ae",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 107
+        },
+        {
+          "h": 6,
+          "i": "d0c7908c-4a59-4686-a361-9bf78052665c",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 107
+        },
+        {
+          "h": 6,
+          "i": "ff7f3415-5cb2-4725-9f40-18f5d821f4db",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 113
+        },
+        {
+          "h": 6,
+          "i": "f2da45aa-b605-42bb-a802-d98d9626b969",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 113
+        },
+        {
+          "h": 6,
+          "i": "59892847-83d5-45b6-8091-1cfb8f860ba4",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 119
+        },
+        {
+          "h": 6,
+          "i": "11604442-257f-4f75-bc92-c2cc6c827ef9",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 119
+        },
+        {
+          "h": 6,
+          "i": "10dbc7e7-a993-4e1c-99ab-c227794f1a48",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 125
+        },
+        {
+          "h": 6,
+          "i": "6f0a714e-4770-4c90-99ad-5a8a9e14fdf9",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 125
+        }
+      ]
+    },
+    "4bf3dd87-edef-4283-862d-573c8a05888f": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "21157659-1ee3-41eb-ba3d-79773842815a",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 132
+        },
+        {
+          "h": 6,
+          "i": "4e0c9096-868e-4db0-85c3-890380f0bfb6",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 132
+        },
+        {
+          "h": 6,
+          "i": "32be7b13-d726-40b0-942f-e604676a8f22",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 138
+        },
+        {
+          "h": 6,
+          "i": "ab9a6d41-6056-4223-827b-55342b5121ec",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 138
+        },
+        {
+          "h": 6,
+          "i": "15966807-72cb-4d08-a13d-4c673af6c6ac",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 144
+        },
+        {
+          "h": 6,
+          "i": "970eb46b-818f-41f8-8335-bd6485ff9d31",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 144
+        },
+        {
+          "h": 6,
+          "i": "37ab121c-c622-44ce-a0bb-383cdc3cb3e2",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 150
+        },
+        {
+          "h": 6,
+          "i": "9e46f559-743b-4abf-9439-be6cd4b9fdb6",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 150
+        }
+      ]
+    },
+    "4b3b7da6-a10f-4fd8-95bc-8dd6b77e05ca": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "23293a81-4088-42f0-8e8e-64bf43ac84e4",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 157
+        },
+        {
+          "h": 6,
+          "i": "11da5a13-f8c6-4f46-8923-ea622884b496",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 157
+        },
+        {
+          "h": 6,
+          "i": "6190deb5-c4fb-4e0b-a16d-b36e55b06a2e",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 163
+        },
+        {
+          "h": 6,
+          "i": "5cdbbe78-1c04-4097-8908-e00fa324ef8d",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 163
+        },
+        {
+          "h": 6,
+          "i": "0595d09b-c6ed-49a7-93df-b1a85ba3b6df",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 169
+        },
+        {
+          "h": 6,
+          "i": "c63759e3-9712-40d9-8517-9d9241354f6c",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 169
+        }
+      ]
+    },
+    "b7194674-d25e-45d9-9f29-5c1f3d50b444": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 3,
+          "i": "98637a27-aed6-4943-8142-c8d0024dd13f",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 0,
+          "y": 176
+        },
+        {
+          "h": 6,
+          "i": "c21597ac-4f65-4ceb-8dab-52ff84268dc1",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 176
+        },
+        {
+          "h": 3,
+          "i": "420c433b-546f-458b-abdf-6eb67e9d1e30",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 6,
+          "y": 176
+        },
+        {
+          "h": 3,
+          "i": "3cade2b6-8a52-494a-a030-19c3c3683775",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 9,
+          "y": 176
+        },
+        {
+          "h": 6,
+          "i": "e8f75f9a-ec72-41a3-9897-f2bd10ff34c3",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 188
+        },
+        {
+          "h": 6,
+          "i": "88d0321b-a823-4ebd-a98f-ead154226198",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 188
+        }
+      ]
+    },
+    "6701f545-4cac-4c66-8c9c-dc7164324d72": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "48e8c011-05b2-4080-b9d9-37c873d0148b",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 195
+        },
+        {
+          "h": 6,
+          "i": "368457d0-fa94-4c33-9934-65f883868293",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 195
+        },
+        {
+          "h": 6,
+          "i": "47d9732e-49af-4042-8ad1-a489c9d69b4f",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 201
+        },
+        {
+          "h": 6,
+          "i": "66f85824-d244-440e-b9cb-ad8fa927dede",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 201
+        },
+        {
+          "h": 6,
+          "i": "7ad39707-4aa2-45e8-97d6-4fe9a64a9416",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 207
+        },
+        {
+          "h": 6,
+          "i": "85220bd5-6036-4dac-834e-8b7b38867b39",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 207
+        },
+        {
+          "h": 6,
+          "i": "6484ceba-73df-4538-975e-b2355de27168",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 213
+        },
+        {
+          "h": 6,
+          "i": "055ce9e2-e320-4ed9-82a4-1c0fcc63befa",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 213
+        }
+      ]
+    },
+    "63f3db70-33db-450a-96a4-340df385af6f": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "9bf263ba-4b45-4e15-8048-a1971e6b2436",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 220
+        },
+        {
+          "h": 6,
+          "i": "86a857cf-9b2c-48d3-ab19-79f15850a7b8",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 220
+        },
+        {
+          "h": 6,
+          "i": "a2bb7fba-ceba-4d1b-8860-1fcd9bc32884",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 226
+        },
+        {
+          "h": 6,
+          "i": "dc8f83a6-1f4f-45ae-ab39-2861aa7552de",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 226
+        },
+        {
+          "h": 6,
+          "i": "1ab41017-cc4d-40d7-abcd-41f4a5cf85c1",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 232
+        },
+        {
+          "h": 6,
+          "i": "d6cbd7fb-5f4c-4f99-81c3-be0a73e9ef2c",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 232
+        },
+        {
+          "h": 6,
+          "i": "a77d261f-2d9d-4420-8812-bb4016b9c2eb",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 238
+        },
+        {
+          "h": 6,
+          "i": "e30160fc-15ed-401b-8b25-5fc94dae763f",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 238
+        }
+      ]
+    }
+  },
+  "tags": [
+    "cloudnativepg",
+    "cnpg",
+    "postgresql",
+    "kubernetes",
+    "database",
+    "prometheus"
+  ],
+  "title": "CloudNativePG Cluster Dashboard",
+  "uploadedGrafana": false,
+  "variables": {
+    "15736632-0e29-49d6-9336-aa3ec00a145a": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "Kubernetes namespace where CloudNativePG clusters are deployed",
+      "id": "15736632-0e29-49d6-9336-aa3ec00a145a",
+      "key": "15736632-0e29-49d6-9336-aa3ec00a145a",
+      "modificationUUID": "710c4443-1096-40b5-9d4f-3b0f98cc3bd2",
+      "multiSelect": false,
+      "name": "namespace",
+      "order": 0,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'namespace'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name = 'cnpg_collector_up'",
+      "selectedValue": "",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "20353f96-724d-414f-96a8-0138a5445ca8": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "CloudNativePG cluster name",
+      "id": "20353f96-724d-414f-96a8-0138a5445ca8",
+      "key": "20353f96-724d-414f-96a8-0138a5445ca8",
+      "modificationUUID": "1ea2f716-a9e9-4be6-9dc6-09f232d22c60",
+      "multiSelect": false,
+      "name": "cluster",
+      "order": 1,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'cluster'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name = 'cnpg_collector_up'\nAND JSONExtractString(labels, 'namespace') = '{{.namespace}}'",
+      "selectedValue": "",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "266db9aa-32ae-43b7-97c6-49dc6eae607e": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "CloudNativePG pod/instance name",
+      "id": "266db9aa-32ae-43b7-97c6-49dc6eae607e",
+      "key": "266db9aa-32ae-43b7-97c6-49dc6eae607e",
+      "modificationUUID": "01d6ffb3-ae70-4343-9c9c-39c4d2e0a9f0",
+      "multiSelect": true,
+      "name": "instance",
+      "order": 2,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'pod'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name = 'cnpg_collector_up'\nAND JSONExtractString(labels, 'namespace') = '{{.namespace}}'\nAND JSONExtractString(labels, 'cluster') = '{{.cluster}}'",
+      "selectedValue": "",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "version": "v4",
+  "widgets": [
+    {
+      "description": "CloudNativePG cluster health and status overview",
+      "id": "ec794f95-5926-4736-9d4d-6e902f50b3a0",
+      "panelTypes": "row",
+      "title": "Cluster Overview"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total number of PostgreSQL instances in the CNPG cluster",
+      "fillSpans": false,
+      "id": "85b2ff91-3fca-4cfe-9f9a-eda11ef04b2e",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b97d8e1f-9a3c-4c2b-adbd-7b59889d9b8b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "count(cnpg_collector_up{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\"})"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Instances",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of instances that are ready and serving traffic",
+      "fillSpans": false,
+      "id": "1daf4820-aa29-498d-ba95-297abc0d3f88",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "89079ce8-65c5-407f-9b70-5e31dc067a25",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "sum(cnpg_collector_up{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\"} == 1)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Ready Instances",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of instances that are NOT ready - requires immediate attention if > 0",
+      "fillSpans": false,
+      "id": "cdbf0e7e-54f5-4aab-adad-aeee15b860fb",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a1083abd-9cd0-401d-85f2-a5844b328c87",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "count(cnpg_collector_up{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\"} == 0) OR on() vector(0)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [
+        {
+          "color": "#e74c3c",
+          "index": 0,
+          "isEditEnabled": false,
+          "thresholdFormat": "1",
+          "thresholdOperator": ">",
+          "thresholdUnit": "",
+          "thresholdValue": 0
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Not Ready Instances",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Indicates which instance is currently the primary (value = 1 for primary)",
+      "fillSpans": false,
+      "id": "1eb3e28c-88ed-495c-ba6e-1931ae1e0750",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9740eaaf-4a58-470d-874e-0cfc949c1e9d",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "cnpg_pg_replication_in_recovery{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\"} == 0"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Current Primary",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "CNPG collector up/down status for each instance over time",
+      "fillSpans": false,
+      "id": "3d04cda1-7ede-4662-b0c7-d60beed784f2",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d03b20a1-8ad5-4f05-b49d-e34076b7ebf7",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "cnpg_collector_up{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Collector Up Status",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Shows role of each instance (0 = primary, 1 = replica/standby)",
+      "fillSpans": false,
+      "id": "c4b22c12-6279-44dc-8708-65b5b8151c49",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "09cdfec8-970b-496e-bfda-d36873cd6c62",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "cnpg_pg_replication_in_recovery{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Instance Roles",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "PostgreSQL server availability status per instance",
+      "fillSpans": false,
+      "id": "7f640a55-0665-4583-97c7-9856f8f7bd9b",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "014d62f1-f3d1-41da-9a19-126f0c4e1cf5",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "cnpg_pg_postmaster_start_time{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"} > 0"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "PostgreSQL Up",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total number of switchover/failover events that have occurred",
+      "fillSpans": false,
+      "id": "ea75eb6a-12f2-4e71-80a1-9df2d61ead3b",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6e0bc234-d266-4c42-ae42-c28a94cb9f39",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "sum(changes(cnpg_pg_replication_in_recovery{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\"}[1h]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Switchover Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Write-Ahead Log and replication metrics",
+      "id": "657957b5-d7fc-4548-abf9-65a46c44d1ac",
+      "panelTypes": "row",
+      "title": "Replication & WAL"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Replication lag in bytes between primary and each replica",
+      "fillSpans": false,
+      "id": "b1916acb-a04d-4bbc-b17c-902ff4c986b6",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9d9152f5-2002-4e30-b520-5d332c174980",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "cnpg_pg_replication_lag{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Replication Lag (bytes)",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Estimated replication lag in seconds for each streaming replica",
+      "fillSpans": false,
+      "id": "be766670-74b7-4f6d-828c-3a9a20a764dc",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6a4b66b2-4707-4162-8b3f-9e007fb3de96",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} replay",
+            "name": "A",
+            "query": "cnpg_pg_replication_replay_lag_seconds{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          },
+          {
+            "disabled": false,
+            "legend": "{{pod}} write",
+            "name": "B",
+            "query": "cnpg_pg_replication_write_lag_seconds{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          },
+          {
+            "disabled": false,
+            "legend": "{{pod}} flush",
+            "name": "C",
+            "query": "cnpg_pg_replication_flush_lag_seconds{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Replication Lag (seconds)",
+      "yAxisUnit": "s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "WAL sent by primary and received/replayed by replicas (LSN positions)",
+      "fillSpans": false,
+      "id": "aecff297-c475-405b-9714-dda835278f96",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6fe167c4-1e38-44ea-b659-8b9cc2b13115",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} sent",
+            "name": "A",
+            "query": "cnpg_pg_replication_sent_lsn{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          },
+          {
+            "disabled": false,
+            "legend": "{{pod}} written",
+            "name": "B",
+            "query": "cnpg_pg_replication_write_lsn{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          },
+          {
+            "disabled": false,
+            "legend": "{{pod}} replayed",
+            "name": "C",
+            "query": "cnpg_pg_replication_replay_lsn{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "WAL Sent vs Received",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of WAL files being archived over time",
+      "fillSpans": false,
+      "id": "85f1f6ea-e0f2-4cda-8e34-05ee0c492fe8",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6fadde6e-0830-43b9-a765-1fde76ba6177",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} archived/s",
+            "name": "A",
+            "query": "rate(cnpg_pg_stat_archiver_archived_count{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}[5m])"
+          },
+          {
+            "disabled": false,
+            "legend": "{{pod}} failed/s",
+            "name": "B",
+            "query": "rate(cnpg_pg_stat_archiver_failed_count{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}[5m])"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "WAL Archiving Rate",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Cumulative count of archived WAL files",
+      "fillSpans": false,
+      "id": "e6f6c1a8-f8f5-480c-8ccd-b7d542dafe38",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "52f23300-2121-48f1-89e9-0868fc2f5f77",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "cnpg_pg_stat_archiver_archived_count{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "WAL Files Archived (total)",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Cumulative count of failed WAL archiving attempts - non-zero indicates archival issues",
+      "fillSpans": false,
+      "id": "50447006-9c59-4234-b8b0-63b047af0822",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9525e475-603c-44cf-98d3-66873ab3fdc1",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "cnpg_pg_stat_archiver_failed_count{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "WAL Archiving Failures (total)",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Time since the last successful WAL archival - increasing value indicates archiving problems",
+      "fillSpans": false,
+      "id": "6dd73c85-4bc3-4a96-8902-e38e0b9e49be",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c0698856-f2f9-45c8-94bd-0d34f1e7b2b3",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "time() - cnpg_pg_stat_archiver_last_archived_time{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Seconds Since Last Archival",
+      "yAxisUnit": "s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Current WAL Log Sequence Number position on each instance",
+      "fillSpans": false,
+      "id": "708758e5-cdfe-478b-9db8-d5065bea1879",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a2c523ee-44a3-40db-8617-fed075961dc9",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} current",
+            "name": "A",
+            "query": "cnpg_pg_wal_current_lsn{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          },
+          {
+            "disabled": false,
+            "legend": "{{pod}} insert",
+            "name": "B",
+            "query": "cnpg_pg_wal_insert_lsn{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Current WAL LSN",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of streaming replication connections from primary to replicas",
+      "fillSpans": false,
+      "id": "78ae2637-49bc-4a24-a4e6-4e7993637601",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "71e2a236-336b-4a75-a47c-0749f023a5ce",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "cnpg_pg_replication_streaming_replicas{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Streaming Replication Connected",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number and status of replication slots",
+      "fillSpans": false,
+      "id": "27e90fda-025f-4648-9442-269e6da29f37",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a9c14d56-710f-4026-9c40-f5c59f7ce86b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} active",
+            "name": "A",
+            "query": "cnpg_pg_replication_slots_active{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          },
+          {
+            "disabled": false,
+            "legend": "{{pod}} inactive",
+            "name": "B",
+            "query": "cnpg_pg_replication_slots_inactive{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Replication Slots",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Connection and transaction metrics",
+      "id": "454f079f-6c73-487d-b3cb-c067696f2022",
+      "panelTypes": "row",
+      "title": "Database Activity"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of currently active database connections per instance",
+      "fillSpans": false,
+      "id": "8a15104b-515c-45d7-9a0c-f75373eb6fd4",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "3126d10c-38b3-40d4-adb7-4569afbd35e1",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} active",
+            "name": "A",
+            "query": "cnpg_pg_stat_activity_connections{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\", state=\"active\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Connections",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Breakdown of connections by state (active, idle, idle in transaction, etc.)",
+      "fillSpans": false,
+      "id": "e45a121d-4ee4-48ee-b114-a888e03232ab",
+      "isStacked": true,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "e20bf054-2577-4c3c-8351-7ba555ce2dcf",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{state}}",
+            "name": "A",
+            "query": "cnpg_pg_stat_activity_connections{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Connections by State",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Maximum allowed connections vs current usage per instance",
+      "fillSpans": false,
+      "id": "8cf043cf-1e97-46df-9175-9ff6d7f4834a",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "539c171e-1d0b-45dd-bee0-b8152d98b913",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} max",
+            "name": "A",
+            "query": "cnpg_pg_settings_setting{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\", name=\"max_connections\"}"
+          },
+          {
+            "disabled": false,
+            "legend": "{{pod}} current",
+            "name": "B",
+            "query": "sum by (pod) (cnpg_pg_stat_activity_connections{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"})"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Max Connections",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of committed and rolled-back transactions per second",
+      "fillSpans": false,
+      "id": "4bba74e2-b54c-488c-98d7-0ad89992effd",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "269439c1-afee-4b9a-8512-db17774398d3",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{datname}} commits/s",
+            "name": "A",
+            "query": "rate(cnpg_pg_stat_database_xact_commit{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}[5m])"
+          },
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{datname}} rollbacks/s",
+            "name": "B",
+            "query": "rate(cnpg_pg_stat_database_xact_rollback{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}[5m])"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Transactions Per Second",
+      "yAxisUnit": "ops"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total transactions committed per database per instance",
+      "fillSpans": false,
+      "id": "8af7399d-1183-4418-bcba-a6346812358f",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f22c2af4-23fd-4d55-a890-7ba8c5fd2bc5",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{datname}}",
+            "name": "A",
+            "query": "cnpg_pg_stat_database_xact_commit{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Transactions Committed (total)",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total transactions rolled back - high values may indicate application errors",
+      "fillSpans": false,
+      "id": "3d7b25c5-479b-4d1a-a404-7708e3a76ec8",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "fa02e534-9487-40ac-883d-c1299d659b84",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{datname}}",
+            "name": "A",
+            "query": "cnpg_pg_stat_database_xact_rollback{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Transactions Rolled Back (total)",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of connections currently waiting for a lock",
+      "fillSpans": false,
+      "id": "ff080d88-1dca-46ac-a868-9bce77745d8f",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "48bfd756-ed02-4ccd-87d2-58aeb048ac9b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "cnpg_pg_stat_activity_connections{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\", state=\"waiting\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Waiting Connections",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Connections in 'idle in transaction' state - long-running idle transactions can hold locks and consume resources",
+      "fillSpans": false,
+      "id": "cbf51a83-9814-435d-828c-3878af0d570d",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "7b8eaecf-1349-4447-b6f9-ab3bcf49dd4f",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "cnpg_pg_stat_activity_connections{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\", state=\"idle in transaction\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Idle in Transaction Connections",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Database and tablespace size metrics",
+      "id": "cb93490c-0ec7-487b-9326-a06b112a14f6",
+      "panelTypes": "row",
+      "title": "Database Size & Storage"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total size of each database across instances",
+      "fillSpans": false,
+      "id": "d6e549a2-c381-4ea6-a2b6-33037edaabeb",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "39644b69-5f60-42e3-bafa-f0e10f0e01b8",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{datname}}",
+            "name": "A",
+            "query": "cnpg_pg_database_size_bytes{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Database Size",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of database size growth per hour - helps predict storage needs",
+      "fillSpans": false,
+      "id": "c912f3ff-55f4-4437-8732-0ff9bc03161d",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8b75ee17-61c3-4614-8ea5-b2ac3e0d7536",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{datname}}",
+            "name": "A",
+            "query": "deriv(cnpg_pg_database_size_bytes{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}[1h])"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Database Size Growth Rate",
+      "yAxisUnit": "binBps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Sum of all database sizes per instance",
+      "fillSpans": false,
+      "id": "c50d9e19-e017-478f-82bd-7576f3d72ec5",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "40970a25-0d8d-4e5e-8497-271510f60bf8",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "sum by (pod) (cnpg_pg_database_size_bytes{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\"})"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Database Size",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Estimated ratio of dead tuples to live tuples per table - high values indicate need for VACUUM",
+      "fillSpans": false,
+      "id": "1a686d96-585c-4630-bc69-b480310ed685",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "45ef55f7-8a73-4ede-9d19-e69007dc094f",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{relname}}",
+            "name": "A",
+            "query": "cnpg_pg_stat_user_tables_n_dead_tup{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"} / (cnpg_pg_stat_user_tables_n_live_tup{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"} + 1)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Table Bloat Estimate",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Disk usage per tablespace (if multiple tablespaces are configured)",
+      "fillSpans": false,
+      "id": "d3c7a549-8baf-4775-b3f9-b771df2b4241",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0ad8b436-8d8c-460e-981b-a4f873c19a17",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{spcname}}",
+            "name": "A",
+            "query": "cnpg_pg_tablespace_size_bytes{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Disk Usage by Tablespace",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Size of temporary files created by queries - large values may indicate insufficient work_mem",
+      "fillSpans": false,
+      "id": "36ca341a-e3dd-4f9f-a56b-f920c2065108",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "036a8741-3b13-44f9-b999-21264122e3e6",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{datname}}",
+            "name": "A",
+            "query": "cnpg_pg_stat_database_temp_bytes{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Temporary File Size",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of temporary file creation per database",
+      "fillSpans": false,
+      "id": "6937b6d2-b82a-4e64-8c3c-d6f9de8289b4",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "61ef4e72-6d09-4b37-97f4-95096cdfbc84",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{datname}}",
+            "name": "A",
+            "query": "rate(cnpg_pg_stat_database_temp_files{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}[5m])"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Temporary Files Created Rate",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Checkpoint activity and autovacuum metrics",
+      "id": "457300fc-9628-48f3-9717-2a848611e2b3",
+      "panelTypes": "row",
+      "title": "Checkpoint & Maintenance"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Checkpoints triggered by request (forced) vs scheduled (timed) - too many requested checkpoints indicate heavy write load",
+      "fillSpans": false,
+      "id": "52de2366-b03d-4e07-a36f-bfb37be1c4ae",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b2f21a82-c1e2-40be-a519-b7cd03987524",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} timed",
+            "name": "A",
+            "query": "rate(cnpg_pg_stat_bgwriter_checkpoints_timed{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}[5m])"
+          },
+          {
+            "disabled": false,
+            "legend": "{{pod}} requested",
+            "name": "B",
+            "query": "rate(cnpg_pg_stat_bgwriter_checkpoints_req{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}[5m])"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Checkpoints Requested vs Timed",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Time spent writing during checkpoints in milliseconds",
+      "fillSpans": false,
+      "id": "d0c7908c-4a59-4686-a361-9bf78052665c",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "14e32379-089a-4ed8-82e1-6101bd47c55a",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "rate(cnpg_pg_stat_bgwriter_checkpoint_write_time{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}[5m])"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Checkpoint Write Time",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Time spent syncing files to disk during checkpoints",
+      "fillSpans": false,
+      "id": "ff7f3415-5cb2-4725-9f40-18f5d821f4db",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "641181df-8fc1-4d30-acb4-a135865db7c3",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "rate(cnpg_pg_stat_bgwriter_checkpoint_sync_time{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}[5m])"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Checkpoint Sync Time",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of buffers written during checkpoints",
+      "fillSpans": false,
+      "id": "f2da45aa-b605-42bb-a802-d98d9626b969",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "66de359e-d89e-4f08-abc5-19dbf06db2c6",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} checkpoint",
+            "name": "A",
+            "query": "rate(cnpg_pg_stat_bgwriter_buffers_checkpoint{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}[5m])"
+          },
+          {
+            "disabled": false,
+            "legend": "{{pod}} backend",
+            "name": "B",
+            "query": "rate(cnpg_pg_stat_bgwriter_buffers_backend{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}[5m])"
+          },
+          {
+            "disabled": false,
+            "legend": "{{pod}} bgwriter",
+            "name": "C",
+            "query": "rate(cnpg_pg_stat_bgwriter_buffers_clean{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}[5m])"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Buffers Written by Checkpoint",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of autovacuum workers currently running",
+      "fillSpans": false,
+      "id": "59892847-83d5-45b6-8091-1cfb8f860ba4",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8ceed680-2ef6-4ac5-8f5d-909a45c9124d",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "cnpg_pg_stat_activity_connections{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\", state=\"active\", backend_type=\"autovacuum worker\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Autovacuum Workers Active",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of dead tuples per user table - high values indicate VACUUM is needed",
+      "fillSpans": false,
+      "id": "11604442-257f-4f75-bc92-c2cc6c827ef9",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a43736fb-914b-4fe4-8863-f98669d85df0",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{relname}}",
+            "name": "A",
+            "query": "topk(10, cnpg_pg_stat_user_tables_n_dead_tup{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"})"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Dead Tuples by Table",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Time since last autovacuum for each user table",
+      "fillSpans": false,
+      "id": "10dbc7e7-a993-4e1c-99ab-c227794f1a48",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0284f62e-e0e2-4cee-8718-55e412e27937",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{relname}}",
+            "name": "A",
+            "query": "time() - cnpg_pg_stat_user_tables_last_autovacuum{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Last Autovacuum Time",
+      "yAxisUnit": "s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Time since last autoanalyze for each user table",
+      "fillSpans": false,
+      "id": "6f0a714e-4770-4c90-99ad-5a8a9e14fdf9",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "cd3da2db-d183-41bf-abad-04ce49b80c5a",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{relname}}",
+            "name": "A",
+            "query": "time() - cnpg_pg_stat_user_tables_last_autoanalyze{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Last Autoanalyze Time",
+      "yAxisUnit": "s"
+    },
+    {
+      "description": "Shared buffer utilization and I/O statistics",
+      "id": "4bf3dd87-edef-4283-862d-573c8a05888f",
+      "panelTypes": "row",
+      "title": "Buffer Cache & I/O Performance"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Buffer cache hit ratio per database - should be > 99% for OLTP workloads",
+      "fillSpans": false,
+      "id": "21157659-1ee3-41eb-ba3d-79773842815a",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "fdedcdb3-8a7d-4f54-9284-90d7146a1fe6",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{datname}}",
+            "name": "A",
+            "query": "cnpg_pg_stat_database_blks_hit{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"} / (cnpg_pg_stat_database_blks_hit{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"} + cnpg_pg_stat_database_blks_read{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"} + 0.001) * 100"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Cache Hit Ratio",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of disk blocks read from disk vs served from shared buffers",
+      "fillSpans": false,
+      "id": "4e0c9096-868e-4db0-85c3-890380f0bfb6",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "efd7d27c-7ae2-4227-bf6e-eb5ddd696273",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{datname}} reads",
+            "name": "A",
+            "query": "rate(cnpg_pg_stat_database_blks_read{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}[5m])"
+          },
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{datname}} hits",
+            "name": "B",
+            "query": "rate(cnpg_pg_stat_database_blks_hit{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}[5m])"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Blocks Read vs Hit",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of buffers written directly by backends (bypassing bgwriter) - high values indicate bgwriter cannot keep up",
+      "fillSpans": false,
+      "id": "32be7b13-d726-40b0-942f-e604676a8f22",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "af350338-ef74-4411-8439-48eb0f4963c7",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "rate(cnpg_pg_stat_bgwriter_buffers_backend{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}[5m])"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Backend Buffers Written",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of fsyncs performed by backends - should ideally be zero",
+      "fillSpans": false,
+      "id": "ab9a6d41-6056-4223-827b-55342b5121ec",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "fcdb4ae7-7845-462a-aabf-1330049bf944",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "rate(cnpg_pg_stat_bgwriter_buffers_backend_fsync{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}[5m])"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Backend Fsync Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of rows returned by queries per database",
+      "fillSpans": false,
+      "id": "15966807-72cb-4d08-a13d-4c673af6c6ac",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0e2474b7-cd4c-49e4-830c-0b7b0e26c1ca",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{datname}}",
+            "name": "A",
+            "query": "rate(cnpg_pg_stat_database_tup_fetched{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}[5m])"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Rows Fetched Rate",
+      "yAxisUnit": "ops"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of rows inserted per database",
+      "fillSpans": false,
+      "id": "970eb46b-818f-41f8-8335-bd6485ff9d31",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6140d723-3e89-4cc0-9712-d8ed93e1134a",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{datname}}",
+            "name": "A",
+            "query": "rate(cnpg_pg_stat_database_tup_inserted{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}[5m])"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Rows Inserted Rate",
+      "yAxisUnit": "ops"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of rows updated per database",
+      "fillSpans": false,
+      "id": "37ab121c-c622-44ce-a0bb-383cdc3cb3e2",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d0bb12a2-d69f-4c2c-9456-9430d5c25f36",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{datname}}",
+            "name": "A",
+            "query": "rate(cnpg_pg_stat_database_tup_updated{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}[5m])"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Rows Updated Rate",
+      "yAxisUnit": "ops"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of rows deleted per database",
+      "fillSpans": false,
+      "id": "9e46f559-743b-4abf-9439-be6cd4b9fdb6",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "959584f4-14ec-4aec-a03d-d0b40472ebe6",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{datname}}",
+            "name": "A",
+            "query": "rate(cnpg_pg_stat_database_tup_deleted{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}[5m])"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Rows Deleted Rate",
+      "yAxisUnit": "ops"
+    },
+    {
+      "description": "Lock contention and database conflict metrics",
+      "id": "4b3b7da6-a10f-4fd8-95bc-8dd6b77e05ca",
+      "panelTypes": "row",
+      "title": "Locks & Conflicts"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of locks held per mode (AccessShare, RowExclusive, etc.)",
+      "fillSpans": false,
+      "id": "23293a81-4088-42f0-8e8e-64bf43ac84e4",
+      "isStacked": true,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ceac5b2b-efc2-483e-9d1c-e2ef66bf7264",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{mode}}",
+            "name": "A",
+            "query": "cnpg_pg_locks_count{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Locks by Mode",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of exclusive locks (AccessExclusive, Exclusive) - can cause severe contention",
+      "fillSpans": false,
+      "id": "11da5a13-f8c6-4f46-8923-ea622884b496",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8b32760e-1e95-430a-99c2-ef5791e4a4d4",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{mode}}",
+            "name": "A",
+            "query": "cnpg_pg_locks_count{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\", mode=~\"AccessExclusiveLock|ExclusiveLock\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Exclusive Locks",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of deadlocks detected per database - any deadlocks indicate application concurrency issues",
+      "fillSpans": false,
+      "id": "6190deb5-c4fb-4e0b-a16d-b36e55b06a2e",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9c2f1b9f-852a-4393-948a-83f55b9301c1",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{datname}}",
+            "name": "A",
+            "query": "rate(cnpg_pg_stat_database_deadlocks{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}[5m])"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Deadlocks",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of queries cancelled due to conflicts with recovery on replicas",
+      "fillSpans": false,
+      "id": "5cdbbe78-1c04-4097-8908-e00fa324ef8d",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6c74a5da-e0c8-4b46-b0ab-56dc91e67e9c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{datname}}",
+            "name": "A",
+            "query": "rate(cnpg_pg_stat_database_conflicts{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}[5m])"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Conflicts",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of queries currently blocked waiting for locks",
+      "fillSpans": false,
+      "id": "0595d09b-c6ed-49a7-93df-b1a85ba3b6df",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "66bad3c7-2c7c-4a6e-b777-d4072ab41014",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "cnpg_pg_stat_activity_connections{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\", wait_event_type=\"Lock\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Waiting Queries (Lock Waits)",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of active queries running for more than 5 minutes",
+      "fillSpans": false,
+      "id": "c63759e3-9712-40d9-8517-9d9241354f6c",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "730d1629-1725-4323-bd55-f11e7e5ad3a7",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "cnpg_pg_long_running_queries{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Long Running Queries",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Backup status, duration, and recovery metrics",
+      "id": "b7194674-d25e-45d9-9f29-5c1f3d50b444",
+      "panelTypes": "row",
+      "title": "Backup & Recovery"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Duration of the most recent backup in seconds",
+      "fillSpans": false,
+      "id": "98637a27-aed6-4943-8142-c8d0024dd13f",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9cdf18da-05fc-4c9d-b0a1-fe4683e018b4",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "cnpg_pg_last_backup_duration_seconds{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Last Backup Duration",
+      "yAxisUnit": "s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Seconds elapsed since last successful backup - alert if > backup schedule interval",
+      "fillSpans": false,
+      "id": "c21597ac-4f65-4ceb-8dab-52ff84268dc1",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6373d583-a14c-4dff-92a9-695ca6388cad",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "time() - cnpg_pg_last_backup_timestamp{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Time Since Last Backup",
+      "yAxisUnit": "s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Size of the most recent backup",
+      "fillSpans": false,
+      "id": "420c433b-546f-458b-abdf-6eb67e9d1e30",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6f9620bd-beb5-4723-bd17-128a701575c1",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "cnpg_pg_last_backup_size_bytes{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Backup Size",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Size of WAL segment files",
+      "fillSpans": false,
+      "id": "3cade2b6-8a52-494a-a030-19c3c3683775",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "bf658439-f11f-4baa-be53-e48e549a7d29",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "cnpg_pg_wal_segment_size_bytes{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "WAL Segment Size",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Whether the last backup was successful (1) or failed (0)",
+      "fillSpans": false,
+      "id": "e8f75f9a-ec72-41a3-9897-f2bd10ff34c3",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "62c1665c-8e8d-4fcf-954f-f59ce0b03fe0",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "cnpg_pg_last_backup_success{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Last Backup Success",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Historical view of backup durations over time",
+      "fillSpans": false,
+      "id": "88d0321b-a823-4ebd-a98f-ead154226198",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0822acef-abd9-42ca-90c3-a82bd9102a9f",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "cnpg_pg_last_backup_duration_seconds{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Backup History Timeline",
+      "yAxisUnit": "s"
+    },
+    {
+      "description": "PgBouncer metrics when connection pooling is enabled in CNPG",
+      "id": "6701f545-4cac-4c66-8c9c-dc7164324d72",
+      "panelTypes": "row",
+      "title": "PgBouncer Connection Pooling"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of active server connections in PgBouncer pools",
+      "fillSpans": false,
+      "id": "48e8c011-05b2-4080-b9d9-37c873d0148b",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9636db48-6581-4fd2-b50c-e46698a1e136",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{database}}",
+            "name": "A",
+            "query": "cnpg_pgbouncer_pool_server_active_connections{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "PgBouncer Active Connections",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of client connections to PgBouncer",
+      "fillSpans": false,
+      "id": "368457d0-fa94-4c33-9934-65f883868293",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "726aa3cc-469a-43ef-8bde-731d220dd157",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{database}} active",
+            "name": "A",
+            "query": "cnpg_pgbouncer_pool_client_active_connections{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          },
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{database}} waiting",
+            "name": "B",
+            "query": "cnpg_pgbouncer_pool_client_waiting_connections{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "PgBouncer Client Connections",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of idle server connections available in PgBouncer pools",
+      "fillSpans": false,
+      "id": "47d9732e-49af-4042-8ad1-a489c9d69b4f",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "2d50d068-e6fc-4550-b581-8e34ad141f77",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{database}}",
+            "name": "A",
+            "query": "cnpg_pgbouncer_pool_server_idle_connections{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "PgBouncer Server Idle Connections",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Maximum time a client had to wait for a connection",
+      "fillSpans": false,
+      "id": "66f85824-d244-440e-b9cb-ad8fa927dede",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "03a6c96b-9e4a-4630-81d6-cc1c7ae319d9",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{database}}",
+            "name": "A",
+            "query": "cnpg_pgbouncer_pool_max_wait_seconds{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "PgBouncer Max Wait Time",
+      "yAxisUnit": "s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of SQL queries executed through PgBouncer",
+      "fillSpans": false,
+      "id": "7ad39707-4aa2-45e8-97d6-4fe9a64a9416",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c816346b-dd9a-463c-90ee-4be5ba5be85c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{database}}",
+            "name": "A",
+            "query": "rate(cnpg_pgbouncer_stats_queries_total{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}[5m])"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "PgBouncer Total Queries",
+      "yAxisUnit": "ops"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Average query duration through PgBouncer",
+      "fillSpans": false,
+      "id": "85220bd5-6036-4dac-834e-8b7b38867b39",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ce0d59e1-8876-4d62-b089-68eb54a2d8d6",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{database}}",
+            "name": "A",
+            "query": "cnpg_pgbouncer_stats_query_avg_duration_seconds{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "PgBouncer Query Duration (avg)",
+      "yAxisUnit": "s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Data throughput through PgBouncer",
+      "fillSpans": false,
+      "id": "6484ceba-73df-4538-975e-b2355de27168",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f0c2fc6a-c569-4b9f-a07e-f2fa53d16e19",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{database}} received",
+            "name": "A",
+            "query": "rate(cnpg_pgbouncer_stats_received_bytes_total{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}[5m])"
+          },
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{database}} sent",
+            "name": "B",
+            "query": "rate(cnpg_pgbouncer_stats_sent_bytes_total{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}[5m])"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "PgBouncer Bytes In/Out",
+      "yAxisUnit": "binBps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of connections currently going through the login process",
+      "fillSpans": false,
+      "id": "055ce9e2-e320-4ed9-82a4-1c0fcc63befa",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "fdccd991-8f42-4df6-9ed6-d219d99068e8",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{database}}",
+            "name": "A",
+            "query": "cnpg_pgbouncer_pool_server_login_connections{namespace=~\"{{.namespace}}\", cluster=~\"{{.cluster}}\", pod=~\"{{.instance}}\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "PgBouncer Login Connections",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "CPU, memory, and storage metrics for CNPG pods",
+      "id": "63f3db70-33db-450a-96a4-340df385af6f",
+      "panelTypes": "row",
+      "title": "Resource Usage (Kubernetes)"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "CPU usage per CNPG pod (requires container metrics collection)",
+      "fillSpans": false,
+      "id": "9bf263ba-4b45-4e15-8048-a1971e6b2436",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "92f1976f-a9b7-428e-baa6-ddb5418a112b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{container}}",
+            "name": "A",
+            "query": "rate(container_cpu_usage_seconds_total{namespace=~\"{{.namespace}}\", pod=~\".*{{.cluster}}.*\"}[5m])"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "CPU Usage by Pod",
+      "yAxisUnit": "percentunit"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Memory (RSS) usage per CNPG pod",
+      "fillSpans": false,
+      "id": "86a857cf-9b2c-48d3-ab19-79f15850a7b8",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9cdccd38-cf1c-47c0-ac5c-249e0108d55e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{container}}",
+            "name": "A",
+            "query": "container_memory_rss{namespace=~\"{{.namespace}}\", pod=~\".*{{.cluster}}.*\", container!=\"\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memory Usage by Pod",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Working set memory per CNPG pod - what K8s uses for OOM decisions",
+      "fillSpans": false,
+      "id": "a2bb7fba-ceba-4d1b-8860-1fcd9bc32884",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "347c2f15-8f5d-4040-84eb-eedec18644f5",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}} {{container}}",
+            "name": "A",
+            "query": "container_memory_working_set_bytes{namespace=~\"{{.namespace}}\", pod=~\".*{{.cluster}}.*\", container!=\"\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memory Working Set by Pod",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Persistent Volume Claim usage (data directory size)",
+      "fillSpans": false,
+      "id": "dc8f83a6-1f4f-45ae-ab39-2861aa7552de",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6e22d3c1-e6e0-4abc-a06c-4fa4ac512cf2",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{persistentvolumeclaim}}",
+            "name": "A",
+            "query": "kubelet_volume_stats_used_bytes{namespace=~\"{{.namespace}}\", persistentvolumeclaim=~\".*{{.cluster}}.*\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "PVC Usage",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Available space in Persistent Volume Claims",
+      "fillSpans": false,
+      "id": "1ab41017-cc4d-40d7-abcd-41f4a5cf85c1",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0d8a2522-0497-42bc-9de0-eb4a9972b214",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{persistentvolumeclaim}}",
+            "name": "A",
+            "query": "kubelet_volume_stats_available_bytes{namespace=~\"{{.namespace}}\", persistentvolumeclaim=~\".*{{.cluster}}.*\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "PVC Available Space",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total capacity vs used for Persistent Volume Claims",
+      "fillSpans": false,
+      "id": "d6cbd7fb-5f4c-4f99-81c3-be0a73e9ef2c",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c20bb41e-42ce-42e9-9ccd-dbf5f53727d8",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{persistentvolumeclaim}} capacity",
+            "name": "A",
+            "query": "kubelet_volume_stats_capacity_bytes{namespace=~\"{{.namespace}}\", persistentvolumeclaim=~\".*{{.cluster}}.*\"}"
+          },
+          {
+            "disabled": false,
+            "legend": "{{persistentvolumeclaim}} used",
+            "name": "B",
+            "query": "kubelet_volume_stats_used_bytes{namespace=~\"{{.namespace}}\", persistentvolumeclaim=~\".*{{.cluster}}.*\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "PVC Capacity",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Network bytes received per CNPG pod",
+      "fillSpans": false,
+      "id": "a77d261f-2d9d-4420-8812-bb4016b9c2eb",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "5842e071-1aba-4792-8a8f-e831390610ea",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "rate(container_network_receive_bytes_total{namespace=~\"{{.namespace}}\", pod=~\".*{{.cluster}}.*\"}[5m])"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Network Receive Rate",
+      "yAxisUnit": "binBps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Network bytes transmitted per CNPG pod",
+      "fillSpans": false,
+      "id": "e30160fc-15ed-401b-8b25-5fc94dae763f",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d20ce3b8-65b2-4dee-b0b4-24bccc03b10c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "rate(container_network_transmit_bytes_total{namespace=~\"{{.namespace}}\", pod=~\".*{{.cluster}}.*\"}[5m])"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Network Transmit Rate",
+      "yAxisUnit": "binBps"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Comprehensive CloudNativePG monitoring dashboard for SigNoz with **87 panels** across **10 sections**, built from the [official Grafana dashboard reference](https://github.com/cloudnative-pg/grafana-dashboards/blob/main/charts/cluster/grafana-dashboard.json).

Closes SigNoz/signoz#7875

## Dashboard Sections

| Section | Panels | Key Metrics |
|---------|--------|-------------|
| **Cluster Overview** | 8 | Instance count, readiness, primary ID, switchover tracking |
| **Replication & WAL** | 10 | Byte/second lag, LSN positions, archival rate/failures, replication slots |
| **Database Activity** | 8 | Connections by state, TPS, max connections, idle-in-transaction |
| **Database Size & Storage** | 7 | Size per DB, growth rate, bloat estimate, temp files |
| **Checkpoint & Maintenance** | 8 | Timed vs requested checkpoints, write/sync time, autovacuum |
| **Buffer Cache & I/O** | 8 | Cache hit ratio, block reads vs hits, row CRUD rates |
| **Locks & Conflicts** | 6 | Lock modes, deadlocks, conflicts, long-running queries |
| **Backup & Recovery** | 6 | Backup duration/size/success, time since last backup |
| **PgBouncer Connection Pooling** | 8 | Pool utilization, query throughput, wait times |
| **Resource Usage (Kubernetes)** | 8 | CPU, memory, PVC usage/capacity, network I/O |

## Template Variables

- `{{namespace}}` — Kubernetes namespace
- `{{cluster}}` — CloudNativePG cluster name
- `{{instance}}` — Individual PostgreSQL instance

## Technical Details

- **Source**: Prometheus (CloudNativePG exposes native Prometheus metrics)
- **93 unique PromQL queries** covering all CNPG metric families
- **Cascading variable queries** for namespace → cluster → instance filtering
- Follows SigNoz dashboard JSON schema and CONTRIBUTING.md guidelines

## Test Plan

- [x] JSON validates (python3 -c "import json; json.load(open('...'))")
- [x] 87 widget IDs match 87 layout entries
- [x] All IDs are unique UUIDs
- [x] README includes metrics ingestion, variables, and panel documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes SigNoz/signoz#7875