### PR TITLE
feat: add cert-manager Prometheus monitoring dashboard

### DIFF
--- a/cert-manager/README.md
+++ b/cert-manager/README.md
@@ -1,0 +1,189 @@
+# Cert-Manager Monitoring Dashboard - Prometheus
+
+A comprehensive SigNoz dashboard for monitoring [cert-manager](https://cert-manager.io/) in Kubernetes clusters, built on Prometheus metrics.
+
+## Metrics Ingestion
+
+cert-manager exposes Prometheus metrics on port `9402` by default. To ingest these metrics into SigNoz, configure the OpenTelemetry Collector with a Prometheus receiver.
+
+### OpenTelemetry Collector Configuration
+
+Add the following to your `otel-collector-config.yaml`:
+
+```yaml
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: 'cert-manager'
+          scrape_interval: 30s
+          kubernetes_sd_configs:
+            - role: pod
+          relabel_configs:
+            - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+              regex: cert-manager
+              action: keep
+            - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
+              regex: controller|webhook|cainjector
+              action: keep
+            - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port]
+              regex: '(\d+)'
+              target_label: __address__
+              replacement: '${1}:$${2}'
+              action: replace
+            - source_labels: [__meta_kubernetes_namespace]
+              target_label: namespace
+            - source_labels: [__meta_kubernetes_pod_name]
+              target_label: pod
+
+exporters:
+  otlp:
+    endpoint: "<SigNoz-endpoint>:4317"
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      exporters: [otlp]
+```
+
+Alternatively, if cert-manager is installed with Helm, enable the ServiceMonitor:
+
+```yaml
+# values.yaml
+prometheus:
+  enabled: true
+  servicemonitor:
+    enabled: true
+```
+
+## Variables
+
+- `{{namespace}}`: Kubernetes namespace where cert-manager components are running. Supports multi-select and "All" option.
+
+## Dashboard Sections
+
+### 1. Certificate Overview
+High-level view of certificate health across the cluster.
+- Total certificates, ready vs not-ready counts
+- Certificates expiring within 24h, 7d, 30d, 90d
+- Average and minimum time to expiry
+- Certificate readiness over time
+
+### 2. Certificate Details
+Per-certificate granular view.
+- Expiry countdown per certificate (days remaining)
+- Renewal countdown per certificate (hours to next renewal)
+- Expiry breakdown by namespace
+- Per-certificate ready status over time
+- Table view of all certificates sorted by remaining lifetime
+
+### 3. Issuer Health
+Monitoring of Issuer and ClusterIssuer resources.
+- Total issuers, sync success rate, sync errors
+- Issuer sync rate over time by status
+- Certificates per issuer
+
+### 4. Certificate Requests & Orders
+Tracking the certificate issuance pipeline.
+- CertificateRequest sync rate by issuer type (ACME, CA, SelfSigned)
+- ACME Order sync rate
+- Challenge sync rate
+- Main certificate controller sync rates
+
+### 5. ACME Operations
+Detailed monitoring of ACME protocol interactions (Let's Encrypt, etc.).
+- ACME request rate, success rate, error rate
+- Average request duration
+- Request rate by HTTP status code, method, path, and host
+- Request duration percentiles (p50/p90/p99)
+- Error breakdown by status and method
+
+### 6. Controller Performance
+Overall cert-manager controller health.
+- Total sync rate, success rate, error rate
+- Sync rate per controller
+- Error rate per controller
+- Sync duration percentiles
+
+### 7. Work Queue Metrics
+Kubernetes controller-runtime work queue monitoring.
+- Queue depth, adds rate, unfinished work
+- Queue depth and adds rate over time per queue
+- Queue wait latency percentiles (p50/p90/p99)
+- Processing duration percentiles
+- Retry rates
+- Longest running processor duration
+
+### 8. Webhook Metrics
+Admission webhook performance monitoring.
+- Webhook request rate, success rate, average latency
+- Request rate by HTTP status
+- Request duration percentiles
+
+### 9. Kubernetes API & Client Metrics
+cert-manager's interaction with the Kubernetes API server.
+- API request rate by verb and resource
+- API request errors by status code
+- API request latency percentiles
+- Client-side rate limiter wait duration
+
+### 10. Leader Election
+Controller leader election status.
+- Current leader status per component
+- Leader election transition rate (instability detection)
+
+### 11. Resource Usage
+Go runtime and process-level metrics.
+- CPU usage, RSS memory, goroutines, open file descriptors
+- CPU and memory over time per pod
+- Goroutines and GC pause duration over time
+- File descriptor usage vs limits
+- Go heap memory (alloc, inuse, sys)
+- GC allocation rate
+- OS thread count
+
+### 12. Network & Miscellaneous
+Auxiliary monitoring metrics.
+- Process uptime
+- Clock skew detection (cert-manager vs Prometheus)
+- Total managed resource count
+- Clock skew over time
+- Component up/down status
+
+## Key Metrics Used
+
+| Metric | Description |
+|--------|-------------|
+| `certmanager_certificate_ready_status` | Certificate readiness (True/False) |
+| `certmanager_certificate_expiration_timestamp_seconds` | Certificate expiry Unix timestamp |
+| `certmanager_certificate_renewal_timestamp_seconds` | Next renewal Unix timestamp |
+| `certmanager_controller_sync_call_count` | Controller sync operation counter |
+| `certmanager_http_acme_client_request_count` | ACME HTTP request counter |
+| `certmanager_http_acme_client_request_duration_seconds` | ACME HTTP request duration histogram |
+| `certmanager_http_webhook_request_count` | Webhook request counter |
+| `certmanager_http_webhook_request_duration_seconds` | Webhook request duration histogram |
+| `certmanager_clock_time_seconds` | cert-manager internal clock |
+| `workqueue_depth` | Controller work queue depth |
+| `workqueue_adds_total` | Work queue add operations |
+| `workqueue_queue_duration_seconds` | Time spent waiting in queue |
+| `workqueue_work_duration_seconds` | Time spent processing items |
+| `workqueue_retries_total` | Work queue retry counter |
+| `workqueue_longest_running_processor_seconds` | Longest active processor duration |
+| `rest_client_requests_total` | Kubernetes API client requests |
+| `rest_client_request_duration_seconds` | Kubernetes API request latency |
+| `leader_election_master_status` | Leader election status |
+| `process_cpu_seconds_total` | Process CPU usage |
+| `process_resident_memory_bytes` | Process RSS memory |
+| `go_goroutines` | Active goroutine count |
+| `go_gc_duration_seconds` | GC pause duration |
+| `go_memstats_heap_alloc_bytes` | Go heap allocation |
+
+## Requirements
+
+- cert-manager v1.0+ (tested with v1.12+)
+- Prometheus metrics endpoint enabled (default: port 9402)
+- OpenTelemetry Collector with Prometheus receiver configured
+- SigNoz v0.30+

--- a/cert-manager/cert-manager-prometheus-v1.json
+++ b/cert-manager/cert-manager-prometheus-v1.json
@@ -1,0 +1,12706 @@
+{
+  "description": "Comprehensive cert-manager monitoring dashboard covering certificate lifecycle, issuer health, ACME operations, controller performance, work queues, webhooks, Kubernetes API interactions, leader election, and Go runtime resource usage. Built for Prometheus metrics exposed by cert-manager.",
+  "image": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxOCIgaGVpZ2h0PSIxOCIgdmlld0JveD0iMCAwIDE4IDE4IiBmaWxsPSJub25lIj4KPHJlY3Qgd2lkdGg9IjE4IiBoZWlnaHQ9IjE4IiByeD0iMyIgZmlsbD0iIzMyNkNFNSIvPgo8dGV4dCB4PSI5IiB5PSIxMyIgZm9udC1mYW1pbHk9IkFyaWFsIiBmb250LXNpemU9IjEyIiBmb250LXdlaWdodD0iYm9sZCIgZmlsbD0id2hpdGUiIHRleHQtYW5jaG9yPSJtaWRkbGUiPkM8L3RleHQ+Cjwvc3ZnPg==",
+  "layout": [
+    {
+      "h": 1,
+      "i": "fdc4ae9b-97bb-4243-b93b-172b22d8d985",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 4,
+      "i": "f59c72ca-4cc1-47de-ad87-6481d9cf9e9f",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 0,
+      "y": 1
+    },
+    {
+      "h": 4,
+      "i": "ef9fc4b3-955c-4603-92e2-f8f4dcdaef9b",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 3,
+      "y": 1
+    },
+    {
+      "h": 4,
+      "i": "6d5e00f2-6b5b-4a5f-8e22-34fcc41ea3d2",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 6,
+      "y": 1
+    },
+    {
+      "h": 4,
+      "i": "688a87c1-ac60-48f3-9e02-a0dcb7076477",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 9,
+      "y": 1
+    },
+    {
+      "h": 4,
+      "i": "d6cf2fab-354f-45bf-b867-af82e8d65db7",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 0,
+      "y": 5
+    },
+    {
+      "h": 4,
+      "i": "5e7b54ab-ec3d-444e-878a-dd13afadd4ad",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 3,
+      "y": 5
+    },
+    {
+      "h": 4,
+      "i": "edebc4b4-de3d-4a66-940a-f30e3cbd7171",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 6,
+      "y": 5
+    },
+    {
+      "h": 4,
+      "i": "afc80366-5240-4feb-b1c2-0b9aa7d1f076",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 9,
+      "y": 5
+    },
+    {
+      "h": 6,
+      "i": "871ee0a6-0b84-4fe1-8d97-65508c2567d8",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 9
+    },
+    {
+      "h": 6,
+      "i": "08a89f4f-8bf5-4596-ab56-f86f17ef0eaf",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 9
+    },
+    {
+      "h": 1,
+      "i": "9c1b27fe-4a60-4697-965b-ba3d854d40b1",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 15
+    },
+    {
+      "h": 6,
+      "i": "bec3170f-55c4-45b6-9515-7f8eb1329e52",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 16
+    },
+    {
+      "h": 6,
+      "i": "2b54a944-b7f0-49b7-b870-ef4ad72114b1",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 16
+    },
+    {
+      "h": 6,
+      "i": "83262dc9-72a7-40ff-b1c1-2779ecb4de37",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 22
+    },
+    {
+      "h": 6,
+      "i": "49d2efe4-1e31-469c-9185-f79343b346d5",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 22
+    },
+    {
+      "h": 6,
+      "i": "871b582a-ea51-49ee-a1fd-fc8a0117c7e8",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 28
+    },
+    {
+      "h": 1,
+      "i": "4fc09140-684f-4174-b742-4aaed9d1186f",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 34
+    },
+    {
+      "h": 4,
+      "i": "d4d96df2-1617-42fc-808c-67fcb3f8c932",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 35
+    },
+    {
+      "h": 4,
+      "i": "f1ff123a-0c6b-427b-abad-c26f598d24ad",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 35
+    },
+    {
+      "h": 4,
+      "i": "12385d85-4842-4f35-9cfc-dec2898e9e72",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 35
+    },
+    {
+      "h": 6,
+      "i": "acbb4a0b-31c4-4a5d-abcb-95ea5cf9ca97",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 39
+    },
+    {
+      "h": 6,
+      "i": "476930a2-d367-42f9-ad0a-c1bf20848b0d",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 39
+    },
+    {
+      "h": 1,
+      "i": "be78b044-aab8-440a-ab9f-fe742d7968f1",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 45
+    },
+    {
+      "h": 6,
+      "i": "f8841e58-0ab5-4896-8798-4f32ce2c9a91",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 46
+    },
+    {
+      "h": 6,
+      "i": "37450b45-fe7a-4565-abcd-51cead8c8705",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 46
+    },
+    {
+      "h": 6,
+      "i": "70569755-6683-4dc0-b596-fb6134aa0609",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 52
+    },
+    {
+      "h": 6,
+      "i": "d6c4561c-f7f8-4a5c-9cf9-f212208565a4",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 52
+    },
+    {
+      "h": 1,
+      "i": "65a0761a-de20-4859-a7cd-fd17226da224",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 58
+    },
+    {
+      "h": 4,
+      "i": "cf7bcc84-f559-4bf5-b094-3e7f4c3c8676",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 0,
+      "y": 59
+    },
+    {
+      "h": 4,
+      "i": "f7155213-0a60-4865-b4fc-4f2ee58ca9d4",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 3,
+      "y": 59
+    },
+    {
+      "h": 4,
+      "i": "4d20c319-a691-4bd2-ac82-068062f5cf1d",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 6,
+      "y": 59
+    },
+    {
+      "h": 4,
+      "i": "28e41f55-7ed9-4911-9896-0d65bcd80b45",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 9,
+      "y": 59
+    },
+    {
+      "h": 6,
+      "i": "ec02e335-d29b-4735-831a-1417729ee57b",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 63
+    },
+    {
+      "h": 6,
+      "i": "7ec6dcd1-0092-4d79-9616-daecea4d7fc1",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 63
+    },
+    {
+      "h": 6,
+      "i": "9c20b0a6-417a-4847-88fe-7804e8feb444",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 69
+    },
+    {
+      "h": 6,
+      "i": "38023e41-fd6d-4d5a-a8b6-947612248480",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 69
+    },
+    {
+      "h": 6,
+      "i": "971f1312-3fbe-4641-b955-29558f4d54c1",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 75
+    },
+    {
+      "h": 6,
+      "i": "a8b66f91-b722-4dca-b1a2-35e060230f6d",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 75
+    },
+    {
+      "h": 1,
+      "i": "66478c87-cc44-47e6-a204-f88535516c00",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 81
+    },
+    {
+      "h": 4,
+      "i": "eebad8b5-8e30-43d6-a196-6bacb893123c",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 82
+    },
+    {
+      "h": 4,
+      "i": "93670cc1-4c47-4cb2-9f55-a0607c5c0d17",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 82
+    },
+    {
+      "h": 4,
+      "i": "b453df31-4427-4abb-86e4-618434896878",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 82
+    },
+    {
+      "h": 6,
+      "i": "f607d209-6c99-47e9-9ff9-99ffb3fe1f11",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 86
+    },
+    {
+      "h": 6,
+      "i": "40fe913e-1206-4c35-b072-c97ebe96f5ae",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 86
+    },
+    {
+      "h": 6,
+      "i": "adb34f2b-e36f-48bc-82f6-7e36a9b1ccd3",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 92
+    },
+    {
+      "h": 6,
+      "i": "98157687-e4ec-42aa-a97e-29c93fe036c6",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 92
+    },
+    {
+      "h": 1,
+      "i": "b3fa1937-2590-4a98-85f6-75cebfee7bc8",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 98
+    },
+    {
+      "h": 4,
+      "i": "47a30f57-3ef6-4d4c-a7db-702745839e81",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 99
+    },
+    {
+      "h": 4,
+      "i": "0c48e3d0-f1c6-4273-92f2-dcc4e55366ff",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 99
+    },
+    {
+      "h": 4,
+      "i": "f369855d-7c4f-47a5-927b-2c577e707d8b",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 99
+    },
+    {
+      "h": 6,
+      "i": "91d75d98-9f3c-4dae-85bd-f9796f8789af",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 103
+    },
+    {
+      "h": 6,
+      "i": "19614af6-3952-4834-8f7e-a41e03830a7b",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 103
+    },
+    {
+      "h": 6,
+      "i": "50b3335e-fb35-4d5b-874f-10bdf1f188ac",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 109
+    },
+    {
+      "h": 6,
+      "i": "d3d1e2b4-888f-430b-937b-6f97f0208cbc",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 109
+    },
+    {
+      "h": 6,
+      "i": "8e0cccb1-6cd8-430e-8d31-5344aa6baa44",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 115
+    },
+    {
+      "h": 6,
+      "i": "ac201eff-4628-4a23-8cd1-3d894b0f88d7",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 115
+    },
+    {
+      "h": 1,
+      "i": "86e295db-647b-434e-aef6-ccb0d353e01a",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 121
+    },
+    {
+      "h": 4,
+      "i": "9a8c33c0-aa94-43af-8e63-fdb61a3dbb84",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 122
+    },
+    {
+      "h": 4,
+      "i": "2a5cbbee-015b-4fb6-a895-f39420526712",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 122
+    },
+    {
+      "h": 4,
+      "i": "275eaa28-e0c6-4caf-9c65-f99324eecd6f",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 122
+    },
+    {
+      "h": 6,
+      "i": "df256cc2-00e8-469e-9de6-b150b4df9645",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 126
+    },
+    {
+      "h": 6,
+      "i": "f2fd98cf-106d-47e2-9e1a-72169756544f",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 126
+    },
+    {
+      "h": 1,
+      "i": "e94d1ba1-c665-4b13-a95e-4951fc39dcce",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 132
+    },
+    {
+      "h": 6,
+      "i": "920ba478-d6c6-47a4-8bb9-44f479c56bd2",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 133
+    },
+    {
+      "h": 6,
+      "i": "7f2d67d1-0f84-4e81-a64b-43e11ae75989",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 133
+    },
+    {
+      "h": 6,
+      "i": "13c827a2-d14c-40c0-977a-ce726396077b",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 139
+    },
+    {
+      "h": 6,
+      "i": "f4fbbe67-8e68-4aa9-8e11-462e711e6970",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 139
+    },
+    {
+      "h": 1,
+      "i": "d7ca8613-51ca-4ca7-a85f-bcccc0f7dc63",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 145
+    },
+    {
+      "h": 6,
+      "i": "08275adb-2984-4aa5-bc21-b6d8764036a2",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 146
+    },
+    {
+      "h": 6,
+      "i": "34694e0c-7531-4e81-8612-d322caedf698",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 146
+    },
+    {
+      "h": 1,
+      "i": "baa2770d-bd4e-43a9-a67b-a06f3e02f8ea",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 152
+    },
+    {
+      "h": 4,
+      "i": "f8e626b8-7886-481d-b39a-3929a61f9667",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 0,
+      "y": 153
+    },
+    {
+      "h": 4,
+      "i": "c9668a64-6d83-4ba2-8249-11f74b24388e",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 3,
+      "y": 153
+    },
+    {
+      "h": 4,
+      "i": "6ad4494f-b772-4e23-8c35-64c4aaa4887d",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 6,
+      "y": 153
+    },
+    {
+      "h": 4,
+      "i": "426fa7e3-254e-4bbb-8c97-9ea99b57aca1",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 9,
+      "y": 153
+    },
+    {
+      "h": 6,
+      "i": "b3447631-b74f-455b-8c56-f42d4a1565bc",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 157
+    },
+    {
+      "h": 6,
+      "i": "368ba6c1-7656-42c2-8761-89dfccbb8158",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 157
+    },
+    {
+      "h": 6,
+      "i": "635d1430-e95a-482d-bb57-b389293e7b2d",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 163
+    },
+    {
+      "h": 6,
+      "i": "782f2f42-26cd-4bd2-ad48-a2a0174b195e",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 163
+    },
+    {
+      "h": 6,
+      "i": "b3d86e10-9af7-4a56-b0a8-86f8efb0620a",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 169
+    },
+    {
+      "h": 6,
+      "i": "f015ed92-2913-4ba0-83bc-ab191fe186bb",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 169
+    },
+    {
+      "h": 6,
+      "i": "da9d59bb-6ebb-4810-8386-fe584112fb2a",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 175
+    },
+    {
+      "h": 6,
+      "i": "3c1839f3-d767-4e2c-9fee-17279c019c07",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 175
+    },
+    {
+      "h": 1,
+      "i": "7ea065d8-ea90-48f4-a0e1-d5e610dec60e",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 181
+    },
+    {
+      "h": 4,
+      "i": "71e01f46-411a-4cba-b088-b813187ba7df",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 182
+    },
+    {
+      "h": 4,
+      "i": "55f7f2e1-6478-4f4a-ab12-ccc7ae68b62b",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 182
+    },
+    {
+      "h": 4,
+      "i": "6648cc02-9a43-4266-ab42-2a13079a1116",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 182
+    },
+    {
+      "h": 6,
+      "i": "8ac9b07d-1284-4158-a080-97ce8a95aa14",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 186
+    },
+    {
+      "h": 6,
+      "i": "caeffd28-1f9e-4aec-84bc-63724b02f3ea",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 186
+    }
+  ],
+  "panelMap": {
+    "fdc4ae9b-97bb-4243-b93b-172b22d8d985": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 4,
+          "i": "f59c72ca-4cc1-47de-ad87-6481d9cf9e9f",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 0,
+          "y": 1
+        },
+        {
+          "h": 4,
+          "i": "ef9fc4b3-955c-4603-92e2-f8f4dcdaef9b",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 3,
+          "y": 1
+        },
+        {
+          "h": 4,
+          "i": "6d5e00f2-6b5b-4a5f-8e22-34fcc41ea3d2",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 6,
+          "y": 1
+        },
+        {
+          "h": 4,
+          "i": "688a87c1-ac60-48f3-9e02-a0dcb7076477",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 9,
+          "y": 1
+        },
+        {
+          "h": 4,
+          "i": "d6cf2fab-354f-45bf-b867-af82e8d65db7",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 0,
+          "y": 5
+        },
+        {
+          "h": 4,
+          "i": "5e7b54ab-ec3d-444e-878a-dd13afadd4ad",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 3,
+          "y": 5
+        },
+        {
+          "h": 4,
+          "i": "edebc4b4-de3d-4a66-940a-f30e3cbd7171",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 6,
+          "y": 5
+        },
+        {
+          "h": 4,
+          "i": "afc80366-5240-4feb-b1c2-0b9aa7d1f076",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 9,
+          "y": 5
+        },
+        {
+          "h": 6,
+          "i": "871ee0a6-0b84-4fe1-8d97-65508c2567d8",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 9
+        },
+        {
+          "h": 6,
+          "i": "08a89f4f-8bf5-4596-ab56-f86f17ef0eaf",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 9
+        }
+      ]
+    },
+    "9c1b27fe-4a60-4697-965b-ba3d854d40b1": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "bec3170f-55c4-45b6-9515-7f8eb1329e52",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 16
+        },
+        {
+          "h": 6,
+          "i": "2b54a944-b7f0-49b7-b870-ef4ad72114b1",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 16
+        },
+        {
+          "h": 6,
+          "i": "83262dc9-72a7-40ff-b1c1-2779ecb4de37",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 22
+        },
+        {
+          "h": 6,
+          "i": "49d2efe4-1e31-469c-9185-f79343b346d5",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 22
+        },
+        {
+          "h": 6,
+          "i": "871b582a-ea51-49ee-a1fd-fc8a0117c7e8",
+          "moved": false,
+          "static": false,
+          "w": 12,
+          "x": 0,
+          "y": 28
+        }
+      ]
+    },
+    "4fc09140-684f-4174-b742-4aaed9d1186f": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 4,
+          "i": "d4d96df2-1617-42fc-808c-67fcb3f8c932",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 0,
+          "y": 35
+        },
+        {
+          "h": 4,
+          "i": "f1ff123a-0c6b-427b-abad-c26f598d24ad",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 4,
+          "y": 35
+        },
+        {
+          "h": 4,
+          "i": "12385d85-4842-4f35-9cfc-dec2898e9e72",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 8,
+          "y": 35
+        },
+        {
+          "h": 6,
+          "i": "acbb4a0b-31c4-4a5d-abcb-95ea5cf9ca97",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 39
+        },
+        {
+          "h": 6,
+          "i": "476930a2-d367-42f9-ad0a-c1bf20848b0d",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 39
+        }
+      ]
+    },
+    "be78b044-aab8-440a-ab9f-fe742d7968f1": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "f8841e58-0ab5-4896-8798-4f32ce2c9a91",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 46
+        },
+        {
+          "h": 6,
+          "i": "37450b45-fe7a-4565-abcd-51cead8c8705",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 46
+        },
+        {
+          "h": 6,
+          "i": "70569755-6683-4dc0-b596-fb6134aa0609",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 52
+        },
+        {
+          "h": 6,
+          "i": "d6c4561c-f7f8-4a5c-9cf9-f212208565a4",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 52
+        }
+      ]
+    },
+    "65a0761a-de20-4859-a7cd-fd17226da224": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 4,
+          "i": "cf7bcc84-f559-4bf5-b094-3e7f4c3c8676",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 0,
+          "y": 59
+        },
+        {
+          "h": 4,
+          "i": "f7155213-0a60-4865-b4fc-4f2ee58ca9d4",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 3,
+          "y": 59
+        },
+        {
+          "h": 4,
+          "i": "4d20c319-a691-4bd2-ac82-068062f5cf1d",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 6,
+          "y": 59
+        },
+        {
+          "h": 4,
+          "i": "28e41f55-7ed9-4911-9896-0d65bcd80b45",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 9,
+          "y": 59
+        },
+        {
+          "h": 6,
+          "i": "ec02e335-d29b-4735-831a-1417729ee57b",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 63
+        },
+        {
+          "h": 6,
+          "i": "7ec6dcd1-0092-4d79-9616-daecea4d7fc1",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 63
+        },
+        {
+          "h": 6,
+          "i": "9c20b0a6-417a-4847-88fe-7804e8feb444",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 69
+        },
+        {
+          "h": 6,
+          "i": "38023e41-fd6d-4d5a-a8b6-947612248480",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 69
+        },
+        {
+          "h": 6,
+          "i": "971f1312-3fbe-4641-b955-29558f4d54c1",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 75
+        },
+        {
+          "h": 6,
+          "i": "a8b66f91-b722-4dca-b1a2-35e060230f6d",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 75
+        }
+      ]
+    },
+    "66478c87-cc44-47e6-a204-f88535516c00": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 4,
+          "i": "eebad8b5-8e30-43d6-a196-6bacb893123c",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 0,
+          "y": 82
+        },
+        {
+          "h": 4,
+          "i": "93670cc1-4c47-4cb2-9f55-a0607c5c0d17",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 4,
+          "y": 82
+        },
+        {
+          "h": 4,
+          "i": "b453df31-4427-4abb-86e4-618434896878",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 8,
+          "y": 82
+        },
+        {
+          "h": 6,
+          "i": "f607d209-6c99-47e9-9ff9-99ffb3fe1f11",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 86
+        },
+        {
+          "h": 6,
+          "i": "40fe913e-1206-4c35-b072-c97ebe96f5ae",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 86
+        },
+        {
+          "h": 6,
+          "i": "adb34f2b-e36f-48bc-82f6-7e36a9b1ccd3",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 92
+        },
+        {
+          "h": 6,
+          "i": "98157687-e4ec-42aa-a97e-29c93fe036c6",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 92
+        }
+      ]
+    },
+    "b3fa1937-2590-4a98-85f6-75cebfee7bc8": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 4,
+          "i": "47a30f57-3ef6-4d4c-a7db-702745839e81",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 0,
+          "y": 99
+        },
+        {
+          "h": 4,
+          "i": "0c48e3d0-f1c6-4273-92f2-dcc4e55366ff",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 4,
+          "y": 99
+        },
+        {
+          "h": 4,
+          "i": "f369855d-7c4f-47a5-927b-2c577e707d8b",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 8,
+          "y": 99
+        },
+        {
+          "h": 6,
+          "i": "91d75d98-9f3c-4dae-85bd-f9796f8789af",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 103
+        },
+        {
+          "h": 6,
+          "i": "19614af6-3952-4834-8f7e-a41e03830a7b",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 103
+        },
+        {
+          "h": 6,
+          "i": "50b3335e-fb35-4d5b-874f-10bdf1f188ac",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 109
+        },
+        {
+          "h": 6,
+          "i": "d3d1e2b4-888f-430b-937b-6f97f0208cbc",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 109
+        },
+        {
+          "h": 6,
+          "i": "8e0cccb1-6cd8-430e-8d31-5344aa6baa44",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 115
+        },
+        {
+          "h": 6,
+          "i": "ac201eff-4628-4a23-8cd1-3d894b0f88d7",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 115
+        }
+      ]
+    },
+    "86e295db-647b-434e-aef6-ccb0d353e01a": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 4,
+          "i": "9a8c33c0-aa94-43af-8e63-fdb61a3dbb84",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 0,
+          "y": 122
+        },
+        {
+          "h": 4,
+          "i": "2a5cbbee-015b-4fb6-a895-f39420526712",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 4,
+          "y": 122
+        },
+        {
+          "h": 4,
+          "i": "275eaa28-e0c6-4caf-9c65-f99324eecd6f",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 8,
+          "y": 122
+        },
+        {
+          "h": 6,
+          "i": "df256cc2-00e8-469e-9de6-b150b4df9645",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 126
+        },
+        {
+          "h": 6,
+          "i": "f2fd98cf-106d-47e2-9e1a-72169756544f",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 126
+        }
+      ]
+    },
+    "e94d1ba1-c665-4b13-a95e-4951fc39dcce": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "920ba478-d6c6-47a4-8bb9-44f479c56bd2",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 133
+        },
+        {
+          "h": 6,
+          "i": "7f2d67d1-0f84-4e81-a64b-43e11ae75989",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 133
+        },
+        {
+          "h": 6,
+          "i": "13c827a2-d14c-40c0-977a-ce726396077b",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 139
+        },
+        {
+          "h": 6,
+          "i": "f4fbbe67-8e68-4aa9-8e11-462e711e6970",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 139
+        }
+      ]
+    },
+    "d7ca8613-51ca-4ca7-a85f-bcccc0f7dc63": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "08275adb-2984-4aa5-bc21-b6d8764036a2",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 146
+        },
+        {
+          "h": 6,
+          "i": "34694e0c-7531-4e81-8612-d322caedf698",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 146
+        }
+      ]
+    },
+    "baa2770d-bd4e-43a9-a67b-a06f3e02f8ea": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 4,
+          "i": "f8e626b8-7886-481d-b39a-3929a61f9667",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 0,
+          "y": 153
+        },
+        {
+          "h": 4,
+          "i": "c9668a64-6d83-4ba2-8249-11f74b24388e",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 3,
+          "y": 153
+        },
+        {
+          "h": 4,
+          "i": "6ad4494f-b772-4e23-8c35-64c4aaa4887d",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 6,
+          "y": 153
+        },
+        {
+          "h": 4,
+          "i": "426fa7e3-254e-4bbb-8c97-9ea99b57aca1",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 9,
+          "y": 153
+        },
+        {
+          "h": 6,
+          "i": "b3447631-b74f-455b-8c56-f42d4a1565bc",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 157
+        },
+        {
+          "h": 6,
+          "i": "368ba6c1-7656-42c2-8761-89dfccbb8158",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 157
+        },
+        {
+          "h": 6,
+          "i": "635d1430-e95a-482d-bb57-b389293e7b2d",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 163
+        },
+        {
+          "h": 6,
+          "i": "782f2f42-26cd-4bd2-ad48-a2a0174b195e",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 163
+        },
+        {
+          "h": 6,
+          "i": "b3d86e10-9af7-4a56-b0a8-86f8efb0620a",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 169
+        },
+        {
+          "h": 6,
+          "i": "f015ed92-2913-4ba0-83bc-ab191fe186bb",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 169
+        },
+        {
+          "h": 6,
+          "i": "da9d59bb-6ebb-4810-8386-fe584112fb2a",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 175
+        },
+        {
+          "h": 6,
+          "i": "3c1839f3-d767-4e2c-9fee-17279c019c07",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 175
+        }
+      ]
+    },
+    "7ea065d8-ea90-48f4-a0e1-d5e610dec60e": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 4,
+          "i": "71e01f46-411a-4cba-b088-b813187ba7df",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 0,
+          "y": 182
+        },
+        {
+          "h": 4,
+          "i": "55f7f2e1-6478-4f4a-ab12-ccc7ae68b62b",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 4,
+          "y": 182
+        },
+        {
+          "h": 4,
+          "i": "6648cc02-9a43-4266-ab42-2a13079a1116",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 8,
+          "y": 182
+        },
+        {
+          "h": 6,
+          "i": "8ac9b07d-1284-4158-a080-97ce8a95aa14",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 186
+        },
+        {
+          "h": 6,
+          "i": "caeffd28-1f9e-4aec-84bc-63724b02f3ea",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 186
+        }
+      ]
+    }
+  },
+  "tags": [
+    "cert-manager",
+    "certificates",
+    "tls",
+    "kubernetes",
+    "acme",
+    "monitoring"
+  ],
+  "title": "Cert-Manager Monitoring Dashboard",
+  "uploadedGrafana": false,
+  "variables": {
+    "2774dc1f-6ed3-4d1c-bbc6-178ce7b22e5f": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Kubernetes namespace where cert-manager components are running",
+      "id": "2774dc1f-6ed3-4d1c-bbc6-178ce7b22e5f",
+      "key": "2774dc1f-6ed3-4d1c-bbc6-178ce7b22e5f",
+      "modificationUUID": "482bcb30-9cf1-4daf-b0c8-52c3c2754c86",
+      "multiSelect": true,
+      "name": "namespace",
+      "order": 0,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'namespace'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name = 'certmanager_certificate_ready_status'",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "version": "v4",
+  "widgets": [
+    {
+      "description": "",
+      "id": "fdc4ae9b-97bb-4243-b93b-172b22d8d985",
+      "panelTypes": "row",
+      "title": "Certificate Overview"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total number of Certificate resources across all namespaces",
+      "fillSpans": false,
+      "id": "f59c72ca-4cc1-47de-ad87-6481d9cf9e9f",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Total",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "55dd4e0d-2b63-4135-8356-fabedf492f32",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Total",
+            "name": "A",
+            "query": "count(certmanager_certificate_ready_status{namespace=~\"$namespace\"})"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Total Certificates",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Certificates in Ready=True state",
+      "fillSpans": false,
+      "id": "ef9fc4b3-955c-4603-92e2-f8f4dcdaef9b",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Ready",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "4a9480ba-3988-4a3c-aaa5-7204e16054eb",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Ready",
+            "name": "A",
+            "query": "sum(certmanager_certificate_ready_status{condition=\"True\", namespace=~\"$namespace\"})"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [
+        {
+          "index": "4fb2b62e-4bcb-44e9-b699-8f34adf5c8a0",
+          "isEditEnabled": false,
+          "keyIndex": 0,
+          "selectedGraph": "value",
+          "thresholdColor": "Green",
+          "thresholdFormat": "Text",
+          "thresholdLabel": "",
+          "thresholdOperator": ">",
+          "thresholdTableOptions": "A",
+          "thresholdUnit": "none",
+          "thresholdValue": 0
+        }
+      ],
+      "title": "Certificates Ready",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Certificates in Ready=False state - requires immediate attention",
+      "fillSpans": false,
+      "id": "6d5e00f2-6b5b-4a5f-8e22-34fcc41ea3d2",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Not Ready",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8b08c99a-a8c5-4e65-a76e-efc9b93809dd",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Not Ready",
+            "name": "A",
+            "query": "sum(certmanager_certificate_ready_status{condition=\"False\", namespace=~\"$namespace\"})"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [
+        {
+          "index": "c99561c5-a12b-4dae-a9ff-1f0892f97804",
+          "isEditEnabled": false,
+          "keyIndex": 0,
+          "selectedGraph": "value",
+          "thresholdColor": "Red",
+          "thresholdFormat": "Text",
+          "thresholdLabel": "",
+          "thresholdOperator": ">",
+          "thresholdTableOptions": "A",
+          "thresholdUnit": "none",
+          "thresholdValue": 0
+        }
+      ],
+      "title": "Certificates Not Ready",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Certificates expiring within the next 7 days",
+      "fillSpans": false,
+      "id": "688a87c1-ac60-48f3-9e02-a0dcb7076477",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Expiring Soon",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a73bab45-058a-4cd1-847d-a94afe2effaa",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Expiring Soon",
+            "name": "A",
+            "query": "count(certmanager_certificate_expiration_timestamp_seconds{namespace=~\"$namespace\"} - time() < 7 * 24 * 3600 > 0)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [
+        {
+          "index": "5e66168c-63b0-4149-9403-75ad1c782067",
+          "isEditEnabled": false,
+          "keyIndex": 0,
+          "selectedGraph": "value",
+          "thresholdColor": "Yellow",
+          "thresholdFormat": "Text",
+          "thresholdLabel": "",
+          "thresholdOperator": ">",
+          "thresholdTableOptions": "A",
+          "thresholdUnit": "none",
+          "thresholdValue": 0
+        }
+      ],
+      "title": "Certificates Expiring <7d",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Certificates expiring within 24 hours - critical",
+      "fillSpans": false,
+      "id": "d6cf2fab-354f-45bf-b867-af82e8d65db7",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Expiring <24h",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b85d46b1-5bbf-495f-ad47-bdda63d21ce8",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Expiring <24h",
+            "name": "A",
+            "query": "count(certmanager_certificate_expiration_timestamp_seconds{namespace=~\"$namespace\"} - time() < 86400 > 0)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [
+        {
+          "index": "c89eb8aa-a4a1-4919-9ac3-9dc23b5de09b",
+          "isEditEnabled": false,
+          "keyIndex": 0,
+          "selectedGraph": "value",
+          "thresholdColor": "Red",
+          "thresholdFormat": "Text",
+          "thresholdLabel": "",
+          "thresholdOperator": ">",
+          "thresholdTableOptions": "A",
+          "thresholdUnit": "none",
+          "thresholdValue": 0
+        }
+      ],
+      "title": "Certificates Expiring <24h",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Certificates past their expiration timestamp",
+      "fillSpans": false,
+      "id": "5e7b54ab-ec3d-444e-878a-dd13afadd4ad",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Expired",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9028bb0b-7286-4704-aade-428e88642376",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Expired",
+            "name": "A",
+            "query": "count(certmanager_certificate_expiration_timestamp_seconds{namespace=~\"$namespace\"} - time() < 0)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [
+        {
+          "index": "7ba67af4-30f5-440e-8703-3d8cdcb1b739",
+          "isEditEnabled": false,
+          "keyIndex": 0,
+          "selectedGraph": "value",
+          "thresholdColor": "Red",
+          "thresholdFormat": "Text",
+          "thresholdLabel": "",
+          "thresholdOperator": ">",
+          "thresholdTableOptions": "A",
+          "thresholdUnit": "none",
+          "thresholdValue": 0
+        }
+      ],
+      "title": "Expired Certificates",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Average time remaining before certificate expiration across all certs",
+      "fillSpans": false,
+      "id": "edebc4b4-de3d-4a66-940a-f30e3cbd7171",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Avg TTL",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "47d9b0dc-af69-4cb6-bd34-83f75037b492",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Avg TTL",
+            "name": "A",
+            "query": "avg(certmanager_certificate_expiration_timestamp_seconds{namespace=~\"$namespace\"} - time())"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Avg Time to Expiry",
+      "yAxisUnit": "s",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Shortest time to expiration across all certs - the most urgent certificate",
+      "fillSpans": false,
+      "id": "afc80366-5240-4feb-b1c2-0b9aa7d1f076",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Min TTL",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f062c15e-332c-42e8-85c6-125856c65b6f",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Min TTL",
+            "name": "A",
+            "query": "min(certmanager_certificate_expiration_timestamp_seconds{namespace=~\"$namespace\"} - time() > 0)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Min Time to Expiry",
+      "yAxisUnit": "s",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Time series of certificate ready status grouped by condition",
+      "fillSpans": false,
+      "id": "871ee0a6-0b84-4fe1-8d97-65508c2567d8",
+      "isStacked": true,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{condition}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d1df8c7d-9175-4da6-915e-a728fcce7ea3",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{condition}}",
+            "name": "A",
+            "query": "sum by (condition) (certmanager_certificate_ready_status{namespace=~\"$namespace\"})"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Certificate Ready Status Over Time",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Count of certificates expiring within 7/30/90 days over time",
+      "fillSpans": false,
+      "id": "08a89f4f-8bf5-4596-ab56-f86f17ef0eaf",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "<7 days",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "<30 days",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "C",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "<90 days",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "C",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c0e74ff1-5cad-40a4-9135-46d47bbf11df",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "<7 days",
+            "name": "A",
+            "query": "count(certmanager_certificate_expiration_timestamp_seconds{namespace=~\"$namespace\"} - time() < 7 * 86400 > 0)"
+          },
+          {
+            "disabled": false,
+            "legend": "<30 days",
+            "name": "B",
+            "query": "count(certmanager_certificate_expiration_timestamp_seconds{namespace=~\"$namespace\"} - time() < 30 * 86400 > 0)"
+          },
+          {
+            "disabled": false,
+            "legend": "<90 days",
+            "name": "C",
+            "query": "count(certmanager_certificate_expiration_timestamp_seconds{namespace=~\"$namespace\"} - time() < 90 * 86400 > 0)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Certificates Expiring Soon (Count Over Time)",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "description": "",
+      "id": "9c1b27fe-4a60-4697-965b-ba3d854d40b1",
+      "panelTypes": "row",
+      "title": "Certificate Details"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Time remaining until each certificate expires, grouped by name and namespace",
+      "fillSpans": false,
+      "id": "bec3170f-55c4-45b6-9515-7f8eb1329e52",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{name}} / {{namespace}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "33eaf119-0880-474e-a88d-f4ff9807b53e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{name}} / {{namespace}}",
+            "name": "A",
+            "query": "(certmanager_certificate_expiration_timestamp_seconds{namespace=~\"$namespace\"} - time()) / 86400"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Certificate Expiry Countdown",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Time until next renewal attempt for each certificate",
+      "fillSpans": false,
+      "id": "2b54a944-b7f0-49b7-b870-ef4ad72114b1",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{name}} / {{namespace}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "24365541-bab2-42e8-a23a-4ce435cfa63f",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{name}} / {{namespace}}",
+            "name": "A",
+            "query": "(certmanager_certificate_renewal_timestamp_seconds{namespace=~\"$namespace\"} - time()) / 3600"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Certificate Renewal Countdown",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Certificate expiry timestamps broken down by namespace",
+      "fillSpans": false,
+      "id": "83262dc9-72a7-40ff-b1c1-2779ecb4de37",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{name}} ({{namespace}})",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "1227b2a1-c912-421d-a675-2aa73b3379f5",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{name}} ({{namespace}})",
+            "name": "A",
+            "query": "sort_desc(certmanager_certificate_expiration_timestamp_seconds{namespace=~\"$namespace\"} - time()) / 86400"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Certificate Expiry per Namespace",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Per-certificate readiness status over time",
+      "fillSpans": false,
+      "id": "49d2efe4-1e31-469c-9185-f79343b346d5",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{name}} ({{namespace}})",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "10451740-ac30-428a-8b67-064638b646c5",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{name}} ({{namespace}})",
+            "name": "A",
+            "query": "certmanager_certificate_ready_status{condition=\"True\", namespace=~\"$namespace\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Certificate Ready Status per Certificate",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {
+        "A": "none"
+      },
+      "description": "Table view of all certificates with their remaining lifetime in days",
+      "fillSpans": false,
+      "id": "871b582a-ea51-49ee-a1fd-fc8a0117c7e8",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "table",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{name}} ({{namespace}})",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "911a951f-4afe-4b9f-b886-5aa257a63a65",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{name}} ({{namespace}})",
+            "name": "A",
+            "query": "sort_desc((certmanager_certificate_expiration_timestamp_seconds{namespace=~\"$namespace\"} - time()) / 86400)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Certificate Lifetime (Expiry - Now)",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "id": "4fc09140-684f-4174-b742-4aaed9d1186f",
+      "panelTypes": "row",
+      "title": "Issuer Health"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total number of Issuer and ClusterIssuer resources",
+      "fillSpans": false,
+      "id": "d4d96df2-1617-42fc-808c-67fcb3f8c932",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Total",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "7879ead0-5b64-4e7e-bae1-53b330616984",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Total",
+            "name": "A",
+            "query": "count(certmanager_controller_sync_call_count{controller=~\"issuers|clusterissuers\", namespace=~\"$namespace\"})"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Total Issuers",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Percentage of issuer sync operations that succeeded",
+      "fillSpans": false,
+      "id": "f1ff123a-0c6b-427b-abad-c26f598d24ad",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "% Success",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "e9f46f86-9c25-4459-9551-dd8baf82e758",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "% Success",
+            "name": "A",
+            "query": "sum(rate(certmanager_controller_sync_call_count{controller=~\"issuers|clusterissuers\", status=\"success\", namespace=~\"$namespace\"}[5m])) / sum(rate(certmanager_controller_sync_call_count{controller=~\"issuers|clusterissuers\", namespace=~\"$namespace\"}[5m])) * 100"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Issuer Sync Success Rate",
+      "yAxisUnit": "percent",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total issuer sync errors",
+      "fillSpans": false,
+      "id": "12385d85-4842-4f35-9cfc-dec2898e9e72",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Errors/sec",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "e9b0eb1a-a2c5-4457-be99-82f068c57e36",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Errors/sec",
+            "name": "A",
+            "query": "sum(rate(certmanager_controller_sync_call_count{controller=~\"issuers|clusterissuers\", status=\"error\", namespace=~\"$namespace\"}[5m]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [
+        {
+          "index": "086934c1-b639-42c0-81c1-ab7bd8634dd5",
+          "isEditEnabled": false,
+          "keyIndex": 0,
+          "selectedGraph": "value",
+          "thresholdColor": "Red",
+          "thresholdFormat": "Text",
+          "thresholdLabel": "",
+          "thresholdOperator": ">",
+          "thresholdTableOptions": "A",
+          "thresholdUnit": "none",
+          "thresholdValue": 0
+        }
+      ],
+      "title": "Issuer Sync Errors",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of issuer/clusterissuer sync operations over time, by status",
+      "fillSpans": false,
+      "id": "acbb4a0b-31c4-4a5d-abcb-95ea5cf9ca97",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{controller}} - {{status}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "cceae38a-e56c-469d-a5e4-f45d756b9060",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{controller}} - {{status}}",
+            "name": "A",
+            "query": "sum by (controller, status) (rate(certmanager_controller_sync_call_count{controller=~\"issuers|clusterissuers\", namespace=~\"$namespace\"}[5m]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Issuer Sync Rate Over Time",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of certificates managed per issuer over time",
+      "fillSpans": false,
+      "id": "476930a2-d367-42f9-ad0a-c1bf20848b0d",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{issuer_name}} ({{issuer_kind}})",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "390967d5-f3a6-425c-a5bf-49d6dd58877e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{issuer_name}} ({{issuer_kind}})",
+            "name": "A",
+            "query": "count by (issuer_name, issuer_kind) (certmanager_certificate_ready_status{condition=\"True\", namespace=~\"$namespace\"})"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Certificates per Issuer",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "description": "",
+      "id": "be78b044-aab8-440a-ab9f-fe742d7968f1",
+      "panelTypes": "row",
+      "title": "Certificate Requests & Orders"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of CertificateRequest controller sync operations",
+      "fillSpans": false,
+      "id": "f8841e58-0ab5-4896-8798-4f32ce2c9a91",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "ACME - {{status}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "CA - {{status}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "C",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "SelfSigned - {{status}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "C",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "4a931aac-a353-44c7-8da4-1a6583ee454f",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "ACME - {{status}}",
+            "name": "A",
+            "query": "sum by (status) (rate(certmanager_controller_sync_call_count{controller=\"certificaterequests-issuer-acme\", namespace=~\"$namespace\"}[5m]))"
+          },
+          {
+            "disabled": false,
+            "legend": "CA - {{status}}",
+            "name": "B",
+            "query": "sum by (status) (rate(certmanager_controller_sync_call_count{controller=\"certificaterequests-issuer-ca\", namespace=~\"$namespace\"}[5m]))"
+          },
+          {
+            "disabled": false,
+            "legend": "SelfSigned - {{status}}",
+            "name": "C",
+            "query": "sum by (status) (rate(certmanager_controller_sync_call_count{controller=\"certificaterequests-issuer-selfsigned\", namespace=~\"$namespace\"}[5m]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "CertificateRequest Sync Rate",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of ACME Order controller sync operations",
+      "fillSpans": false,
+      "id": "37450b45-fe7a-4565-abcd-51cead8c8705",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{status}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "bac6c94c-9fff-4eb7-b234-213113dcc3ef",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{status}}",
+            "name": "A",
+            "query": "sum by (status) (rate(certmanager_controller_sync_call_count{controller=\"orders\", namespace=~\"$namespace\"}[5m]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Order Sync Rate",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of ACME Challenge controller sync operations by status",
+      "fillSpans": false,
+      "id": "70569755-6683-4dc0-b596-fb6134aa0609",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{status}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "cdc81c5f-1307-4ff4-a5db-e074f884abb6",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{status}}",
+            "name": "A",
+            "query": "sum by (status) (rate(certmanager_controller_sync_call_count{controller=\"challenges\", namespace=~\"$namespace\"}[5m]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Challenge Sync Rate",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of the main certificates controller sync operations",
+      "fillSpans": false,
+      "id": "d6c4561c-f7f8-4a5c-9cf9-f212208565a4",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{controller}} - {{status}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "50a034ac-e6e5-46cc-83d2-3cd8b8ee0af0",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{controller}} - {{status}}",
+            "name": "A",
+            "query": "sum by (status) (rate(certmanager_controller_sync_call_count{controller=~\"certificates-trigger|certificates-issuing|certificates-key-manager|certificates-readiness|certificates-request-manager\", namespace=~\"$namespace\"}[5m]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Certificate Controller Sync Rate",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "description": "",
+      "id": "65a0761a-de20-4859-a7cd-fd17226da224",
+      "panelTypes": "row",
+      "title": "ACME Operations"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of ACME client HTTP requests per second",
+      "fillSpans": false,
+      "id": "cf7bcc84-f559-4bf5-b094-3e7f4c3c8676",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "req/s",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9f3291ec-f90f-41cc-9f9d-729f5b0b193f",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "req/s",
+            "name": "A",
+            "query": "sum(rate(certmanager_http_acme_client_request_count{namespace=~\"$namespace\"}[5m]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "ACME Client Requests/sec",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Percentage of ACME requests returning 2xx status",
+      "fillSpans": false,
+      "id": "f7155213-0a60-4865-b4fc-4f2ee58ca9d4",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "% Success",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "979b461a-056f-4cce-8af6-60f1a5d85ef8",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "% Success",
+            "name": "A",
+            "query": "sum(rate(certmanager_http_acme_client_request_count{status=~\"2..\", namespace=~\"$namespace\"}[5m])) / sum(rate(certmanager_http_acme_client_request_count{namespace=~\"$namespace\"}[5m])) * 100"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "ACME Request Success Rate",
+      "yAxisUnit": "percent",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of ACME requests returning non-2xx status",
+      "fillSpans": false,
+      "id": "4d20c319-a691-4bd2-ac82-068062f5cf1d",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "err/s",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d464342c-4909-4389-80dd-f918b9f2fa69",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "err/s",
+            "name": "A",
+            "query": "sum(rate(certmanager_http_acme_client_request_count{status!~\"2..\", namespace=~\"$namespace\"}[5m]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [
+        {
+          "index": "17a87fc0-c79b-49a3-a04d-7ef8505c877e",
+          "isEditEnabled": false,
+          "keyIndex": 0,
+          "selectedGraph": "value",
+          "thresholdColor": "Red",
+          "thresholdFormat": "Text",
+          "thresholdLabel": "",
+          "thresholdOperator": ">",
+          "thresholdTableOptions": "A",
+          "thresholdUnit": "none",
+          "thresholdValue": 0
+        }
+      ],
+      "title": "ACME Request Errors/sec",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Average duration of ACME HTTP requests",
+      "fillSpans": false,
+      "id": "28e41f55-7ed9-4911-9896-0d65bcd80b45",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "avg latency",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "675c5872-fb57-4d7b-8dd5-7b8cfe06589f",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "avg latency",
+            "name": "A",
+            "query": "sum(rate(certmanager_http_acme_client_request_duration_seconds_sum{namespace=~\"$namespace\"}[5m])) / sum(rate(certmanager_http_acme_client_request_duration_seconds_count{namespace=~\"$namespace\"}[5m]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "ACME Avg Request Duration",
+      "yAxisUnit": "s",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "ACME HTTP request rate broken down by HTTP status code",
+      "fillSpans": false,
+      "id": "ec02e335-d29b-4735-831a-1417729ee57b",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{status}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "67a0efd6-1720-49ea-b715-101e53c2bf85",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{status}}",
+            "name": "A",
+            "query": "sum by (status) (rate(certmanager_http_acme_client_request_count{namespace=~\"$namespace\"}[5m]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "ACME Request Rate by Status Code",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "ACME HTTP request rate by HTTP method and path",
+      "fillSpans": false,
+      "id": "7ec6dcd1-0092-4d79-9616-daecea4d7fc1",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{method}} {{path}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8cb2f8a5-f283-4f50-bfd9-84a6ef241bb7",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{method}} {{path}}",
+            "name": "A",
+            "query": "sum by (method, path) (rate(certmanager_http_acme_client_request_count{namespace=~\"$namespace\"}[5m]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "ACME Request Rate by Method & Path",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "ACME HTTP request duration percentiles",
+      "fillSpans": false,
+      "id": "9c20b0a6-417a-4847-88fe-7804e8feb444",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p50",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p90",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "C",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p99",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "C",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a20357cf-8e48-4444-82af-f36cd2328e75",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "p50",
+            "name": "A",
+            "query": "histogram_quantile(0.50, sum by (le) (rate(certmanager_http_acme_client_request_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))"
+          },
+          {
+            "disabled": false,
+            "legend": "p90",
+            "name": "B",
+            "query": "histogram_quantile(0.90, sum by (le) (rate(certmanager_http_acme_client_request_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))"
+          },
+          {
+            "disabled": false,
+            "legend": "p99",
+            "name": "C",
+            "query": "histogram_quantile(0.99, sum by (le) (rate(certmanager_http_acme_client_request_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "ACME Request Duration (p50/p90/p99)",
+      "yAxisUnit": "s",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "ACME HTTP request average duration per ACME server host",
+      "fillSpans": false,
+      "id": "38023e41-fd6d-4d5a-a8b6-947612248480",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{host}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "490fbf86-0184-4478-8566-5c47e691beef",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{host}}",
+            "name": "A",
+            "query": "sum by (host) (rate(certmanager_http_acme_client_request_duration_seconds_sum{namespace=~\"$namespace\"}[5m])) / sum by (host) (rate(certmanager_http_acme_client_request_duration_seconds_count{namespace=~\"$namespace\"}[5m]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "ACME Request Duration by Host",
+      "yAxisUnit": "s",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "ACME HTTP request rate grouped by ACME server host",
+      "fillSpans": false,
+      "id": "971f1312-3fbe-4641-b955-29558f4d54c1",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{host}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "5a136446-481b-43d6-b593-7aa8293b518c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{host}}",
+            "name": "A",
+            "query": "sum by (host) (rate(certmanager_http_acme_client_request_count{namespace=~\"$namespace\"}[5m]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "ACME Requests by Host",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Breakdown of non-success ACME requests by status code and method",
+      "fillSpans": false,
+      "id": "a8b66f91-b722-4dca-b1a2-35e060230f6d",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{status}} {{method}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "bd30b12a-67c7-417d-8a01-91a8b0c9a652",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{status}} {{method}}",
+            "name": "A",
+            "query": "sum by (status, method) (rate(certmanager_http_acme_client_request_count{status!~\"2..\", namespace=~\"$namespace\"}[5m]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "ACME Error Rate by Status & Method",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "description": "",
+      "id": "66478c87-cc44-47e6-a204-f88535516c00",
+      "panelTypes": "row",
+      "title": "Controller Performance"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Overall rate of all controller sync operations",
+      "fillSpans": false,
+      "id": "eebad8b5-8e30-43d6-a196-6bacb893123c",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "syncs/s",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6b697089-8ca9-4917-8317-f39d703c6613",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "syncs/s",
+            "name": "A",
+            "query": "sum(rate(certmanager_controller_sync_call_count{namespace=~\"$namespace\"}[5m]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Controller Sync Total Rate",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Global sync success percentage across all controllers",
+      "fillSpans": false,
+      "id": "93670cc1-4c47-4cb2-9f55-a0607c5c0d17",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "% Success",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9ee2fb3a-fa6e-4776-936e-aeb50b0eb057",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "% Success",
+            "name": "A",
+            "query": "sum(rate(certmanager_controller_sync_call_count{status=\"success\", namespace=~\"$namespace\"}[5m])) / sum(rate(certmanager_controller_sync_call_count{namespace=~\"$namespace\"}[5m])) * 100"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Controller Sync Success Rate",
+      "yAxisUnit": "percent",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total error rate across all controllers",
+      "fillSpans": false,
+      "id": "b453df31-4427-4abb-86e4-618434896878",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "errors/s",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a3a9b1a5-55e7-4f8d-974f-93e90d5568e3",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "errors/s",
+            "name": "A",
+            "query": "sum(rate(certmanager_controller_sync_call_count{status=\"error\", namespace=~\"$namespace\"}[5m]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [
+        {
+          "index": "102a49dc-c66e-497f-82ba-9121ae0f6171",
+          "isEditEnabled": false,
+          "keyIndex": 0,
+          "selectedGraph": "value",
+          "thresholdColor": "Red",
+          "thresholdFormat": "Text",
+          "thresholdLabel": "",
+          "thresholdOperator": ">",
+          "thresholdTableOptions": "A",
+          "thresholdUnit": "none",
+          "thresholdValue": 0
+        }
+      ],
+      "title": "Controller Sync Errors/sec",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Sync operation rate broken down by individual controller",
+      "fillSpans": false,
+      "id": "f607d209-6c99-47e9-9ff9-99ffb3fe1f11",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{controller}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "421b72fe-1fbe-42d9-84ab-22fdbb39849d",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{controller}}",
+            "name": "A",
+            "query": "sum by (controller) (rate(certmanager_controller_sync_call_count{namespace=~\"$namespace\"}[5m]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Controller Sync Rate by Controller",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Error rate per individual controller",
+      "fillSpans": false,
+      "id": "40fe913e-1206-4c35-b072-c97ebe96f5ae",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{controller}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0cc4a7fe-eb82-4168-886c-7f4edcfa3638",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{controller}}",
+            "name": "A",
+            "query": "sum by (controller) (rate(certmanager_controller_sync_call_count{status=\"error\", namespace=~\"$namespace\"}[5m]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Controller Sync Error Rate by Controller",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Stacked view of success and error sync operations over time",
+      "fillSpans": false,
+      "id": "adb34f2b-e36f-48bc-82f6-7e36a9b1ccd3",
+      "isStacked": true,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{status}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "98a5a456-3f85-4358-9d53-cb4a12c18e54",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{status}}",
+            "name": "A",
+            "query": "sum by (status) (rate(certmanager_controller_sync_call_count{namespace=~\"$namespace\"}[5m]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Controller Sync Success vs Error",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Controller sync call duration percentiles across all controllers",
+      "fillSpans": false,
+      "id": "98157687-e4ec-42aa-a97e-29c93fe036c6",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p50",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p90",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "C",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p99",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "C",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "674306b4-e75d-43b3-9645-8fb0f84f500b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "p50",
+            "name": "A",
+            "query": "histogram_quantile(0.50, sum by (le) (rate(certmanager_controller_sync_call_count{namespace=~\"$namespace\"}[5m])))"
+          },
+          {
+            "disabled": false,
+            "legend": "p90",
+            "name": "B",
+            "query": "histogram_quantile(0.90, sum by (le) (rate(certmanager_controller_sync_call_count{namespace=~\"$namespace\"}[5m])))"
+          },
+          {
+            "disabled": false,
+            "legend": "p99",
+            "name": "C",
+            "query": "histogram_quantile(0.99, sum by (le) (rate(certmanager_controller_sync_call_count{namespace=~\"$namespace\"}[5m])))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Controller Sync Duration (p50/p90/p99)",
+      "yAxisUnit": "s",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "description": "",
+      "id": "b3fa1937-2590-4a98-85f6-75cebfee7bc8",
+      "panelTypes": "row",
+      "title": "Work Queue Metrics"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Current depth of the controller work queues",
+      "fillSpans": false,
+      "id": "47a30f57-3ef6-4d4c-a7db-702745839e81",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Total Depth",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ea2d2c19-b826-4b42-ab30-d9a97c1e7f31",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Total Depth",
+            "name": "A",
+            "query": "sum(workqueue_depth{namespace=~\"$namespace\"})"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Queue Depth",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of items being added to work queues",
+      "fillSpans": false,
+      "id": "0c48e3d0-f1c6-4273-92f2-dcc4e55366ff",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "adds/s",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "58cdfe81-f70a-4152-8566-e02066c265b7",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "adds/s",
+            "name": "A",
+            "query": "sum(rate(workqueue_adds_total{namespace=~\"$namespace\"}[5m]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Queue Adds Rate",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Items currently being processed (started but not finished)",
+      "fillSpans": false,
+      "id": "f369855d-7c4f-47a5-927b-2c577e707d8b",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "seconds",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9114f7f2-694d-46c9-9710-2efec4727ad9",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "seconds",
+            "name": "A",
+            "query": "sum(workqueue_unfinished_work_seconds{namespace=~\"$namespace\"})"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Queue Unfinished Work",
+      "yAxisUnit": "s",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Work queue depth per queue name over time",
+      "fillSpans": false,
+      "id": "91d75d98-9f3c-4dae-85bd-f9796f8789af",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f8c5fd06-e1ed-4b6d-a26d-2346fd21123a",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{name}}",
+            "name": "A",
+            "query": "workqueue_depth{namespace=~\"$namespace\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Work Queue Depth Over Time",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of items added to each work queue",
+      "fillSpans": false,
+      "id": "19614af6-3952-4834-8f7e-a41e03830a7b",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8f237720-dc10-47d6-a7cf-1877b70c9869",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{name}}",
+            "name": "A",
+            "query": "rate(workqueue_adds_total{namespace=~\"$namespace\"}[5m])"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Work Queue Adds Rate",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Time items spend waiting in the queue before being processed",
+      "fillSpans": false,
+      "id": "50b3335e-fb35-4d5b-874f-10bdf1f188ac",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p50 {{name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p90 {{name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "C",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p99 {{name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "C",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "18ad0fa1-a7f1-49b6-ada0-953823ebe3ae",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "p50 {{name}}",
+            "name": "A",
+            "query": "histogram_quantile(0.50, sum by (le, name) (rate(workqueue_queue_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))"
+          },
+          {
+            "disabled": false,
+            "legend": "p90 {{name}}",
+            "name": "B",
+            "query": "histogram_quantile(0.90, sum by (le, name) (rate(workqueue_queue_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))"
+          },
+          {
+            "disabled": false,
+            "legend": "p99 {{name}}",
+            "name": "C",
+            "query": "histogram_quantile(0.99, sum by (le, name) (rate(workqueue_queue_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Work Queue Latency (p50/p90/p99)",
+      "yAxisUnit": "s",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Time taken to process items once dequeued",
+      "fillSpans": false,
+      "id": "d3d1e2b4-888f-430b-937b-6f97f0208cbc",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p50 {{name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p90 {{name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "C",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p99 {{name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "C",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "975cc25d-c151-4ee4-8169-6206708f5a23",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "p50 {{name}}",
+            "name": "A",
+            "query": "histogram_quantile(0.50, sum by (le, name) (rate(workqueue_work_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))"
+          },
+          {
+            "disabled": false,
+            "legend": "p90 {{name}}",
+            "name": "B",
+            "query": "histogram_quantile(0.90, sum by (le, name) (rate(workqueue_work_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))"
+          },
+          {
+            "disabled": false,
+            "legend": "p99 {{name}}",
+            "name": "C",
+            "query": "histogram_quantile(0.99, sum by (le, name) (rate(workqueue_work_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Work Queue Processing Duration (p50/p90/p99)",
+      "yAxisUnit": "s",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of item retries across work queues",
+      "fillSpans": false,
+      "id": "8e0cccb1-6cd8-430e-8d31-5344aa6baa44",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "425c62c7-c872-4295-9eb3-31ac294a270f",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{name}}",
+            "name": "A",
+            "query": "rate(workqueue_retries_total{namespace=~\"$namespace\"}[5m])"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Queue Retries Rate",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Duration of the longest running processor in each work queue",
+      "fillSpans": false,
+      "id": "ac201eff-4628-4a23-8cd1-3d894b0f88d7",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ca9a45e3-d5ba-490c-b128-5a98745d4438",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{name}}",
+            "name": "A",
+            "query": "workqueue_longest_running_processor_seconds{namespace=~\"$namespace\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Longest Running Processor",
+      "yAxisUnit": "s",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "description": "",
+      "id": "86e295db-647b-434e-aef6-ccb0d353e01a",
+      "panelTypes": "row",
+      "title": "Webhook Metrics"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of admission webhook requests received",
+      "fillSpans": false,
+      "id": "9a8c33c0-aa94-43af-8e63-fdb61a3dbb84",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "req/s",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6d7b686f-1a3e-4dd0-a357-208892b186c5",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "req/s",
+            "name": "A",
+            "query": "sum(rate(certmanager_http_webhook_request_count{namespace=~\"$namespace\"}[5m]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Webhook Request Rate",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Percentage of webhook requests returning success status",
+      "fillSpans": false,
+      "id": "2a5cbbee-015b-4fb6-a895-f39420526712",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "% Success",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0ad611ea-68aa-41c0-bea7-bb7a0261b71a",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "% Success",
+            "name": "A",
+            "query": "sum(rate(certmanager_http_webhook_request_count{status=~\"2..\", namespace=~\"$namespace\"}[5m])) / sum(rate(certmanager_http_webhook_request_count{namespace=~\"$namespace\"}[5m])) * 100"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Webhook Success Rate",
+      "yAxisUnit": "percent",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Average webhook request processing duration",
+      "fillSpans": false,
+      "id": "275eaa28-e0c6-4caf-9c65-f99324eecd6f",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "avg",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "113ba4bf-4395-4bad-9a53-83e005944f13",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "avg",
+            "name": "A",
+            "query": "sum(rate(certmanager_http_webhook_request_duration_seconds_sum{namespace=~\"$namespace\"}[5m])) / sum(rate(certmanager_http_webhook_request_duration_seconds_count{namespace=~\"$namespace\"}[5m]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Webhook Avg Latency",
+      "yAxisUnit": "s",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Webhook request rate broken down by HTTP status code",
+      "fillSpans": false,
+      "id": "df256cc2-00e8-469e-9de6-b150b4df9645",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{status}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "bccca440-737d-41bd-ab1d-f0c30c315648",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{status}}",
+            "name": "A",
+            "query": "sum by (status) (rate(certmanager_http_webhook_request_count{namespace=~\"$namespace\"}[5m]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Webhook Request Rate by Status",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Webhook request duration percentiles",
+      "fillSpans": false,
+      "id": "f2fd98cf-106d-47e2-9e1a-72169756544f",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p50",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p90",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "C",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p99",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "C",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "55ccc590-5bd4-443c-b4b3-0fb7f77fcf1f",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "p50",
+            "name": "A",
+            "query": "histogram_quantile(0.50, sum by (le) (rate(certmanager_http_webhook_request_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))"
+          },
+          {
+            "disabled": false,
+            "legend": "p90",
+            "name": "B",
+            "query": "histogram_quantile(0.90, sum by (le) (rate(certmanager_http_webhook_request_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))"
+          },
+          {
+            "disabled": false,
+            "legend": "p99",
+            "name": "C",
+            "query": "histogram_quantile(0.99, sum by (le) (rate(certmanager_http_webhook_request_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Webhook Request Duration (p50/p90/p99)",
+      "yAxisUnit": "s",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "description": "",
+      "id": "e94d1ba1-c665-4b13-a95e-4951fc39dcce",
+      "panelTypes": "row",
+      "title": "Kubernetes API & Client Metrics"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of requests to the Kubernetes API server from cert-manager",
+      "fillSpans": false,
+      "id": "920ba478-d6c6-47a4-8bb9-44f479c56bd2",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{verb}} {{resource}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f4b00b05-9096-4f78-ab06-047c936edf1f",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{verb}} {{resource}}",
+            "name": "A",
+            "query": "sum by (verb, resource) (rate(rest_client_requests_total{namespace=~\"$namespace\"}[5m]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "K8s API Request Rate",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of failed Kubernetes API requests (non-2xx responses)",
+      "fillSpans": false,
+      "id": "7f2d67d1-0f84-4e81-a64b-43e11ae75989",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{code}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "36b85fa4-3b40-4df0-b45b-15ce92566a95",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{code}}",
+            "name": "A",
+            "query": "sum by (code) (rate(rest_client_requests_total{namespace=~\"$namespace\", code!~\"2..\"}[5m]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "K8s API Request Errors",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Latency of Kubernetes API requests from cert-manager",
+      "fillSpans": false,
+      "id": "13c827a2-d14c-40c0-977a-ce726396077b",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p50 {{verb}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p90 {{verb}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "C",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p99 {{verb}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "C",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "27ed6bbd-64a4-44fb-9bdd-7d83faf68d9e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "p50 {{verb}}",
+            "name": "A",
+            "query": "histogram_quantile(0.50, sum by (le, verb) (rate(rest_client_request_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))"
+          },
+          {
+            "disabled": false,
+            "legend": "p90 {{verb}}",
+            "name": "B",
+            "query": "histogram_quantile(0.90, sum by (le, verb) (rate(rest_client_request_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))"
+          },
+          {
+            "disabled": false,
+            "legend": "p99 {{verb}}",
+            "name": "C",
+            "query": "histogram_quantile(0.99, sum by (le, verb) (rate(rest_client_request_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "K8s API Request Latency (p50/p90/p99)",
+      "yAxisUnit": "s",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Time spent waiting for client-side rate limiter",
+      "fillSpans": false,
+      "id": "f4fbbe67-8e68-4aa9-8e11-462e711e6970",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "rate limiter wait",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "822b1c29-e0e9-4955-9416-ba046c4f9530",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "rate limiter wait",
+            "name": "A",
+            "query": "rate(rest_client_rate_limiter_duration_seconds_sum{namespace=~\"$namespace\"}[5m]) / rate(rest_client_rate_limiter_duration_seconds_count{namespace=~\"$namespace\"}[5m])"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "K8s Client Rate Limiter Duration",
+      "yAxisUnit": "s",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "description": "",
+      "id": "d7ca8613-51ca-4ca7-a85f-bcccc0f7dc63",
+      "panelTypes": "row",
+      "title": "Leader Election"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Whether this instance currently holds the leader lease (1 = leader)",
+      "fillSpans": false,
+      "id": "08275adb-2984-4aa5-bc21-b6d8764036a2",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d73d5b34-746b-48fb-8a8c-770e9e0a6283",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{name}}",
+            "name": "A",
+            "query": "leader_election_master_status{namespace=~\"$namespace\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Leader Election Status",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of leader election transitions (high rate indicates instability)",
+      "fillSpans": false,
+      "id": "34694e0c-7531-4e81-8612-d322caedf698",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "790d24a4-dadb-45e6-b7e1-ec8140ae0c79",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{name}}",
+            "name": "A",
+            "query": "rate(leader_election_master_status{namespace=~\"$namespace\"}[5m])"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Leader Election Transitions",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "description": "",
+      "id": "baa2770d-bd4e-43a9-a67b-a06f3e02f8ea",
+      "panelTypes": "row",
+      "title": "Resource Usage"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "CPU time consumed by the cert-manager process",
+      "fillSpans": false,
+      "id": "f8e626b8-7886-481d-b39a-3929a61f9667",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "CPU cores",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0d6f8f8a-3626-4f46-abc2-e6ef8ffb96f5",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "CPU cores",
+            "name": "A",
+            "query": "rate(process_cpu_seconds_total{namespace=~\"$namespace\", job=~\".*cert-manager.*\"}[5m])"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "CPU Usage",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Resident set size memory used by cert-manager",
+      "fillSpans": false,
+      "id": "c9668a64-6d83-4ba2-8249-11f74b24388e",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "RSS",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9fb70dbd-61b3-498a-bdb7-51f24003393d",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "RSS",
+            "name": "A",
+            "query": "process_resident_memory_bytes{namespace=~\"$namespace\", job=~\".*cert-manager.*\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Memory (RSS)",
+      "yAxisUnit": "bytes",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of active goroutines in the cert-manager process",
+      "fillSpans": false,
+      "id": "6ad4494f-b772-4e23-8c35-64c4aaa4887d",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "goroutines",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "51e5af62-5e19-40b3-828b-5febc53d4e1a",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "goroutines",
+            "name": "A",
+            "query": "go_goroutines{namespace=~\"$namespace\", job=~\".*cert-manager.*\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Goroutines",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of open file descriptors",
+      "fillSpans": false,
+      "id": "426fa7e3-254e-4bbb-8c97-9ea99b57aca1",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "fds",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "174101bb-75b5-496e-bb17-6b4cb025af1e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "fds",
+            "name": "A",
+            "query": "process_open_fds{namespace=~\"$namespace\", job=~\".*cert-manager.*\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Open File Descriptors",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "CPU core usage of cert-manager components over time",
+      "fillSpans": false,
+      "id": "b3447631-b74f-455b-8c56-f42d4a1565bc",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{pod}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f9d8fbf1-7d11-4fe4-a67e-c2cc2a655202",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "rate(process_cpu_seconds_total{namespace=~\"$namespace\", job=~\".*cert-manager.*\"}[5m])"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "CPU Usage Over Time",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "RSS and virtual memory over time",
+      "fillSpans": false,
+      "id": "368ba6c1-7656-42c2-8761-89dfccbb8158",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "RSS {{pod}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Virtual {{pod}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "22990143-4113-4b67-a619-0c18bf88a475",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "RSS {{pod}}",
+            "name": "A",
+            "query": "process_resident_memory_bytes{namespace=~\"$namespace\", job=~\".*cert-manager.*\"}"
+          },
+          {
+            "disabled": false,
+            "legend": "Virtual {{pod}}",
+            "name": "B",
+            "query": "process_virtual_memory_bytes{namespace=~\"$namespace\", job=~\".*cert-manager.*\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Memory Usage Over Time",
+      "yAxisUnit": "bytes",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Active goroutine count over time",
+      "fillSpans": false,
+      "id": "635d1430-e95a-482d-bb57-b389293e7b2d",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{pod}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "de79b4cb-666d-43a9-86d1-1f454ae4b378",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "go_goroutines{namespace=~\"$namespace\", job=~\".*cert-manager.*\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Goroutines Over Time",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Go garbage collection pause duration percentiles",
+      "fillSpans": false,
+      "id": "782f2f42-26cd-4bd2-ad48-a2a0174b195e",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p50 {{pod}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p99 {{pod}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "5425bd5d-e537-4696-9ea0-e79de8634b8c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "p50 {{pod}}",
+            "name": "A",
+            "query": "go_gc_duration_seconds{namespace=~\"$namespace\", job=~\".*cert-manager.*\", quantile=\"0.5\"}"
+          },
+          {
+            "disabled": false,
+            "legend": "p99 {{pod}}",
+            "name": "B",
+            "query": "go_gc_duration_seconds{namespace=~\"$namespace\", job=~\".*cert-manager.*\", quantile=\"0.99\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "GC Duration (p50/p99)",
+      "yAxisUnit": "s",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "File descriptor usage vs limit",
+      "fillSpans": false,
+      "id": "b3d86e10-9af7-4a56-b0a8-86f8efb0620a",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "open {{pod}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "max {{pod}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "032c36bc-563b-431c-86ef-65eb922f4e6d",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "open {{pod}}",
+            "name": "A",
+            "query": "process_open_fds{namespace=~\"$namespace\", job=~\".*cert-manager.*\"}"
+          },
+          {
+            "disabled": false,
+            "legend": "max {{pod}}",
+            "name": "B",
+            "query": "process_max_fds{namespace=~\"$namespace\", job=~\".*cert-manager.*\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Open File Descriptors Over Time",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Go heap allocation metrics",
+      "fillSpans": false,
+      "id": "f015ed92-2913-4ba0-83bc-ab191fe186bb",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "heap alloc {{pod}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "heap inuse {{pod}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "C",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "heap sys {{pod}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "C",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "e7d065a4-47b3-4db0-8d10-4f0d9f711da5",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "heap alloc {{pod}}",
+            "name": "A",
+            "query": "go_memstats_heap_alloc_bytes{namespace=~\"$namespace\", job=~\".*cert-manager.*\"}"
+          },
+          {
+            "disabled": false,
+            "legend": "heap inuse {{pod}}",
+            "name": "B",
+            "query": "go_memstats_heap_inuse_bytes{namespace=~\"$namespace\", job=~\".*cert-manager.*\"}"
+          },
+          {
+            "disabled": false,
+            "legend": "heap sys {{pod}}",
+            "name": "C",
+            "query": "go_memstats_heap_sys_bytes{namespace=~\"$namespace\", job=~\".*cert-manager.*\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Go Heap Memory",
+      "yAxisUnit": "bytes",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of bytes allocated triggering GC",
+      "fillSpans": false,
+      "id": "da9d59bb-6ebb-4810-8386-fe584112fb2a",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{pod}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ebba612f-ef12-474f-8e56-3284385fc8cc",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "rate(go_memstats_alloc_bytes_total{namespace=~\"$namespace\", job=~\".*cert-manager.*\"}[5m])"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Go GC Allocations Rate",
+      "yAxisUnit": "bytes",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of OS threads used by the cert-manager process",
+      "fillSpans": false,
+      "id": "3c1839f3-d767-4e2c-9fee-17279c019c07",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{pod}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "417a3156-9099-437e-a725-60e463b7582e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{pod}}",
+            "name": "A",
+            "query": "go_threads{namespace=~\"$namespace\", job=~\".*cert-manager.*\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Process Threads",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "description": "",
+      "id": "7ea065d8-ea90-48f4-a0e1-d5e610dec60e",
+      "panelTypes": "row",
+      "title": "Network & Miscellaneous"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "When cert-manager process was last started (for uptime tracking)",
+      "fillSpans": false,
+      "id": "71e01f46-411a-4cba-b088-b813187ba7df",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Uptime",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "4f3048f4-12a0-464c-a0f5-62434600df43",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Uptime",
+            "name": "A",
+            "query": "time() - process_start_time_seconds{namespace=~\"$namespace\", job=~\".*cert-manager.*\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Process Start Time",
+      "yAxisUnit": "s",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Difference between cert-manager reported clock and Prometheus scrape time (should be ~0)",
+      "fillSpans": false,
+      "id": "55f7f2e1-6478-4f4a-ab12-ccc7ae68b62b",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "skew",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a23179ac-19ee-4d6b-9683-c9b1aee1fbc2",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "skew",
+            "name": "A",
+            "query": "abs(certmanager_clock_time_seconds{namespace=~\"$namespace\"} - time())"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Clock Skew Detection",
+      "yAxisUnit": "s",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Sum of all controller sync call counts (approximation of total managed resources)",
+      "fillSpans": false,
+      "id": "6648cc02-9a43-4266-ab42-2a13079a1116",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "total syncs",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "2164c4c2-0e16-4b3c-bde6-305277c91e46",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "total syncs",
+            "name": "A",
+            "query": "sum(certmanager_controller_sync_call_count{namespace=~\"$namespace\"})"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Total Managed Resources",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Monitor for clock drift between cert-manager and Prometheus",
+      "fillSpans": false,
+      "id": "8ac9b07d-1284-4158-a080-97ce8a95aa14",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "skew",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "1287788e-fbed-4aed-a568-d9bef0ad32c6",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "skew",
+            "name": "A",
+            "query": "certmanager_clock_time_seconds{namespace=~\"$namespace\"} - time()"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "Clock Skew Over Time",
+      "yAxisUnit": "s",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Scrape target up status for cert-manager components",
+      "fillSpans": false,
+      "id": "caeffd28-1f9e-4aec-84bc-63724b02f3ea",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "{{instance}} ({{job}})",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8d603fee-6131-4c69-b871-433893c12302",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{instance}} ({{job}})",
+            "name": "A",
+            "query": "up{namespace=~\"$namespace\", job=~\".*cert-manager.*\"}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "title": "cert-manager Component Up/Down",
+      "yAxisUnit": "none",
+      "fillMode": "none",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Comprehensive cert-manager monitoring dashboard for SigNoz with **90 panels** across **12 sections**, built from official cert-manager Prometheus metrics (port 9402).

Closes SigNoz/signoz#6023

/claim #6023

### Sections

| Section | Panels | Description |
|---------|--------|-------------|
| Certificate Overview | 8 | Total certs, ready/not-ready status, expiring alerts |
| Certificate Details | 7 | Per-certificate expiry, renewal timeline, condition status |
| Issuer Health | 5 | Issuer readiness, certs per issuer, ClusterIssuer status |
| Certificate Requests & Orders | 8 | CertificateRequest status, Order tracking, challenge progress |
| ACME Operations | 8 | ACME client requests, duration histograms, error rates |
| Controller Performance | 7 | Sync operations, success/error rates by controller |
| Work Queue Metrics | 8 | Queue depth, latency, processing duration, retries |
| Webhook Metrics | 7 | Webhook request count, duration, TLS status |
| Kubernetes API & Client Metrics | 9 | API server request rates, client-go cache hits, watch events |
| Leader Election | 4 | Leader status, election transitions, last acquisition |
| Resource Usage | 12 | CPU, memory, goroutines, GC, file descriptors, threads |
| Network & Miscellaneous | 7 | REST client requests, gRPC calls, DNS latency |

### Features
- **Template variable**: `namespace` for filtering by Kubernetes namespace
- **PromQL queries**: All panels use Prometheus-compatible queries
- **OTel Collector config**: README includes OpenTelemetry Collector scrape configuration
- **cert-manager logo**: SVG icon embedded

### Metrics Ingestion

Configure the OpenTelemetry Collector with a Prometheus receiver targeting cert-manager pods on port 9402. Full configuration in `cert-manager/README.md`.

### Files
- `cert-manager/cert-manager-prometheus-v1.json` — Dashboard JSON (12,895 lines)
- `cert-manager/README.md` — Setup instructions and OTel Collector config

Closes SigNoz/signoz#6023