### PR TITLE
feat(dashboard): Add ASP.NET Core Metrics dashboard

### DIFF
--- a/aspnetcore/README.md
+++ b/aspnetcore/README.md
@@ -1,0 +1,117 @@
+# ASP.NET Core Metrics Dashboard - OTLP
+
+A comprehensive monitoring dashboard for ASP.NET Core applications using OpenTelemetry (OTLP) metrics. Covers HTTP server performance, .NET runtime internals, and Kestrel server metrics.
+
+Uses modern .NET 9+ metric names (`dotnet.*` prefix) with backwards compatibility for .NET 8.
+
+## Metrics Ingestion
+
+### otel-config.yaml
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  otlp:
+    endpoint: "<signoz-endpoint>:4317"
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      exporters: [otlp]
+```
+
+### ASP.NET Core Application Setup
+
+Add the following NuGet packages:
+
+```bash
+dotnet add package OpenTelemetry.Extensions.Hosting
+dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol
+dotnet add package OpenTelemetry.Instrumentation.AspNetCore
+dotnet add package OpenTelemetry.Instrumentation.Http
+dotnet add package OpenTelemetry.Instrumentation.Runtime
+dotnet add package OpenTelemetry.Instrumentation.Process
+```
+
+Configure OpenTelemetry in `Program.cs`:
+
+```csharp
+builder.Services.AddOpenTelemetry()
+    .WithMetrics(metrics =>
+    {
+        metrics
+            .AddAspNetCoreInstrumentation()
+            .AddHttpClientInstrumentation()
+            .AddProcessInstrumentation()
+            .AddRuntimeInstrumentation()
+            .AddMeter("Microsoft.AspNetCore.Hosting")
+            .AddMeter("Microsoft.AspNetCore.Server.Kestrel")
+            .AddOtlpExporter(opts =>
+            {
+                opts.Endpoint = new Uri("http://<otel-collector>:4317");
+            });
+    });
+```
+
+Set the service name and deployment environment:
+
+```bash
+export OTEL_SERVICE_NAME=my-aspnetcore-app
+export OTEL_RESOURCE_ATTRIBUTES=deployment.environment=production
+```
+
+## Variables
+
+| Variable | Description |
+|----------|-------------|
+| `service_name` | Filter by ASP.NET Core service (from `service.name` resource attribute) |
+| `deployment_environment` | Filter by deployment environment (from `deployment.environment` resource attribute) |
+
+## Dashboard Panels
+
+### Section 1: Application Performance
+
+| Panel | Metric | Description |
+|-------|--------|-------------|
+| CPU Usage | `dotnet.process.cpu.time` / `process.cpu.time` | CPU time consumed (supports .NET 8 and 9+) |
+| Memory Usage | `dotnet.process.memory.working_set` / `process.memory.usage` | Memory consumption in bytes |
+| Request Rate | `http.server.request.duration` | Incoming HTTP requests per second |
+| Request Latency P95 | `http.server.request.duration` | 95th percentile request latency |
+| Error Rate | `http.server.request.duration` | Requests with HTTP status >= 400 |
+
+### Section 2: Request & Response
+
+| Panel | Metric | Description |
+|-------|--------|-------------|
+| Active Requests | `http.server.active_requests` | In-flight HTTP requests |
+| Request Rate by Status Code | `http.server.request.duration` | Request rate grouped by response status |
+| Request Duration by Route (P95) | `http.server.request.duration` | Latency per HTTP route |
+
+### Section 3: .NET Runtime
+
+| Panel | Metric | Description |
+|-------|--------|-------------|
+| GC Collections | `dotnet.gc.collections` | Garbage collection rate by generation (gen0, gen1, gen2) |
+| GC Heap Size | `dotnet.gc.last_collection.heap.size` | Heap size by generation |
+| Thread Pool Threads | `dotnet.thread_pool.thread.count` | Active thread pool threads |
+| Thread Pool Queue | `dotnet.thread_pool.queue.length` | Queued work items (spikes indicate saturation) |
+| Exceptions | `dotnet.exceptions` | Exception rate |
+
+### Section 4: Kestrel Server
+
+| Panel | Metric | Description |
+|-------|--------|-------------|
+| Active Connections | `kestrel.active_connections` | Current TCP connections |
+| Connection Duration P95 | `kestrel.connection.duration` | 95th percentile connection lifetime |
+| Queued Connections | `kestrel.queued_connections` | Connections waiting to be accepted |
+| Rejected Connections | `kestrel.rejected_connections` | Connections rejected (MaxConcurrentConnections exceeded) |

--- a/aspnetcore/aspnetcore-otlp-v1.json
+++ b/aspnetcore/aspnetcore-otlp-v1.json
@@ -2,33 +2,235 @@
   "description": "Monitor ASP.NET Core application performance with modern .NET 9+ OTLP metrics. Covers HTTP server requests, Kestrel server internals, .NET runtime process metrics (GC, thread pool, exceptions), and resource usage (CPU, memory).",
   "image": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0NTYgNDU2Ij48cmVjdCB3aWR0aD0iNDU2IiBoZWlnaHQ9IjQ1NiIgcng9IjUwIiByeT0iNTAiIGZpbGw9IiM1MTJCRDQiLz48cGF0aCBkPSJNMzgwLjIgMjgxLjNjLTEuNS0uMS0zLS4yLTQuNS0uMi03LjQgMC0xNC42IDEuNC0yMS4zIDQuMi0yLjIuOS00LjMgMS45LTYuMyAzLjEtMS43LTExLjgtNS4xLTIzLjEtMTEuNS0zMy4zLTEyLjItMTkuNC0zMC4yLTMzLjUtNTEuMy0zOS45IDIuNS0zLjMgNC44LTYuOCA2LjktMTAuNSA2LjEtMTAuNyAxMC41LTIyLjYgMTIuOC0zNS4yLjUtMi42LjgtNS4yIDEtNy45LjQtNC44LjUtOS43LjItMTQuNS0uNi0xMC4zLTMuMi0yMC4yLTguMi0yOC44LTEuNy0yLjktMy43LTUuNi01LjktOC4xLTE0LjgtMTYuNS0zNi41LTI0LjktNTkuMi0yNC45LTQ3LjQgMC04NS44IDM4LjQtODUuOCA4NS44IDAgMi4xLjEgNC4xLjIgNi4yLTQ1LjcgMTMuNC04MC4xIDU0LjQtODQuOSAxMDEuNS0uNCA0LS42IDgtLjYgMTIuMSAwIDUzLjUgNDMuNCA5Ni45IDk2LjkgOTYuOWgyMTEuN2MyLjUgMCA1LS4xIDcuNS0uNCAzMy42LTIuNiA1OS40LTMxLjIgNTcuOS02NC45LTEuNS0zMy43LTI4LjQtNTkuOS02Mi4zLTYyLjF6IiBmaWxsPSIjZmZmIi8+PC9zdmc+",
   "layout": [
-    { "h": 1, "i": "row-app-performance", "moved": false, "static": false, "w": 12, "x": 0, "y": 0 },
-    { "h": 3, "i": "panel-cpu-time", "moved": false, "static": false, "w": 6, "x": 0, "y": 1 },
-    { "h": 3, "i": "panel-memory-working-set", "moved": false, "static": false, "w": 6, "x": 6, "y": 1 },
-    { "h": 9, "i": "panel-http-request-rate", "moved": false, "static": false, "w": 6, "x": 0, "y": 4 },
-    { "h": 9, "i": "panel-http-latency-p95", "moved": false, "static": false, "w": 6, "x": 6, "y": 4 },
-    { "h": 9, "i": "panel-http-error-rate", "moved": false, "static": false, "w": 12, "x": 0, "y": 13 },
-
-    { "h": 1, "i": "row-http-details", "moved": false, "static": false, "w": 12, "x": 0, "y": 22 },
-    { "h": 3, "i": "panel-http-active-requests", "moved": false, "static": false, "w": 12, "x": 0, "y": 23 },
-    { "h": 9, "i": "panel-http-rate-by-status", "moved": false, "static": false, "w": 6, "x": 0, "y": 26 },
-    { "h": 9, "i": "panel-http-duration-by-route", "moved": false, "static": false, "w": 6, "x": 6, "y": 26 },
-
-    { "h": 1, "i": "row-dotnet-runtime", "moved": false, "static": false, "w": 12, "x": 0, "y": 35 },
-    { "h": 9, "i": "panel-gc-collections", "moved": false, "static": false, "w": 6, "x": 0, "y": 36 },
-    { "h": 9, "i": "panel-gc-heap-size", "moved": false, "static": false, "w": 6, "x": 6, "y": 36 },
-    { "h": 9, "i": "panel-threadpool-threads", "moved": false, "static": false, "w": 6, "x": 0, "y": 45 },
-    { "h": 9, "i": "panel-threadpool-queue", "moved": false, "static": false, "w": 6, "x": 6, "y": 45 },
-    { "h": 9, "i": "panel-exceptions", "moved": false, "static": false, "w": 12, "x": 0, "y": 54 },
-
-    { "h": 1, "i": "row-kestrel-server", "moved": false, "static": false, "w": 12, "x": 0, "y": 63 },
-    { "h": 3, "i": "panel-kestrel-active-connections", "moved": false, "static": false, "w": 12, "x": 0, "y": 64 },
-    { "h": 9, "i": "panel-kestrel-queued-connections", "moved": false, "static": false, "w": 6, "x": 0, "y": 67 },
-    { "h": 9, "i": "panel-kestrel-connection-duration", "moved": false, "static": false, "w": 6, "x": 6, "y": 67 },
-    { "h": 9, "i": "panel-kestrel-rejected-connections", "moved": false, "static": false, "w": 12, "x": 0, "y": 76 }
+    {
+      "h": 1,
+      "i": "row-app-performance",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 0,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 1,
+      "i": "row-http-details",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 22,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 1,
+      "i": "row-dotnet-runtime",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 35,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 1,
+      "i": "row-kestrel-server",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 63,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    }
   ],
-  "panelMap": {},
-  "tags": ["aspnetcore", "dotnet", "otel"],
+  "panelMap": {
+    "row-app-performance": {
+      "collapsed": true,
+      "widgets": [
+        {
+          "h": 3,
+          "i": "panel-cpu-time",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 1
+        },
+        {
+          "h": 3,
+          "i": "panel-memory-working-set",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 1
+        },
+        {
+          "h": 9,
+          "i": "panel-http-request-rate",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 4
+        },
+        {
+          "h": 9,
+          "i": "panel-http-latency-p95",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 4
+        },
+        {
+          "h": 9,
+          "i": "panel-http-error-rate",
+          "moved": false,
+          "static": false,
+          "w": 12,
+          "x": 0,
+          "y": 13
+        }
+      ]
+    },
+    "row-http-details": {
+      "collapsed": true,
+      "widgets": [
+        {
+          "h": 3,
+          "i": "panel-http-active-requests",
+          "moved": false,
+          "static": false,
+          "w": 12,
+          "x": 0,
+          "y": 23
+        },
+        {
+          "h": 9,
+          "i": "panel-http-rate-by-status",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 26
+        },
+        {
+          "h": 9,
+          "i": "panel-http-duration-by-route",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 26
+        }
+      ]
+    },
+    "row-dotnet-runtime": {
+      "collapsed": true,
+      "widgets": [
+        {
+          "h": 9,
+          "i": "panel-gc-collections",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 36
+        },
+        {
+          "h": 9,
+          "i": "panel-gc-heap-size",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 36
+        },
+        {
+          "h": 9,
+          "i": "panel-threadpool-threads",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 45
+        },
+        {
+          "h": 9,
+          "i": "panel-threadpool-queue",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 45
+        },
+        {
+          "h": 9,
+          "i": "panel-exceptions",
+          "moved": false,
+          "static": false,
+          "w": 12,
+          "x": 0,
+          "y": 54
+        }
+      ]
+    },
+    "row-kestrel-server": {
+      "collapsed": true,
+      "widgets": [
+        {
+          "h": 3,
+          "i": "panel-kestrel-active-connections",
+          "moved": false,
+          "static": false,
+          "w": 12,
+          "x": 0,
+          "y": 64
+        },
+        {
+          "h": 9,
+          "i": "panel-kestrel-queued-connections",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 67
+        },
+        {
+          "h": 9,
+          "i": "panel-kestrel-connection-duration",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 67
+        },
+        {
+          "h": 9,
+          "i": "panel-kestrel-rejected-connections",
+          "moved": false,
+          "static": false,
+          "w": 12,
+          "x": 0,
+          "y": 76
+        }
+      ]
+    }
+  },
+  "tags": [
+    "aspnetcore",
+    "dotnet",
+    "otel"
+  ],
   "title": "ASP.NET Core Metrics",
   "uploadedGrafana": false,
   "uuid": "8e0f5179-1012-4e21-8130-fa5e01a21f7a",
@@ -44,7 +246,9 @@
       "name": "service_name",
       "order": 0,
       "queryValue": "SELECT JSONExtractString(labels, 'service.name') AS `service.name`\nFROM signoz_metrics.distributed_time_series_v4_1day\nWHERE metric_name = 'http.server.request.duration'\nGROUP BY `service.name`",
-      "selectedValue": [""],
+      "selectedValue": [
+        ""
+      ],
       "showALLOption": true,
       "sort": "ASC",
       "textboxValue": "",
@@ -61,14 +265,16 @@
       "name": "deployment_environment",
       "order": 1,
       "queryValue": "SELECT JSONExtractString(labels, 'deployment.environment') AS `deployment.environment`\nFROM signoz_metrics.distributed_time_series_v4_1day\nWHERE metric_name = 'http.server.request.duration'\nGROUP BY `deployment.environment`",
-      "selectedValue": [""],
+      "selectedValue": [
+        ""
+      ],
       "showALLOption": true,
       "sort": "ASC",
       "textboxValue": "",
       "type": "QUERY"
     }
   },
-  "version": "v4",
+  "version": "v5",
   "widgets": [
     {
       "description": "",
@@ -77,19 +283,40 @@
       "title": "Application Performance",
       "collapsed": false,
       "query": {
-        "builder": { "queryData": [], "queryFormulas": [] },
-        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "id": "row-app-performance-query",
-        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "queryType": "builder",
         "unit": ""
       }
     },
     {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
       "description": "Total CPU time consumed by the process, shown as a rate per second. Queries both dotnet.process.cpu.time (.NET 9+) and process.cpu.time (.NET 8) for compatibility.",
       "fillSpans": false,
       "id": "panel-cpu-time",
       "isStacked": false,
+      "mergeAllActiveQueries": false,
       "nullZeroValues": "zero",
       "opacity": "1",
       "panelTypes": "value",
@@ -122,7 +349,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.service_name}}"]
+                    "value": [
+                      "{{.service_name}}"
+                    ]
                   },
                   {
                     "id": "a1b1c1d1-e1f1-4a1b-c1d1-e1f1a1b1c1d2",
@@ -135,7 +364,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.deployment_environment}}"]
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
                   }
                 ],
                 "op": "AND"
@@ -178,7 +409,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.service_name}}"]
+                    "value": [
+                      "{{.service_name}}"
+                    ]
                   },
                   {
                     "id": "a1b1c1d1-e1f1-4a1b-c1d1-e1f1a1b1c1d4",
@@ -191,7 +424,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.deployment_environment}}"]
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
                   }
                 ],
                 "op": "AND"
@@ -211,12 +446,80 @@
           ],
           "queryFormulas": []
         },
-        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "id": "panel-cpu-time-query",
-        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "queryType": "builder",
         "unit": ""
       },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
       "softMax": 0,
       "softMin": 0,
       "stackedBarChart": false,
@@ -226,10 +529,14 @@
       "yAxisUnit": "none"
     },
     {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
       "description": "Current process memory working set. Queries both dotnet.process.memory.working_set (.NET 9+) and process.memory.usage (.NET 8) for compatibility.",
       "fillSpans": false,
       "id": "panel-memory-working-set",
       "isStacked": false,
+      "mergeAllActiveQueries": false,
       "nullZeroValues": "zero",
       "opacity": "1",
       "panelTypes": "value",
@@ -262,7 +569,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.service_name}}"]
+                    "value": [
+                      "{{.service_name}}"
+                    ]
                   },
                   {
                     "id": "a2b2c2d2-e2f2-4a2b-c2d2-e2f2a2b2c2d2",
@@ -275,7 +584,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.deployment_environment}}"]
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
                   }
                 ],
                 "op": "AND"
@@ -318,7 +629,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.service_name}}"]
+                    "value": [
+                      "{{.service_name}}"
+                    ]
                   },
                   {
                     "id": "a2b2c2d2-e2f2-4a2b-c2d2-e2f2a2b2c2d4",
@@ -331,7 +644,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.deployment_environment}}"]
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
                   }
                 ],
                 "op": "AND"
@@ -351,12 +666,80 @@
           ],
           "queryFormulas": []
         },
-        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "id": "panel-memory-working-set-query",
-        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "queryType": "builder",
         "unit": ""
       },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
       "softMax": 0,
       "softMin": 0,
       "stackedBarChart": false,
@@ -366,10 +749,14 @@
       "yAxisUnit": "bytes"
     },
     {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
       "description": "Rate of incoming HTTP requests per second, grouped by service name.",
       "fillSpans": false,
       "id": "panel-http-request-rate",
       "isStacked": false,
+      "mergeAllActiveQueries": false,
       "nullZeroValues": "zero",
       "opacity": "1",
       "panelTypes": "graph",
@@ -402,7 +789,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.service_name}}"]
+                    "value": [
+                      "{{.service_name}}"
+                    ]
                   },
                   {
                     "id": "a3b3c3d3-e3f3-4a3b-c3d3-e3f3a3b3c3d2",
@@ -415,7 +804,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.deployment_environment}}"]
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
                   }
                 ],
                 "op": "AND"
@@ -444,12 +835,80 @@
           ],
           "queryFormulas": []
         },
-        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "id": "panel-http-request-rate-query",
-        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "queryType": "builder",
         "unit": ""
       },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
       "softMax": 0,
       "softMin": 0,
       "stackedBarChart": false,
@@ -459,10 +918,14 @@
       "yAxisUnit": "reqps"
     },
     {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
       "description": "95th percentile HTTP server request latency.",
       "fillSpans": false,
       "id": "panel-http-latency-p95",
       "isStacked": false,
+      "mergeAllActiveQueries": false,
       "nullZeroValues": "zero",
       "opacity": "1",
       "panelTypes": "graph",
@@ -495,7 +958,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.service_name}}"]
+                    "value": [
+                      "{{.service_name}}"
+                    ]
                   },
                   {
                     "id": "a4b4c4d4-e4f4-4a4b-c4d4-e4f4a4b4c4d2",
@@ -508,7 +973,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.deployment_environment}}"]
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
                   }
                 ],
                 "op": "AND"
@@ -537,12 +1004,80 @@
           ],
           "queryFormulas": []
         },
-        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "id": "panel-http-latency-p95-query",
-        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "queryType": "builder",
         "unit": ""
       },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
       "softMax": 0,
       "softMin": 0,
       "stackedBarChart": false,
@@ -552,10 +1087,14 @@
       "yAxisUnit": "ns"
     },
     {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
       "description": "Percentage of HTTP requests resulting in 4xx or 5xx status codes. Computed as (error count / total count) * 100.",
       "fillSpans": false,
       "id": "panel-http-error-rate",
       "isStacked": false,
+      "mergeAllActiveQueries": false,
       "nullZeroValues": "zero",
       "opacity": "1",
       "panelTypes": "graph",
@@ -588,7 +1127,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.service_name}}"]
+                    "value": [
+                      "{{.service_name}}"
+                    ]
                   },
                   {
                     "id": "a5b5c5d5-e5f5-4a5b-c5d5-e5f5a5b5c5d2",
@@ -601,7 +1142,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.deployment_environment}}"]
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
                   },
                   {
                     "id": "a5b5c5d5-e5f5-4a5b-c5d5-e5f5a5b5c5d3",
@@ -657,7 +1200,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.service_name}}"]
+                    "value": [
+                      "{{.service_name}}"
+                    ]
                   },
                   {
                     "id": "a5b5c5d5-e5f5-4a5b-c5d5-e5f5a5b5c5d5",
@@ -670,7 +1215,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.deployment_environment}}"]
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
                   }
                 ],
                 "op": "AND"
@@ -697,12 +1244,80 @@
             }
           ]
         },
-        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "id": "panel-http-error-rate-query",
-        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "queryType": "builder",
         "unit": ""
       },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
       "softMax": 0,
       "softMin": 0,
       "stackedBarChart": false,
@@ -711,7 +1326,6 @@
       "title": "Error Rate (%)",
       "yAxisUnit": "percent"
     },
-
     {
       "description": "",
       "id": "row-http-details",
@@ -719,19 +1333,40 @@
       "title": "Request and Response Details",
       "collapsed": false,
       "query": {
-        "builder": { "queryData": [], "queryFormulas": [] },
-        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "id": "row-http-details-query",
-        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "queryType": "builder",
         "unit": ""
       }
     },
     {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
       "description": "Number of HTTP requests currently being handled by the server.",
       "fillSpans": false,
       "id": "panel-http-active-requests",
       "isStacked": false,
+      "mergeAllActiveQueries": false,
       "nullZeroValues": "zero",
       "opacity": "1",
       "panelTypes": "value",
@@ -764,7 +1399,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.service_name}}"]
+                    "value": [
+                      "{{.service_name}}"
+                    ]
                   },
                   {
                     "id": "a6b6c6d6-e6f6-4a6b-c6d6-e6f6a6b6c6d2",
@@ -777,7 +1414,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.deployment_environment}}"]
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
                   }
                 ],
                 "op": "AND"
@@ -797,12 +1436,80 @@
           ],
           "queryFormulas": []
         },
-        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "id": "panel-http-active-requests-query",
-        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "queryType": "builder",
         "unit": ""
       },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
       "softMax": 0,
       "softMin": 0,
       "stackedBarChart": false,
@@ -812,10 +1519,14 @@
       "yAxisUnit": "none"
     },
     {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
       "description": "HTTP request rate broken down by response status code to identify error patterns.",
       "fillSpans": false,
       "id": "panel-http-rate-by-status",
       "isStacked": true,
+      "mergeAllActiveQueries": false,
       "nullZeroValues": "zero",
       "opacity": "1",
       "panelTypes": "graph",
@@ -848,7 +1559,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.service_name}}"]
+                    "value": [
+                      "{{.service_name}}"
+                    ]
                   },
                   {
                     "id": "a7b7c7d7-e7f7-4a7b-c7d7-e7f7a7b7c7d2",
@@ -861,7 +1574,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.deployment_environment}}"]
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
                   }
                 ],
                 "op": "AND"
@@ -890,12 +1605,80 @@
           ],
           "queryFormulas": []
         },
-        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "id": "panel-http-rate-by-status-query",
-        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "queryType": "builder",
         "unit": ""
       },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
       "softMax": 0,
       "softMin": 0,
       "stackedBarChart": false,
@@ -905,10 +1688,14 @@
       "yAxisUnit": "reqps"
     },
     {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
       "description": "95th percentile request duration broken down by HTTP route.",
       "fillSpans": false,
       "id": "panel-http-duration-by-route",
       "isStacked": false,
+      "mergeAllActiveQueries": false,
       "nullZeroValues": "zero",
       "opacity": "1",
       "panelTypes": "graph",
@@ -941,7 +1728,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.service_name}}"]
+                    "value": [
+                      "{{.service_name}}"
+                    ]
                   },
                   {
                     "id": "a8b8c8d8-e8f8-4a8b-c8d8-e8f8a8b8c8d2",
@@ -954,7 +1743,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.deployment_environment}}"]
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
                   }
                 ],
                 "op": "AND"
@@ -983,12 +1774,80 @@
           ],
           "queryFormulas": []
         },
-        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "id": "panel-http-duration-by-route-query",
-        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "queryType": "builder",
         "unit": ""
       },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
       "softMax": 0,
       "softMin": 0,
       "stackedBarChart": false,
@@ -997,7 +1856,6 @@
       "title": "Request Duration by Route (P95)",
       "yAxisUnit": "ns"
     },
-
     {
       "description": "",
       "id": "row-dotnet-runtime",
@@ -1005,19 +1863,40 @@
       "title": ".NET Runtime",
       "collapsed": false,
       "query": {
-        "builder": { "queryData": [], "queryFormulas": [] },
-        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "id": "row-dotnet-runtime-query",
-        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "queryType": "builder",
         "unit": ""
       }
     },
     {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
       "description": "Number of garbage collections per generation, using the modern dotnet.gc.collections metric (.NET 9+).",
       "fillSpans": false,
       "id": "panel-gc-collections",
       "isStacked": false,
+      "mergeAllActiveQueries": false,
       "nullZeroValues": "zero",
       "opacity": "1",
       "panelTypes": "graph",
@@ -1050,7 +1929,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.service_name}}"]
+                    "value": [
+                      "{{.service_name}}"
+                    ]
                   },
                   {
                     "id": "a9b9c9d9-e9f9-4a9b-c9d9-e9f9a9b9c9d2",
@@ -1063,7 +1944,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.deployment_environment}}"]
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
                   }
                 ],
                 "op": "AND"
@@ -1092,12 +1975,80 @@
           ],
           "queryFormulas": []
         },
-        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "id": "panel-gc-collections-query",
-        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "queryType": "builder",
         "unit": ""
       },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
       "softMax": 0,
       "softMin": 0,
       "stackedBarChart": false,
@@ -1107,10 +2058,14 @@
       "yAxisUnit": "none"
     },
     {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
       "description": "Size of the .NET garbage collector managed heap per generation after the last collection.",
       "fillSpans": false,
       "id": "panel-gc-heap-size",
       "isStacked": false,
+      "mergeAllActiveQueries": false,
       "nullZeroValues": "zero",
       "opacity": "1",
       "panelTypes": "graph",
@@ -1143,7 +2098,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.service_name}}"]
+                    "value": [
+                      "{{.service_name}}"
+                    ]
                   },
                   {
                     "id": "b0c0d0e0-f0a0-4b0c-d0e0-f0a0b0c0d0e2",
@@ -1156,7 +2113,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.deployment_environment}}"]
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
                   }
                 ],
                 "op": "AND"
@@ -1185,12 +2144,80 @@
           ],
           "queryFormulas": []
         },
-        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "id": "panel-gc-heap-size-query",
-        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "queryType": "builder",
         "unit": ""
       },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
       "softMax": 0,
       "softMin": 0,
       "stackedBarChart": false,
@@ -1200,10 +2227,14 @@
       "yAxisUnit": "bytes"
     },
     {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
       "description": "Number of thread pool threads currently active, using the modern dotnet.thread_pool.thread.count metric (.NET 9+).",
       "fillSpans": false,
       "id": "panel-threadpool-threads",
       "isStacked": false,
+      "mergeAllActiveQueries": false,
       "nullZeroValues": "zero",
       "opacity": "1",
       "panelTypes": "graph",
@@ -1236,7 +2267,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.service_name}}"]
+                    "value": [
+                      "{{.service_name}}"
+                    ]
                   },
                   {
                     "id": "b1c1d1e1-f1a1-4b1c-d1e1-f1a1b1c1d1e2",
@@ -1249,7 +2282,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.deployment_environment}}"]
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
                   }
                 ],
                 "op": "AND"
@@ -1269,12 +2304,80 @@
           ],
           "queryFormulas": []
         },
-        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "id": "panel-threadpool-threads-query",
-        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "queryType": "builder",
         "unit": ""
       },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
       "softMax": 0,
       "softMin": 0,
       "stackedBarChart": false,
@@ -1284,10 +2387,14 @@
       "yAxisUnit": "none"
     },
     {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
       "description": "Number of work items queued to the .NET thread pool, using the modern dotnet.thread_pool.queue.length metric (.NET 9+).",
       "fillSpans": false,
       "id": "panel-threadpool-queue",
       "isStacked": false,
+      "mergeAllActiveQueries": false,
       "nullZeroValues": "zero",
       "opacity": "1",
       "panelTypes": "graph",
@@ -1320,7 +2427,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.service_name}}"]
+                    "value": [
+                      "{{.service_name}}"
+                    ]
                   },
                   {
                     "id": "b2c2d2e2-f2a2-4b2c-d2e2-f2a2b2c2d2e2",
@@ -1333,7 +2442,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.deployment_environment}}"]
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
                   }
                 ],
                 "op": "AND"
@@ -1353,12 +2464,80 @@
           ],
           "queryFormulas": []
         },
-        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "id": "panel-threadpool-queue-query",
-        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "queryType": "builder",
         "unit": ""
       },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
       "softMax": 0,
       "softMin": 0,
       "stackedBarChart": false,
@@ -1368,10 +2547,14 @@
       "yAxisUnit": "none"
     },
     {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
       "description": "Count of exceptions thrown by the .NET runtime, using the modern dotnet.exceptions metric (.NET 9+).",
       "fillSpans": false,
       "id": "panel-exceptions",
       "isStacked": false,
+      "mergeAllActiveQueries": false,
       "nullZeroValues": "zero",
       "opacity": "1",
       "panelTypes": "graph",
@@ -1404,7 +2587,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.service_name}}"]
+                    "value": [
+                      "{{.service_name}}"
+                    ]
                   },
                   {
                     "id": "b3c3d3e3-f3a3-4b3c-d3e3-f3a3b3c3d3e2",
@@ -1417,7 +2602,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.deployment_environment}}"]
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
                   }
                 ],
                 "op": "AND"
@@ -1437,12 +2624,80 @@
           ],
           "queryFormulas": []
         },
-        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "id": "panel-exceptions-query",
-        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "queryType": "builder",
         "unit": ""
       },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
       "softMax": 0,
       "softMin": 0,
       "stackedBarChart": false,
@@ -1451,7 +2706,6 @@
       "title": "Exception Count",
       "yAxisUnit": "none"
     },
-
     {
       "description": "",
       "id": "row-kestrel-server",
@@ -1459,19 +2713,40 @@
       "title": "Kestrel Server",
       "collapsed": false,
       "query": {
-        "builder": { "queryData": [], "queryFormulas": [] },
-        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "id": "row-kestrel-server-query",
-        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "queryType": "builder",
         "unit": ""
       }
     },
     {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
       "description": "Number of active connections currently open on Kestrel.",
       "fillSpans": false,
       "id": "panel-kestrel-active-connections",
       "isStacked": false,
+      "mergeAllActiveQueries": false,
       "nullZeroValues": "zero",
       "opacity": "1",
       "panelTypes": "value",
@@ -1504,7 +2779,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.service_name}}"]
+                    "value": [
+                      "{{.service_name}}"
+                    ]
                   },
                   {
                     "id": "b4c4d4e4-f4a4-4b4c-d4e4-f4a4b4c4d4e2",
@@ -1517,7 +2794,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.deployment_environment}}"]
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
                   }
                 ],
                 "op": "AND"
@@ -1537,12 +2816,80 @@
           ],
           "queryFormulas": []
         },
-        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "id": "panel-kestrel-active-connections-query",
-        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "queryType": "builder",
         "unit": ""
       },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
       "softMax": 0,
       "softMin": 0,
       "stackedBarChart": false,
@@ -1552,10 +2899,14 @@
       "yAxisUnit": "none"
     },
     {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
       "description": "Number of connections waiting in the Kestrel connection queue.",
       "fillSpans": false,
       "id": "panel-kestrel-queued-connections",
       "isStacked": false,
+      "mergeAllActiveQueries": false,
       "nullZeroValues": "zero",
       "opacity": "1",
       "panelTypes": "graph",
@@ -1588,7 +2939,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.service_name}}"]
+                    "value": [
+                      "{{.service_name}}"
+                    ]
                   },
                   {
                     "id": "b5c5d5e5-f5a5-4b5c-d5e5-f5a5b5c5d5e2",
@@ -1601,7 +2954,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.deployment_environment}}"]
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
                   }
                 ],
                 "op": "AND"
@@ -1621,12 +2976,80 @@
           ],
           "queryFormulas": []
         },
-        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "id": "panel-kestrel-queued-connections-query",
-        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "queryType": "builder",
         "unit": ""
       },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
       "softMax": 0,
       "softMin": 0,
       "stackedBarChart": false,
@@ -1636,10 +3059,14 @@
       "yAxisUnit": "none"
     },
     {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
       "description": "95th percentile connection duration on the Kestrel server.",
       "fillSpans": false,
       "id": "panel-kestrel-connection-duration",
       "isStacked": false,
+      "mergeAllActiveQueries": false,
       "nullZeroValues": "zero",
       "opacity": "1",
       "panelTypes": "graph",
@@ -1672,7 +3099,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.service_name}}"]
+                    "value": [
+                      "{{.service_name}}"
+                    ]
                   },
                   {
                     "id": "b6c6d6e6-f6a6-4b6c-d6e6-f6a6b6c6d6e2",
@@ -1685,7 +3114,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.deployment_environment}}"]
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
                   }
                 ],
                 "op": "AND"
@@ -1705,12 +3136,80 @@
           ],
           "queryFormulas": []
         },
-        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "id": "panel-kestrel-connection-duration-query",
-        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "queryType": "builder",
         "unit": ""
       },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
       "softMax": 0,
       "softMin": 0,
       "stackedBarChart": false,
@@ -1720,10 +3219,14 @@
       "yAxisUnit": "ns"
     },
     {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
       "description": "Rate of connections rejected by the Kestrel server due to connection limits being reached.",
       "fillSpans": false,
       "id": "panel-kestrel-rejected-connections",
       "isStacked": false,
+      "mergeAllActiveQueries": false,
       "nullZeroValues": "zero",
       "opacity": "1",
       "panelTypes": "graph",
@@ -1756,7 +3259,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.service_name}}"]
+                    "value": [
+                      "{{.service_name}}"
+                    ]
                   },
                   {
                     "id": "b7c7d7e7-f7a7-4b7c-d7e7-f7a7b7c7d7e2",
@@ -1769,7 +3274,9 @@
                       "type": "tag"
                     },
                     "op": "in",
-                    "value": ["{{.deployment_environment}}"]
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
                   }
                 ],
                 "op": "AND"
@@ -1789,12 +3296,80 @@
           ],
           "queryFormulas": []
         },
-        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "id": "panel-kestrel-rejected-connections-query",
-        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
         "queryType": "builder",
         "unit": ""
       },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
       "softMax": 0,
       "softMin": 0,
       "stackedBarChart": false,

--- a/aspnetcore/aspnetcore-otlp-v1.json
+++ b/aspnetcore/aspnetcore-otlp-v1.json
@@ -1,0 +1,1807 @@
+{
+  "description": "Monitor ASP.NET Core application performance with modern .NET 9+ OTLP metrics. Covers HTTP server requests, Kestrel server internals, .NET runtime process metrics (GC, thread pool, exceptions), and resource usage (CPU, memory).",
+  "image": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0NTYgNDU2Ij48cmVjdCB3aWR0aD0iNDU2IiBoZWlnaHQ9IjQ1NiIgcng9IjUwIiByeT0iNTAiIGZpbGw9IiM1MTJCRDQiLz48cGF0aCBkPSJNMzgwLjIgMjgxLjNjLTEuNS0uMS0zLS4yLTQuNS0uMi03LjQgMC0xNC42IDEuNC0yMS4zIDQuMi0yLjIuOS00LjMgMS45LTYuMyAzLjEtMS43LTExLjgtNS4xLTIzLjEtMTEuNS0zMy4zLTEyLjItMTkuNC0zMC4yLTMzLjUtNTEuMy0zOS45IDIuNS0zLjMgNC44LTYuOCA2LjktMTAuNSA2LjEtMTAuNyAxMC41LTIyLjYgMTIuOC0zNS4yLjUtMi42LjgtNS4yIDEtNy45LjQtNC44LjUtOS43LjItMTQuNS0uNi0xMC4zLTMuMi0yMC4yLTguMi0yOC44LTEuNy0yLjktMy43LTUuNi01LjktOC4xLTE0LjgtMTYuNS0zNi41LTI0LjktNTkuMi0yNC45LTQ3LjQgMC04NS44IDM4LjQtODUuOCA4NS44IDAgMi4xLjEgNC4xLjIgNi4yLTQ1LjcgMTMuNC04MC4xIDU0LjQtODQuOSAxMDEuNS0uNCA0LS42IDgtLjYgMTIuMSAwIDUzLjUgNDMuNCA5Ni45IDk2LjkgOTYuOWgyMTEuN2MyLjUgMCA1LS4xIDcuNS0uNCAzMy42LTIuNiA1OS40LTMxLjIgNTcuOS02NC45LTEuNS0zMy43LTI4LjQtNTkuOS02Mi4zLTYyLjF6IiBmaWxsPSIjZmZmIi8+PC9zdmc+",
+  "layout": [
+    { "h": 1, "i": "row-app-performance", "moved": false, "static": false, "w": 12, "x": 0, "y": 0 },
+    { "h": 3, "i": "panel-cpu-time", "moved": false, "static": false, "w": 6, "x": 0, "y": 1 },
+    { "h": 3, "i": "panel-memory-working-set", "moved": false, "static": false, "w": 6, "x": 6, "y": 1 },
+    { "h": 9, "i": "panel-http-request-rate", "moved": false, "static": false, "w": 6, "x": 0, "y": 4 },
+    { "h": 9, "i": "panel-http-latency-p95", "moved": false, "static": false, "w": 6, "x": 6, "y": 4 },
+    { "h": 9, "i": "panel-http-error-rate", "moved": false, "static": false, "w": 12, "x": 0, "y": 13 },
+
+    { "h": 1, "i": "row-http-details", "moved": false, "static": false, "w": 12, "x": 0, "y": 22 },
+    { "h": 3, "i": "panel-http-active-requests", "moved": false, "static": false, "w": 12, "x": 0, "y": 23 },
+    { "h": 9, "i": "panel-http-rate-by-status", "moved": false, "static": false, "w": 6, "x": 0, "y": 26 },
+    { "h": 9, "i": "panel-http-duration-by-route", "moved": false, "static": false, "w": 6, "x": 6, "y": 26 },
+
+    { "h": 1, "i": "row-dotnet-runtime", "moved": false, "static": false, "w": 12, "x": 0, "y": 35 },
+    { "h": 9, "i": "panel-gc-collections", "moved": false, "static": false, "w": 6, "x": 0, "y": 36 },
+    { "h": 9, "i": "panel-gc-heap-size", "moved": false, "static": false, "w": 6, "x": 6, "y": 36 },
+    { "h": 9, "i": "panel-threadpool-threads", "moved": false, "static": false, "w": 6, "x": 0, "y": 45 },
+    { "h": 9, "i": "panel-threadpool-queue", "moved": false, "static": false, "w": 6, "x": 6, "y": 45 },
+    { "h": 9, "i": "panel-exceptions", "moved": false, "static": false, "w": 12, "x": 0, "y": 54 },
+
+    { "h": 1, "i": "row-kestrel-server", "moved": false, "static": false, "w": 12, "x": 0, "y": 63 },
+    { "h": 3, "i": "panel-kestrel-active-connections", "moved": false, "static": false, "w": 12, "x": 0, "y": 64 },
+    { "h": 9, "i": "panel-kestrel-queued-connections", "moved": false, "static": false, "w": 6, "x": 0, "y": 67 },
+    { "h": 9, "i": "panel-kestrel-connection-duration", "moved": false, "static": false, "w": 6, "x": 6, "y": 67 },
+    { "h": 9, "i": "panel-kestrel-rejected-connections", "moved": false, "static": false, "w": 12, "x": 0, "y": 76 }
+  ],
+  "panelMap": {},
+  "tags": ["aspnetcore", "dotnet", "otel"],
+  "title": "ASP.NET Core Metrics",
+  "uploadedGrafana": false,
+  "uuid": "8e0f5179-1012-4e21-8130-fa5e01a21f7a",
+  "variables": {
+    "b0ef5386-5803-4810-86c6-be43f2ce9ec9": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Filter by service name",
+      "id": "b0ef5386-5803-4810-86c6-be43f2ce9ec9",
+      "key": "b0ef5386-5803-4810-86c6-be43f2ce9ec9",
+      "modificationUUID": "b27f9d43-8829-4d74-bdb9-493301394d7f",
+      "multiSelect": true,
+      "name": "service_name",
+      "order": 0,
+      "queryValue": "SELECT JSONExtractString(labels, 'service.name') AS `service.name`\nFROM signoz_metrics.distributed_time_series_v4_1day\nWHERE metric_name = 'http.server.request.duration'\nGROUP BY `service.name`",
+      "selectedValue": [""],
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "4b3dfcc1-1af0-4fb7-9739-997418786cf6": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Filter by deployment environment",
+      "id": "4b3dfcc1-1af0-4fb7-9739-997418786cf6",
+      "key": "4b3dfcc1-1af0-4fb7-9739-997418786cf6",
+      "modificationUUID": "961f9ddd-26af-4f4d-9633-2a5fc4d54c49",
+      "multiSelect": true,
+      "name": "deployment_environment",
+      "order": 1,
+      "queryValue": "SELECT JSONExtractString(labels, 'deployment.environment') AS `deployment.environment`\nFROM signoz_metrics.distributed_time_series_v4_1day\nWHERE metric_name = 'http.server.request.duration'\nGROUP BY `deployment.environment`",
+      "selectedValue": [""],
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "version": "v4",
+  "widgets": [
+    {
+      "description": "",
+      "id": "row-app-performance",
+      "panelTypes": "row",
+      "title": "Application Performance",
+      "collapsed": false,
+      "query": {
+        "builder": { "queryData": [], "queryFormulas": [] },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "row-app-performance-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      }
+    },
+    {
+      "description": "Total CPU time consumed by the process, shown as a rate per second. Queries both dotnet.process.cpu.time (.NET 9+) and process.cpu.time (.NET 8) for compatibility.",
+      "fillSpans": false,
+      "id": "panel-cpu-time",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "dotnet.process.cpu.time--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "dotnet.process.cpu.time",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "a1b1c1d1-e1f1-4a1b-c1d1-e1f1a1b1c1d1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "a1b1c1d1-e1f1-4a1b-c1d1-e1f1a1b1c1d2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "CPU (.NET 9+)",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "process.cpu.time--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "process.cpu.time",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "a1b1c1d1-e1f1-4a1b-c1d1-e1f1a1b1c1d3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "a1b1c1d1-e1f1-4a1b-c1d1-e1f1a1b1c1d4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "CPU (.NET 8)",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "panel-cpu-time-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "CPU Usage",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Current process memory working set. Queries both dotnet.process.memory.working_set (.NET 9+) and process.memory.usage (.NET 8) for compatibility.",
+      "fillSpans": false,
+      "id": "panel-memory-working-set",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "dotnet.process.memory.working_set--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "dotnet.process.memory.working_set",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "last",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "a2b2c2d2-e2f2-4a2b-c2d2-e2f2a2b2c2d1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "a2b2c2d2-e2f2-4a2b-c2d2-e2f2a2b2c2d2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Memory (.NET 9+)",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "process.memory.usage--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "process.memory.usage",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "last",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "a2b2c2d2-e2f2-4a2b-c2d2-e2f2a2b2c2d3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "a2b2c2d2-e2f2-4a2b-c2d2-e2f2a2b2c2d4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Memory (.NET 8)",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "panel-memory-working-set-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memory Usage",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "Rate of incoming HTTP requests per second, grouped by service name.",
+      "fillSpans": false,
+      "id": "panel-http-request-rate",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http.server.request.duration--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http.server.request.duration",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "count_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "a3b3c3d3-e3f3-4a3b-c3d3-e3f3a3b3c3d1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "a3b3c3d3-e3f3-4a3b-c3d3-e3f3a3b3c3d2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "service.name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "service.name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{service.name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "panel-http-request-rate-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Rate",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "95th percentile HTTP server request latency.",
+      "fillSpans": false,
+      "id": "panel-http-latency-p95",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http.server.request.duration--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http.server.request.duration",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p95",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "a4b4c4d4-e4f4-4a4b-c4d4-e4f4a4b4c4d1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "a4b4c4d4-e4f4-4a4b-c4d4-e4f4a4b4c4d2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "service.name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "service.name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{service.name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "panel-http-latency-p95-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Latency P95",
+      "yAxisUnit": "ns"
+    },
+    {
+      "description": "Percentage of HTTP requests resulting in 4xx or 5xx status codes. Computed as (error count / total count) * 100.",
+      "fillSpans": false,
+      "id": "panel-http-error-rate",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http.server.request.duration--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http.server.request.duration",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "count_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "a5b5c5d5-e5f5-4a5b-c5d5-e5f5a5b5c5d1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "a5b5c5d5-e5f5-4a5b-c5d5-e5f5a5b5c5d2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  },
+                  {
+                    "id": "a5b5c5d5-e5f5-4a5b-c5d5-e5f5a5b5c5d3",
+                    "key": {
+                      "dataType": "int64",
+                      "id": "http.response.status_code--int64--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "http.response.status_code",
+                      "type": "tag"
+                    },
+                    "op": ">=",
+                    "value": "400"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Error Requests",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http.server.request.duration--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http.server.request.duration",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "count_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "a5b5c5d5-e5f5-4a5b-c5d5-e5f5a5b5c5d4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "a5b5c5d5-e5f5-4a5b-c5d5-e5f5a5b5c5d5",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Total Requests",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "A * 100 / B",
+              "legend": "Error Rate %",
+              "queryName": "F1"
+            }
+          ]
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "panel-http-error-rate-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Error Rate (%)",
+      "yAxisUnit": "percent"
+    },
+
+    {
+      "description": "",
+      "id": "row-http-details",
+      "panelTypes": "row",
+      "title": "Request and Response Details",
+      "collapsed": false,
+      "query": {
+        "builder": { "queryData": [], "queryFormulas": [] },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "row-http-details-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      }
+    },
+    {
+      "description": "Number of HTTP requests currently being handled by the server.",
+      "fillSpans": false,
+      "id": "panel-http-active-requests",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http.server.active_requests--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http.server.active_requests",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "last",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "a6b6c6d6-e6f6-4a6b-c6d6-e6f6a6b6c6d1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "a6b6c6d6-e6f6-4a6b-c6d6-e6f6a6b6c6d2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Active Requests",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "panel-http-active-requests-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Requests",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "HTTP request rate broken down by response status code to identify error patterns.",
+      "fillSpans": false,
+      "id": "panel-http-rate-by-status",
+      "isStacked": true,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http.server.request.duration--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http.server.request.duration",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "count_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "a7b7c7d7-e7f7-4a7b-c7d7-e7f7a7b7c7d1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "a7b7c7d7-e7f7-4a7b-c7d7-e7f7a7b7c7d2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "int64",
+                  "id": "http.response.status_code--int64--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "http.response.status_code",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{http.response.status_code}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "panel-http-rate-by-status-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "HTTP Request Rate by Status Code",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "95th percentile request duration broken down by HTTP route.",
+      "fillSpans": false,
+      "id": "panel-http-duration-by-route",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http.server.request.duration--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http.server.request.duration",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p95",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "a8b8c8d8-e8f8-4a8b-c8d8-e8f8a8b8c8d1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "a8b8c8d8-e8f8-4a8b-c8d8-e8f8a8b8c8d2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "http.route--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "http.route",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{http.route}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "panel-http-duration-by-route-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Duration by Route (P95)",
+      "yAxisUnit": "ns"
+    },
+
+    {
+      "description": "",
+      "id": "row-dotnet-runtime",
+      "panelTypes": "row",
+      "title": ".NET Runtime",
+      "collapsed": false,
+      "query": {
+        "builder": { "queryData": [], "queryFormulas": [] },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "row-dotnet-runtime-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      }
+    },
+    {
+      "description": "Number of garbage collections per generation, using the modern dotnet.gc.collections metric (.NET 9+).",
+      "fillSpans": false,
+      "id": "panel-gc-collections",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "dotnet.gc.collections--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "dotnet.gc.collections",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "a9b9c9d9-e9f9-4a9b-c9d9-e9f9a9b9c9d1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "a9b9c9d9-e9f9-4a9b-c9d9-e9f9a9b9c9d2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "dotnet.gc.heap.generation--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "dotnet.gc.heap.generation",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Gen {{dotnet.gc.heap.generation}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "panel-gc-collections-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "GC Collections Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Size of the .NET garbage collector managed heap per generation after the last collection.",
+      "fillSpans": false,
+      "id": "panel-gc-heap-size",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "dotnet.gc.last_collection.heap.size--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "dotnet.gc.last_collection.heap.size",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b0c0d0e0-f0a0-4b0c-d0e0-f0a0b0c0d0e1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "b0c0d0e0-f0a0-4b0c-d0e0-f0a0b0c0d0e2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "dotnet.gc.heap.generation--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "dotnet.gc.heap.generation",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Gen {{dotnet.gc.heap.generation}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "panel-gc-heap-size-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "GC Heap Size",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "Number of thread pool threads currently active, using the modern dotnet.thread_pool.thread.count metric (.NET 9+).",
+      "fillSpans": false,
+      "id": "panel-threadpool-threads",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "dotnet.thread_pool.thread.count--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "dotnet.thread_pool.thread.count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b1c1d1e1-f1a1-4b1c-d1e1-f1a1b1c1d1e1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "b1c1d1e1-f1a1-4b1c-d1e1-f1a1b1c1d1e2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Thread Count",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "panel-threadpool-threads-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Thread Pool Threads",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Number of work items queued to the .NET thread pool, using the modern dotnet.thread_pool.queue.length metric (.NET 9+).",
+      "fillSpans": false,
+      "id": "panel-threadpool-queue",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "dotnet.thread_pool.queue.length--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "dotnet.thread_pool.queue.length",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b2c2d2e2-f2a2-4b2c-d2e2-f2a2b2c2d2e1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "b2c2d2e2-f2a2-4b2c-d2e2-f2a2b2c2d2e2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Queue Length",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "panel-threadpool-queue-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Thread Pool Queue Length",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Count of exceptions thrown by the .NET runtime, using the modern dotnet.exceptions metric (.NET 9+).",
+      "fillSpans": false,
+      "id": "panel-exceptions",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "dotnet.exceptions--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "dotnet.exceptions",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b3c3d3e3-f3a3-4b3c-d3e3-f3a3b3c3d3e1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "b3c3d3e3-f3a3-4b3c-d3e3-f3a3b3c3d3e2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Exceptions",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "panel-exceptions-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Exception Count",
+      "yAxisUnit": "none"
+    },
+
+    {
+      "description": "",
+      "id": "row-kestrel-server",
+      "panelTypes": "row",
+      "title": "Kestrel Server",
+      "collapsed": false,
+      "query": {
+        "builder": { "queryData": [], "queryFormulas": [] },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "row-kestrel-server-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      }
+    },
+    {
+      "description": "Number of active connections currently open on Kestrel.",
+      "fillSpans": false,
+      "id": "panel-kestrel-active-connections",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "kestrel.active_connections--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "kestrel.active_connections",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "last",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b4c4d4e4-f4a4-4b4c-d4e4-f4a4b4c4d4e1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "b4c4d4e4-f4a4-4b4c-d4e4-f4a4b4c4d4e2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Active Connections",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "panel-kestrel-active-connections-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Kestrel Active Connections",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Number of connections waiting in the Kestrel connection queue.",
+      "fillSpans": false,
+      "id": "panel-kestrel-queued-connections",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "kestrel.queued_connections--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "kestrel.queued_connections",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b5c5d5e5-f5a5-4b5c-d5e5-f5a5b5c5d5e1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "b5c5d5e5-f5a5-4b5c-d5e5-f5a5b5c5d5e2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Queue Length",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "panel-kestrel-queued-connections-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Kestrel Queue Length",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "95th percentile connection duration on the Kestrel server.",
+      "fillSpans": false,
+      "id": "panel-kestrel-connection-duration",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "kestrel.connection.duration--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "kestrel.connection.duration",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p95",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b6c6d6e6-f6a6-4b6c-d6e6-f6a6b6c6d6e1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "b6c6d6e6-f6a6-4b6c-d6e6-f6a6b6c6d6e2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "P95 Duration",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "panel-kestrel-connection-duration-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Kestrel Connection Duration (P95)",
+      "yAxisUnit": "ns"
+    },
+    {
+      "description": "Rate of connections rejected by the Kestrel server due to connection limits being reached.",
+      "fillSpans": false,
+      "id": "panel-kestrel-rejected-connections",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "kestrel.rejected_connections--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "kestrel.rejected_connections",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b7c7d7e7-f7a7-4b7c-d7e7-f7a7b7c7d7e1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.service_name}}"]
+                  },
+                  {
+                    "id": "b7c7d7e7-f7a7-4b7c-d7e7-f7a7b7c7d7e2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.deployment_environment}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Rejected Connections",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "panel-kestrel-rejected-connections-query",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Kestrel Rejected Connections",
+      "yAxisUnit": "cps"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Comprehensive ASP.NET Core monitoring dashboard using OpenTelemetry (OTLP) metrics with SigNoz Query Builder format.

- **17 panels** across 4 collapsible sections
- **2 template variables**: `service_name` and `deployment_environment`
- Uses modern .NET 9+ metric names (`dotnet.*` prefix) with backwards compatibility for .NET 8
- Includes Kestrel server metrics (active connections, connection duration, queued, rejected)

### Metrics Coverage

| Section | Panels | Key Metrics |
|---------|--------|-------------|
| Application Performance | 5 | `dotnet.process.cpu.time`, `dotnet.process.memory.working_set`, `http.server.request.duration` (rate, P95, errors) |
| Request & Response | 3 | `http.server.active_requests`, request rate by status code, duration by route P95 |
| .NET Runtime | 5 | `dotnet.gc.collections`, `dotnet.gc.last_collection.heap.size`, `dotnet.thread_pool.thread.count`, `dotnet.exceptions` |
| Kestrel Server | 4 | `kestrel.active_connections`, `kestrel.connection.duration`, `kestrel.queued_connections`, `kestrel.rejected_connections` |

### Setup

README includes full OpenTelemetry .NET SDK configuration with NuGet packages and `Program.cs` setup.

Closes: https://github.com/SigNoz/signoz/issues/5996