### PR TITLE
feat(dashboard): Add AWS MSK Cluster monitoring dashboard (Prometheus v1)

### DIFF
--- a/aws-msk/README.md
+++ b/aws-msk/README.md
@@ -1,0 +1,64 @@
+# AWS MSK Cluster Monitoring Dashboard — Prometheus
+
+Comprehensive AWS Managed Streaming for Apache Kafka (MSK) monitoring dashboard for SigNoz, built on CloudWatch and JMX Exporter metrics exposed via Prometheus.
+
+## Metrics Ingestion
+
+### 1. Enable Open Monitoring on MSK
+
+```bash
+aws kafka update-monitoring \
+  --cluster-arn <CLUSTER_ARN> \
+  --current-version <CLUSTER_VERSION> \
+  --open-monitoring '{"Prometheus":{"JmxExporter":{"EnabledInBroker":true},"NodeExporter":{"EnabledInBroker":true}}}'
+```
+
+JMX metrics are exposed on port `11001` and Node Exporter on port `11002`.
+
+### 2. OpenTelemetry Collector Configuration
+
+```yaml
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: 'aws-msk'
+          scrape_interval: 15s
+          static_configs:
+            - targets:
+                - 'b-1.msk-cluster.region.amazonaws.com:11001'
+                - 'b-2.msk-cluster.region.amazonaws.com:11001'
+                - 'b-3.msk-cluster.region.amazonaws.com:11001'
+
+exporters:
+  otlp:
+    endpoint: "ingest.signoz.io:443"
+    tls:
+      insecure: false
+    headers:
+      "signoz-ingestion-key": "<SIGNOZ_INGESTION_KEY>"
+
+service:
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      exporters: [otlp]
+```
+
+## Variables
+
+- `{{cluster_name}}`: MSK cluster name
+- `{{broker_id}}`: Filter by broker ID
+- `{{topic}}`: Filter by topic
+- `{{consumer_group}}`: Filter by consumer group
+
+## Dashboard Sections
+
+1. **Cluster Overview** — Active controller, offline partitions, under-replicated partitions, broker count
+2. **Throughput** — Messages/bytes in/out per second, replication bytes
+3. **Request Performance** — Produce/fetch latency, handler/processor idle %
+4. **Storage** — Disk usage, partition count, log segments
+5. **Consumer Group** — Offset lag, time lag, partition count
+6. **CPU & Memory** — CPU user/system, memory, swap, network packets
+7. **Replication** — ISR shrink/expand, leader count, min-ISR
+8. **Connections** — Connection count, creation/close rate, auth errors

--- a/aws-msk/aws-msk-cluster-prometheus-v1.json
+++ b/aws-msk/aws-msk-cluster-prometheus-v1.json
@@ -1,0 +1,17934 @@
+{
+  "description": "Comprehensive monitoring dashboard for AWS Managed Streaming for Apache Kafka (MSK) clusters. Covers cluster health, throughput, request performance, storage, consumer groups, CPU/memory utilization, replication, and client connections using CloudWatch and JMX metrics exported via Prometheus and collected by OpenTelemetry Collector.",
+  "image": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgZmlsbD0ibm9uZSI+PHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0IiByeD0iOCIgZmlsbD0iIzIzMkYzRSIvPjxwYXRoIGQ9Ik0zMiAxMkwxNiAyMHYyNGwxNiA4IDE2LThWMjBMMzIgMTJ6IiBmaWxsPSIjRkY5OTAwIiBvcGFjaXR5PSIwLjkiLz48cGF0aCBkPSJNMzIgMTJ2NDBsMTYtOFYyMEwzMiAxMnoiIGZpbGw9IiNGRjk5MDAiLz48cGF0aCBkPSJNMzIgMTJMMTYgMjBsMTYgOCAxNi04TDMyIDEyeiIgZmlsbD0iI0ZGQjg0RCIvPjxjaXJjbGUgY3g9IjI0IiBjeT0iMzIiIHI9IjMiIGZpbGw9IiMyMzJGM0UiLz48Y2lyY2xlIGN4PSIzMiIgY3k9IjI4IiByPSIzIiBmaWxsPSIjMjMyRjNFIi8+PGNpcmNsZSBjeD0iNDAiIGN5PSIzMiIgcj0iMyIgZmlsbD0iIzIzMkYzRSIvPjxjaXJjbGUgY3g9IjI4IiBjeT0iMzgiIHI9IjMiIGZpbGw9IiMyMzJGM0UiLz48Y2lyY2xlIGN4PSIzNiIgY3k9IjM4IiByPSIzIiBmaWxsPSIjMjMyRjNFIi8+PGxpbmUgeDE9IjI0IiB5MT0iMzIiIHgyPSIzMiIgeTI9IjI4IiBzdHJva2U9IiMyMzJGM0UiIHN0cm9rZS13aWR0aD0iMS41Ii8+PGxpbmUgeDE9IjMyIiB5MT0iMjgiIHgyPSI0MCIgeTI9IjMyIiBzdHJva2U9IiMyMzJGM0UiIHN0cm9rZS13aWR0aD0iMS41Ii8+PGxpbmUgeDE9IjI0IiB5MT0iMzIiIHgyPSIyOCIgeTI9IjM4IiBzdHJva2U9IiMyMzJGM0UiIHN0cm9rZS13aWR0aD0iMS41Ii8+PGxpbmUgeDE9IjQwIiB5MT0iMzIiIHgyPSIzNiIgeTI9IjM4IiBzdHJva2U9IiMyMzJGM0UiIHN0cm9rZS13aWR0aD0iMS41Ii8+PGxpbmUgeDE9IjI4IiB5MT0iMzgiIHgyPSIzNiIgeTI9IjM4IiBzdHJva2U9IiMyMzJGM0UiIHN0cm9rZS13aWR0aD0iMS41Ii8+PC9zdmc+",
+  "layout": [
+    {
+      "h": 1,
+      "i": "0acae52a-2f13-44bb-b1bf-c591ed7832a1",
+      "w": 12,
+      "x": 0,
+      "y": 0,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 2,
+      "i": "2d834616-d215-4b49-873d-0a6e90d390a5",
+      "w": 3,
+      "x": 0,
+      "y": 1,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 2,
+      "i": "52a6cf2c-e49d-4595-b8a0-4929c3663b8b",
+      "w": 3,
+      "x": 3,
+      "y": 1,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 2,
+      "i": "f1f0540e-9ccd-4248-aa14-9c97aac2b697",
+      "w": 3,
+      "x": 6,
+      "y": 1,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 2,
+      "i": "b8ddd769-3499-423a-8ef3-a329663855ea",
+      "w": 3,
+      "x": 9,
+      "y": 1,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 2,
+      "i": "4fcc5aa7-7ce6-4a6e-a85e-87a5309a5409",
+      "w": 3,
+      "x": 0,
+      "y": 3,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 2,
+      "i": "cdb7e1bb-ceac-47c6-a6c5-22dc5996c6d7",
+      "w": 3,
+      "x": 3,
+      "y": 3,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 2,
+      "i": "2605cc86-3926-4d1f-b832-e460cb4f35ba",
+      "w": 3,
+      "x": 6,
+      "y": 3,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 2,
+      "i": "3ad1bcfb-bb4d-44fe-afa4-3e8e9164497a",
+      "w": 3,
+      "x": 9,
+      "y": 3,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "f442d2bd-c8c5-45e6-b65d-9f83e980e7db",
+      "w": 6,
+      "x": 0,
+      "y": 5,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "fb8e17a1-ad97-4227-993c-9fd0cb9e0b82",
+      "w": 6,
+      "x": 6,
+      "y": 5,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "837cbc4d-4f95-4fa3-a6b2-6a8c85c0ad61",
+      "w": 6,
+      "x": 0,
+      "y": 8,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "084924e5-892f-429d-ae1f-caef84667026",
+      "w": 6,
+      "x": 6,
+      "y": 8,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "eb2c4bf7-4315-4e92-becb-62f8e8bf2c8f",
+      "w": 6,
+      "x": 0,
+      "y": 11,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "9b93f218-39dd-40e8-829f-d9880a79eee7",
+      "w": 6,
+      "x": 6,
+      "y": 11,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 1,
+      "i": "3b17d137-f782-4917-afa3-656f03bcb85e",
+      "w": 12,
+      "x": 0,
+      "y": 14,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "4170f879-4d89-4a63-9ef8-294f1a887c24",
+      "w": 6,
+      "x": 0,
+      "y": 15,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "89cf80e7-87bc-4bbf-a4b8-a28af2090180",
+      "w": 6,
+      "x": 6,
+      "y": 15,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "84c6790d-8ae7-435f-9d02-8fa57de2f08f",
+      "w": 6,
+      "x": 0,
+      "y": 18,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "23bdf17c-295f-4d1c-9bc9-a7469e41f708",
+      "w": 6,
+      "x": 6,
+      "y": 18,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "f5003721-bbf8-4fcd-9855-3517856a29b6",
+      "w": 6,
+      "x": 0,
+      "y": 21,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "b31ae6d0-7178-47d5-b7c0-5468110916de",
+      "w": 6,
+      "x": 6,
+      "y": 21,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "a7473ce3-dafc-4078-b579-376cda99a755",
+      "w": 6,
+      "x": 0,
+      "y": 24,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "8d6a0b07-8f3b-470e-8234-a7a915fcf2ae",
+      "w": 6,
+      "x": 6,
+      "y": 24,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "1e733cd9-f7ce-42f6-9cfa-95637a278b56",
+      "w": 6,
+      "x": 0,
+      "y": 27,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "d4d5fdba-3bfe-40a7-aee7-8cb9d4f3e69e",
+      "w": 6,
+      "x": 6,
+      "y": 27,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "b278c6e5-3db5-4905-8f38-1797d4ad8ab5",
+      "w": 6,
+      "x": 0,
+      "y": 30,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "32948ba9-993f-45f0-91e1-a0ad54cc46f7",
+      "w": 6,
+      "x": 6,
+      "y": 30,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 1,
+      "i": "5501c75f-9bbc-47ee-bb41-1144c22f6ec8",
+      "w": 12,
+      "x": 0,
+      "y": 33,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "29413c15-71c5-4cdf-861c-fb5e973f4f1d",
+      "w": 6,
+      "x": 0,
+      "y": 34,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "07806373-1e74-493e-aac0-4a0e3a5f4c33",
+      "w": 6,
+      "x": 6,
+      "y": 34,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "8bc8b23d-0e01-4914-9952-502c78643fb0",
+      "w": 6,
+      "x": 0,
+      "y": 37,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "50f2fe83-a0d7-4a88-915b-7086ff285ff8",
+      "w": 6,
+      "x": 6,
+      "y": 37,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "9b0bbf12-5897-4477-95c7-d39e0729662c",
+      "w": 6,
+      "x": 0,
+      "y": 40,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "02850e82-0e70-484a-bb67-6cdb5bca082d",
+      "w": 6,
+      "x": 6,
+      "y": 40,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "696f91a1-c1a7-4414-ad06-4f1b72e77860",
+      "w": 6,
+      "x": 0,
+      "y": 43,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "81cb8c28-18b3-44bd-9c86-5e9a3658b21f",
+      "w": 6,
+      "x": 6,
+      "y": 43,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "e21af47c-8f64-49b0-b19c-399ed0c1b314",
+      "w": 6,
+      "x": 0,
+      "y": 46,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "83728cf4-bbd3-4e0e-9852-bc271d596bc1",
+      "w": 6,
+      "x": 6,
+      "y": 46,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "86a4fcd6-9698-4b34-80b8-e534bb480d17",
+      "w": 6,
+      "x": 0,
+      "y": 49,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "7e270c5b-b465-46fe-90c0-faf9f9f2e3d0",
+      "w": 6,
+      "x": 6,
+      "y": 49,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "117d0fd8-e4b4-4af8-938f-31426cc023ed",
+      "w": 6,
+      "x": 0,
+      "y": 52,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "06d7ebc6-d4a8-4d21-8133-9196c4ca792a",
+      "w": 6,
+      "x": 6,
+      "y": 52,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 1,
+      "i": "58889ad8-d262-4871-9eba-5ef7100a6f73",
+      "w": 12,
+      "x": 0,
+      "y": 55,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "3f494f72-323e-4f8d-8649-6d4ca29180a1",
+      "w": 6,
+      "x": 0,
+      "y": 56,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "52c975b1-9c1a-4a24-bfb2-7114798154eb",
+      "w": 6,
+      "x": 6,
+      "y": 56,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "5b688ca0-18ea-4f20-a789-5657814b7f9b",
+      "w": 6,
+      "x": 0,
+      "y": 59,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 2,
+      "i": "92016c38-fa84-42e9-8056-830bee64b157",
+      "w": 3,
+      "x": 6,
+      "y": 59,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 2,
+      "i": "be078ad8-7cc7-4213-b93b-ffa0e8a15a9c",
+      "w": 3,
+      "x": 9,
+      "y": 59,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "9f69b97e-489e-4f4a-b27a-d993ebc2c38b",
+      "w": 6,
+      "x": 0,
+      "y": 61,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "40a11ae3-42bc-427c-a25c-887c091b0fad",
+      "w": 6,
+      "x": 6,
+      "y": 61,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "2d9361c6-24c9-4ca3-82ab-717f0bf23ea5",
+      "w": 6,
+      "x": 0,
+      "y": 64,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "8bc041bb-ff14-473a-be4a-ec4f83d1820f",
+      "w": 6,
+      "x": 6,
+      "y": 64,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 1,
+      "i": "964f2820-e0d5-468d-bff3-27e845f6e185",
+      "w": 12,
+      "x": 0,
+      "y": 67,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "ec1f7313-0cbb-4b0b-a06c-2f9aa02e2459",
+      "w": 6,
+      "x": 0,
+      "y": 68,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "96afc832-4262-4028-892f-f21996ec74f2",
+      "w": 6,
+      "x": 6,
+      "y": 68,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "d2eff157-9ff4-4afc-9c17-42e6b674faf6",
+      "w": 6,
+      "x": 0,
+      "y": 71,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 2,
+      "i": "d815a127-a36a-4a15-a5af-0a79f72b47bd",
+      "w": 3,
+      "x": 6,
+      "y": 71,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 2,
+      "i": "7b9d6e7c-92d6-4881-81d3-3002d1693d69",
+      "w": 3,
+      "x": 9,
+      "y": 71,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 2,
+      "i": "e1678935-7910-4bfa-8d87-8a9d246942ca",
+      "w": 3,
+      "x": 0,
+      "y": 73,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "46774466-3de6-48ab-a2a7-eeeea50648f2",
+      "w": 6,
+      "x": 3,
+      "y": 73,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "3f56bdfd-6fb1-43b6-8b5f-180e589ca5b6",
+      "w": 6,
+      "x": 0,
+      "y": 73,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "62a8380c-2989-4891-b9e0-0ef807959760",
+      "w": 6,
+      "x": 6,
+      "y": 73,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 1,
+      "i": "eae76018-3ff7-444f-b3b4-58a91d2ba866",
+      "w": 12,
+      "x": 0,
+      "y": 76,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "a8266c5b-a230-4703-a828-983c7810c60d",
+      "w": 4,
+      "x": 0,
+      "y": 77,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "8c514a65-68b6-4a56-b718-27b97522d628",
+      "w": 4,
+      "x": 4,
+      "y": 77,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "a1155cb4-ab4b-4729-b3e1-e88b67de502e",
+      "w": 4,
+      "x": 8,
+      "y": 77,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "6738fe18-bbe5-4426-b617-e36f659bd5d0",
+      "w": 6,
+      "x": 0,
+      "y": 80,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "73203aa7-62da-4e40-bd21-2f312610388e",
+      "w": 6,
+      "x": 6,
+      "y": 80,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "672e36f7-31ca-49f9-9069-357d82d5515e",
+      "w": 6,
+      "x": 0,
+      "y": 83,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "6a37957a-5788-4d7b-a0fe-b30146e67640",
+      "w": 6,
+      "x": 6,
+      "y": 83,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "b4d9b8ed-ad88-4484-aa0a-e1929efd48ee",
+      "w": 6,
+      "x": 0,
+      "y": 86,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "282d090e-2648-4782-a1d5-a9ce4ee9ee30",
+      "w": 6,
+      "x": 6,
+      "y": 86,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "86c8b361-c501-4efd-be5d-53c5e0611ef7",
+      "w": 6,
+      "x": 0,
+      "y": 89,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "e56797ac-6047-4149-9a8d-252d8cd76df8",
+      "w": 6,
+      "x": 6,
+      "y": 89,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "697f9d73-b764-402a-b3e8-a18a4ac01e54",
+      "w": 6,
+      "x": 0,
+      "y": 92,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "debe56d5-371c-496a-9dd0-816fe408e174",
+      "w": 6,
+      "x": 6,
+      "y": 92,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "69d51446-bd31-4153-a1e7-ccb0f8d0774e",
+      "w": 6,
+      "x": 0,
+      "y": 95,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "6f03d9fd-97b8-43df-af14-37c74d3cbcbe",
+      "w": 6,
+      "x": 6,
+      "y": 95,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "5c7dcdb8-3b45-4047-a620-b0cb5ccece2d",
+      "w": 6,
+      "x": 0,
+      "y": 98,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 1,
+      "i": "8f474378-7bb0-4b59-adf7-3429564686e7",
+      "w": 12,
+      "x": 0,
+      "y": 98,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "fe5d5aa8-f090-431c-ae89-444e60307be7",
+      "w": 6,
+      "x": 0,
+      "y": 99,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "c4222a2a-d055-437d-9135-9a92cb6a462c",
+      "w": 6,
+      "x": 6,
+      "y": 99,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "775930af-caeb-425e-ae2d-5b06e5f8c82b",
+      "w": 6,
+      "x": 0,
+      "y": 102,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "888152a9-32f8-4e3b-921e-49aad2669751",
+      "w": 6,
+      "x": 6,
+      "y": 102,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "b6f42733-ca04-459f-aa2d-c51b24dfe244",
+      "w": 6,
+      "x": 0,
+      "y": 105,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "fb8f1c24-a9c0-4600-9ed8-142e389db2b4",
+      "w": 6,
+      "x": 6,
+      "y": 105,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "937ec46b-de8a-49cd-b214-4f9a54a15ac4",
+      "w": 6,
+      "x": 0,
+      "y": 108,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "0e4615a6-8aa6-4282-9ef1-f49a58a594d2",
+      "w": 6,
+      "x": 6,
+      "y": 108,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "d00354c6-6431-4787-9a78-ad60c352dfaa",
+      "w": 6,
+      "x": 0,
+      "y": 111,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "e62e8347-720f-4267-9d44-ae97109d01c7",
+      "w": 6,
+      "x": 6,
+      "y": 111,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 1,
+      "i": "b032d75a-aa5b-4f5d-8767-b5290c76ef98",
+      "w": 12,
+      "x": 0,
+      "y": 114,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "1b1a1e1a-3d32-48c7-92c1-85e1be3205c6",
+      "w": 6,
+      "x": 0,
+      "y": 115,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 2,
+      "i": "409b3724-1dc7-452e-aab3-75e93246174a",
+      "w": 6,
+      "x": 6,
+      "y": 115,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "eeb6d7c8-36d1-4863-afb4-b20281dd40bb",
+      "w": 6,
+      "x": 0,
+      "y": 117,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "4d676368-5318-4ac5-9b02-cae260eaa811",
+      "w": 6,
+      "x": 6,
+      "y": 117,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "def56b05-1dc9-4bfe-a147-e831a03fb76f",
+      "w": 6,
+      "x": 0,
+      "y": 120,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "1db36cd1-8bdd-499f-bd6c-038e1f48c2a5",
+      "w": 6,
+      "x": 6,
+      "y": 120,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "6532c061-0ac5-4aab-b865-bb37bf3b75f5",
+      "w": 6,
+      "x": 0,
+      "y": 123,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 2,
+      "i": "fa6cc78d-ac45-4788-beac-1bf9c98b6ae0",
+      "w": 3,
+      "x": 6,
+      "y": 123,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 2,
+      "i": "1ac92fb7-36e3-4a27-840a-41c8e062cfc6",
+      "w": 3,
+      "x": 9,
+      "y": 123,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "89792ad6-2676-4c30-a181-4d054c38aa18",
+      "w": 6,
+      "x": 0,
+      "y": 125,
+      "moved": false,
+      "static": false
+    },
+    {
+      "h": 3,
+      "i": "f6d2fa4e-83b9-4841-9090-e6b53ce5b138",
+      "w": 6,
+      "x": 6,
+      "y": 125,
+      "moved": false,
+      "static": false
+    }
+  ],
+  "tags": [
+    "aws",
+    "msk",
+    "kafka"
+  ],
+  "title": "AWS MSK Cluster Monitoring",
+  "uploadedGrafana": false,
+  "variables": {
+    "cluster_name": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "MSK Cluster Name",
+      "id": "494a3971-8bb1-49a1-a103-520587f0fc19",
+      "key": "12d8dae5-ad8a-4bb8-9d68-225e9abfb5aa",
+      "modificationUUID": "febcb950-8d30-441f-a444-49728268b08f",
+      "multiSelect": false,
+      "name": "cluster_name",
+      "order": 0,
+      "queryValue": "SHOW TAG VALUES FROM 'aws_kafka_activecontrollercount' WITH KEY = 'ClusterName'",
+      "selectedValue": "ALL",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "broker_id": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Broker ID",
+      "id": "b5a1e26b-9038-474c-b386-3eaa5fca9fa6",
+      "key": "38cbe972-8afe-4621-8202-f4ca195f3e6d",
+      "modificationUUID": "1fe15ade-d631-49d6-b179-2d2a20c66824",
+      "multiSelect": true,
+      "name": "broker_id",
+      "order": 1,
+      "queryValue": "SHOW TAG VALUES FROM 'aws_kafka_bytesinpersec' WITH KEY = 'BrokerId'",
+      "selectedValue": "ALL",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "topic": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Kafka Topic",
+      "id": "9f76f286-1c5c-4277-94c0-d679d0d43609",
+      "key": "014f5c08-b279-4f09-8f8e-bb3ba8fc64cb",
+      "modificationUUID": "3ea364ae-41c4-480d-8f65-2f7d2c325fcb",
+      "multiSelect": true,
+      "name": "topic",
+      "order": 2,
+      "queryValue": "SHOW TAG VALUES FROM 'aws_kafka_messagesinpersec' WITH KEY = 'Topic'",
+      "selectedValue": "ALL",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "consumer_group": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Consumer Group",
+      "id": "e5c0e0cc-e667-4f36-8f8e-d469b62b6976",
+      "key": "ad2b2280-c6ea-4ec3-a370-46b6b26cb259",
+      "modificationUUID": "a9341bfa-f435-4d60-97cf-150c0a1b0aff",
+      "multiSelect": true,
+      "name": "consumer_group",
+      "order": 3,
+      "queryValue": "SHOW TAG VALUES FROM 'aws_kafka_sumoffsetlag' WITH KEY = 'ConsumerGroup'",
+      "selectedValue": "ALL",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "version": "v4",
+  "widgets": [
+    {
+      "description": "High-level health indicators for your AWS MSK cluster including controller status, partition health, and ZooKeeper metrics",
+      "id": "0acae52a-2f13-44bb-b1bf-c591ed7832a1",
+      "panelTypes": "row",
+      "title": "Cluster Overview"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Number of active controllers in the cluster. Should always be 1.",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "2d834616-d215-4b49-873d-0a6e90d390a5",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_activecontrollercount",
+                  "reduceTo": "latest",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "ac04ae22-8c3e-4721-9dde-fda923edc240",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6c68833b-b900-4a32-8ac7-c6591fa8068c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [
+        {
+          "color": "#ff4d4f",
+          "index": 0,
+          "isDefult": false,
+          "value": 0
+        },
+        {
+          "color": "#52c41a",
+          "index": 1,
+          "isDefult": false,
+          "value": 1
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Controller Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Number of partitions that are offline. Should be 0.",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "52a6cf2c-e49d-4595-b8a0-4929c3663b8b",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_offlinepartitionscount",
+                  "reduceTo": "latest",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "73d1fca0-56fb-4a74-a6b3-3ba04a8d99d5",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "334d008a-268e-4167-8a23-33bf939d08ae",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [
+        {
+          "color": "#52c41a",
+          "index": 0,
+          "isDefult": false,
+          "value": 0
+        },
+        {
+          "color": "#ff4d4f",
+          "index": 1,
+          "isDefult": false,
+          "value": 1
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Offline Partitions",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Number of under-replicated partitions. Non-zero indicates replication lag.",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "f1f0540e-9ccd-4248-aa14-9c97aac2b697",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_underreplicatedpartitions",
+                  "reduceTo": "latest",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "a8310ce1-6dc1-4d8a-9fe0-a5d78d72b4f5",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c43469f5-29e3-4aac-b5f8-ae3b29c846e5",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [
+        {
+          "color": "#52c41a",
+          "index": 0,
+          "isDefult": false,
+          "value": 0
+        },
+        {
+          "color": "#faad14",
+          "index": 1,
+          "isDefult": false,
+          "value": 1
+        },
+        {
+          "color": "#ff4d4f",
+          "index": 2,
+          "isDefult": false,
+          "value": 5
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Under-Replicated Partitions",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Partitions where ISR count is below min.insync.replicas. Critical alert condition.",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "b8ddd769-3499-423a-8ef3-a329663855ea",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_underminisrpartitioncount",
+                  "reduceTo": "latest",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "648db63a-3e81-49e5-860a-73c0e4203950",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "cf877ca6-eab5-4538-a837-7522ab6da12d",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [
+        {
+          "color": "#52c41a",
+          "index": 0,
+          "isDefult": false,
+          "value": 0
+        },
+        {
+          "color": "#ff4d4f",
+          "index": 1,
+          "isDefult": false,
+          "value": 1
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Under Min ISR Partitions",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Total number of topics across the cluster",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "4fcc5aa7-7ce6-4a6e-a85e-87a5309a5409",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_globaltopiccount",
+                  "reduceTo": "latest",
+                  "spaceAggregation": "max",
+                  "temporality": "",
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "28201e47-036d-4950-96d3-967f1d2028e4",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9f3b741f-6bef-4c3e-afdc-a22aee690559",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Global Topic Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Total number of partitions across all topics in the cluster",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "cdb7e1bb-ceac-47c6-a6c5-22dc5996c6d7",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_globalpartitioncount",
+                  "reduceTo": "latest",
+                  "spaceAggregation": "max",
+                  "temporality": "",
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "01cf9ac8-c3ba-4c16-af00-d9618607c98b",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "19f76c37-90a1-40cf-a225-78395500aedd",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Global Partition Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Mean ZooKeeper request latency in milliseconds",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "2605cc86-3926-4d1f-b832-e460cb4f35ba",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_zookeeperrequestlatencyms_mean",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "79056071-5764-43b1-ada4-0764a0efa2f3",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "83cb26ca-353b-44ff-885a-f50af5a04b8c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "ZooKeeper Request Latency (Mean)",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "ZooKeeper session state. 0 = not connected, 1 = connected",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "3ad1bcfb-bb4d-44fe-afa4-3e8e9164497a",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_zookeepersessionstate",
+                  "reduceTo": "latest",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "c7cc8110-4f35-4b80-a6dc-185d3a0d8000",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "32b62033-fb58-439a-8ba7-db3e0bfcdb86",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "ZooKeeper Session Expiry Rate",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Active controller count over time. Drops to 0 indicate leader election events.",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "f442d2bd-c8c5-45e6-b65d-9f83e980e7db",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_activecontrollercount",
+                  "reduceTo": "latest",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "15b07431-9602-4e40-9a21-01621570d78b",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "ClusterName",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{ClusterName}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "08c7e970-e53a-48ee-9327-39059c1e347e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Controller Count Over Time",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Under-replicated partitions by broker over time",
+      "fillMode": "solid",
+      "fillSpans": false,
+      "id": "fb8e17a1-ad97-4227-993c-9fd0cb9e0b82",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_underreplicatedpartitions",
+                  "reduceTo": "latest",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "30c86af2-1202-49b3-8a39-47e3636f1157",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "7f7b95e0-bf0d-4a2e-8f0c-4b959885a48d",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c29d5888-85dd-4eef-bb6c-8cf51349d162",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Under-Replicated Partitions Over Time",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Offline partition count trend. Any value > 0 is critical.",
+      "fillMode": "solid",
+      "fillSpans": false,
+      "id": "837cbc4d-4f95-4fa3-a6b2-6a8c85c0ad61",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_offlinepartitionscount",
+                  "reduceTo": "latest",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "0c767533-6e04-4399-9f89-a78e3e8bbb61",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "ClusterName",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{ClusterName}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "28e42aae-55e0-4b6f-a72b-8ffc8ffe2004",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Offline Partitions Over Time",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "ZooKeeper request latency percentiles by broker",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "084924e5-892f-429d-ae1f-caef84667026",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_zookeeperrequestlatencyms_mean",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "bf9d5afd-486a-410b-89ed-8ed803e42593",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "f1e1d03a-f250-43d6-bfe5-fef5bfc66fbf",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Mean - Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_zookeeperrequestlatencyms_p99",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "2d84ddd7-8ed7-471b-a9cb-747f65036c02",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "b3c8a87d-75f1-469d-80a0-621d3b7346ba",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "P99 - Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "7865d18d-78f7-48cf-8eaa-4049ae7ac2e9",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "ZooKeeper Request Latency Over Time",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Number of partitions per broker. Imbalance indicates need for partition reassignment.",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "eb2c4bf7-4315-4e92-becb-62f8e8bf2c8f",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_partitioncount",
+                  "reduceTo": "latest",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "31ffc2b5-74d9-4bc9-8f9b-e8ac65003695",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "1d20ad16-aba8-408b-b9ef-c41298286d4e",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "bb1ab073-a5a5-42be-8235-55da1ef3f539",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Partition Count by Broker",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Number of partition leaders per broker. Should be evenly distributed.",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "9b93f218-39dd-40e8-829f-d9880a79eee7",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_leadercount",
+                  "reduceTo": "latest",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "aac59080-2ea4-47db-a371-3a5ea4cf83b7",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "26b9e4a9-08ee-4304-a7fb-9790e37acfcc",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "da0cdcb4-93c0-40a0-bfa5-6b78ac20b088",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Leader Count by Broker",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Message and byte throughput metrics for producers and consumers across the MSK cluster",
+      "id": "3b17d137-f782-4917-afa3-656f03bcb85e",
+      "panelTypes": "row",
+      "title": "Throughput"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Rate of incoming messages per second by broker",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "4170f879-4d89-4a63-9ef8-294f1a887c24",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_messagesinpersec",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "306dbee9-c80b-424f-bc83-324aac85fc8a",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "135ac38f-29bf-4f59-a207-69d452a7a6df",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "862c3a58-170a-43ac-a19a-db3ccfb6211e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Messages In Per Second",
+      "yAxisUnit": "cps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Rate of incoming messages per second by topic",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "89cf80e7-87bc-4bbf-a4b8-a28af2090180",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_messagesinpersec",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "a8b68a95-467d-489d-a595-6fb3876ffb55",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "369961e6-5ccb-4056-abc3-a6c2a38e9c41",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  },
+                  {
+                    "id": "94284c4b-ea0c-4e5a-97e2-356f534275b8",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "Topic",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.topic}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "Topic",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{Topic}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "bc192a55-9aac-454b-84d8-817cdc3b4c34",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Messages In Per Second (by Topic)",
+      "yAxisUnit": "cps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Incoming byte rate per broker",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "84c6790d-8ae7-435f-9d02-8fa57de2f08f",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_bytesinpersec",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "9fdb4e4d-57c0-43c5-b728-9512e3396ccf",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "3d6d9b75-9527-4a14-9bd6-841eb28a9d89",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c07632e1-fb5a-4931-920f-89e7b7232d7c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Bytes In Per Second",
+      "yAxisUnit": "binBps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Outgoing byte rate per broker",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "23bdf17c-295f-4d1c-9bc9-a7469e41f708",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_bytesoutpersec",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "4df13ae9-b5d2-42b4-bfca-a4e7b9c6ce5d",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "ed5561d3-c9c5-4e83-a564-9d95c70c8c4b",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d4ae33e7-9606-40a9-b33a-f4dca715372e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Bytes Out Per Second",
+      "yAxisUnit": "binBps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Incoming bytes per second broken down by topic",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "f5003721-bbf8-4fcd-9855-3517856a29b6",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_bytesinpersec",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "b934eb42-2bf6-4c9a-b3f1-2d9cf976a71c",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "510bb3b2-4333-43bd-b5f4-774342d8e059",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  },
+                  {
+                    "id": "c6f3faa1-650c-4312-a022-f232279a41e4",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "Topic",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.topic}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "Topic",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{Topic}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "89fd0457-ec39-4a05-9c68-b3da474a10a9",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Bytes In Per Second (by Topic)",
+      "yAxisUnit": "binBps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Outgoing bytes per second broken down by topic",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "b31ae6d0-7178-47d5-b7c0-5468110916de",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_bytesoutpersec",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "0cb94df1-4eff-41ec-a89c-a6fb7e863021",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "13dfa719-2d19-4e14-ba2d-d394f917d699",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  },
+                  {
+                    "id": "1865bd65-c4ec-40f1-8627-0cc718122943",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "Topic",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.topic}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "Topic",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{Topic}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a7f96488-bbc1-4128-b9bd-f084d5ee9d07",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Bytes Out Per Second (by Topic)",
+      "yAxisUnit": "binBps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Rate of produce message format conversions. High values indicate clients using old message formats.",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "a7473ce3-dafc-4078-b579-376cda99a755",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_producemessageconversionspersec",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "41a21c3a-e0fa-4082-8c5e-3eab38077081",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "1c9cfca2-193c-47c8-9bfe-4b6bd5a6811c",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "4fdc09a9-8bba-461c-a117-7b5bec4957ef",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Produce Message Conversions/sec",
+      "yAxisUnit": "cps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Rate of fetch message format conversions. High values indicate consumers using old message formats.",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "8d6a0b07-8f3b-470e-8234-a7a915fcf2ae",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_fetchmessageconversionspersec",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "c7a6f210-cbe0-43f1-8b0d-55db80027282",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "ed24c77c-bc5d-4422-b17b-3df86f22e655",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "4f530535-6a81-48d9-b776-9ec4349f50fe",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Fetch Message Conversions/sec",
+      "yAxisUnit": "cps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Bytes per second incoming from other brokers for replication",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "1e733cd9-f7ce-42f6-9cfa-95637a278b56",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_replicationbytesinpersec",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "45080313-8cd1-49ec-977c-54e4644c0f37",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "9617115d-9c3f-47b5-b479-80fced0cc810",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ff31a7da-df1c-4638-826a-11fbb9c0a3bb",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Replication Bytes In/sec",
+      "yAxisUnit": "binBps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Bytes per second outgoing to other brokers for replication",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "d4d5fdba-3bfe-40a7-aee7-8cb9d4f3e69e",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_replicationbytesoutpersec",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "9ecd9676-b70b-45a8-895c-43d86d2fb314",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "d7b1486e-ecc8-4b55-acce-79f497cf9949",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ae4a4663-a39f-4af9-8cd0-00ae7a8d9b68",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Replication Bytes Out/sec",
+      "yAxisUnit": "binBps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Cluster-wide aggregate bytes in vs bytes out",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "b278c6e5-3db5-4905-8f38-1797d4ad8ab5",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_bytesinpersec",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "f836cdbd-ca7c-4dcc-9451-c621f41c6177",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "ClusterName",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Bytes In",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_bytesoutpersec",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "415a7c95-351d-4635-ac61-4492fd0bc831",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "ClusterName",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Bytes Out",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "1e3a068d-0582-45fb-9f14-32ddf6ba014e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Bytes In vs Out (Cluster)",
+      "yAxisUnit": "binBps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Cluster-wide aggregate message ingestion rate",
+      "fillMode": "solid",
+      "fillSpans": false,
+      "id": "32948ba9-993f-45f0-91e1-a0ad54cc46f7",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_messagesinpersec",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "3e3f2173-b2e3-4adc-8779-aa4b6158a0ff",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "ClusterName",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{ClusterName}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "2436582b-30da-4917-91de-e62ff5a997c1",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Messages In (Cluster)",
+      "yAxisUnit": "cps"
+    },
+    {
+      "description": "Kafka broker request handling latency and handler utilization metrics",
+      "id": "5501c75f-9bbc-47ee-bb41-1144c22f6ec8",
+      "panelTypes": "row",
+      "title": "Request Performance"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Mean time the leader spends processing produce requests at the partition level",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "29413c15-71c5-4cdf-861c-fb5e973f4f1d",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_producelocaltimemsmean",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "2e7b61c2-fd96-4a04-a621-825177f52705",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "89e24ba4-ac81-4a09-a6c7-e4c6c34675d3",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "69759742-9413-4710-8b8c-327e0cdd5899",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Produce Local Time (Mean)",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Mean time to process produce requests including network time",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "07806373-1e74-493e-aac0-4a0e3a5f4c33",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_producerequesttimemsmean",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "776080ac-bdce-4317-ae2a-7add121723d4",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "4d4bb3f4-0c85-40f6-b1ea-cd672819b4c4",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a538d7c5-efca-44f9-9cc9-6fe5aad70b21",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Produce Request Time (Mean)",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Mean total time for produce requests end-to-end",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "8bc8b23d-0e01-4914-9952-502c78643fb0",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_producetotaltimemsmean",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "b097cc94-83da-4a9d-bca0-8e6a96863efc",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "57a97a01-e792-4ea9-993a-3761b6b058b3",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "17123893-d6c5-4cd0-ae02-351bd0be28e3",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Produce Total Time (Mean)",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Mean time produce responses spend in the response queue",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "50f2fe83-a0d7-4a88-915b-7086ff285ff8",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_produceresponsequeuetimemsmean",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "9d0ed777-82b1-421b-b18f-8b718a5d729c",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "0b730dca-cf09-4f79-860c-18d52bca29ff",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "308b63c2-5f15-46c2-ae34-fe594fe508b4",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Produce Response Queue Time (Mean)",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Mean time the leader spends processing fetch consumer requests",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "9b0bbf12-5897-4477-95c7-d39e0729662c",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_fetchconsumerlocaltimemsmean",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "bf310be0-f157-48d6-90e6-adbca1c402fc",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "3887c0dd-8b6a-4ed0-a099-a8a687480ebc",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b919f7a0-c12d-4d9d-8330-1edf18efa326",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Fetch Consumer Local Time (Mean)",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Mean request time for fetch consumer operations",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "02850e82-0e70-484a-bb67-6cdb5bca082d",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_fetchconsumerrequesttimemsmean",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "c3319558-9740-424a-a76c-78d588bcd47e",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "83c02d19-8ec8-4526-aa93-01932bf60e60",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c96b8b96-7716-43cc-80ce-fe40fe51e0b7",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Fetch Consumer Request Time (Mean)",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Mean total time for consumer fetch requests",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "696f91a1-c1a7-4414-ad06-4f1b72e77860",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_fetchconsumertotaltimemsmean",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "1fbe8ecd-60b9-43d5-ba7b-07c5eac4d93c",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "51f22473-9e1e-4f64-9f09-42d053414b64",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "7ebe6772-a8b4-430f-998f-5b1935e96d06",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Fetch Consumer Total Time (Mean)",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Mean time consumer fetch responses spend in the response queue",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "81cb8c28-18b3-44bd-9c86-5e9a3658b21f",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_fetchconsumerresponsequeuetimemsmean",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "04e6d2c2-44f8-4189-8d3a-4f7e311c70d4",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "9eb797f4-c8fd-4891-af22-9165c7588eff",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "76ca2ffa-e526-44fa-83fc-81ba65911a18",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Fetch Consumer Response Queue Time",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Mean time the leader spends processing fetch follower requests (replication)",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "e21af47c-8f64-49b0-b19c-399ed0c1b314",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_fetchfollowerlocaltimemsmean",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "b1f35b0d-51e6-446f-8252-b5122f97141d",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "815c5baf-8560-4908-98db-3a840afd33d9",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "86b4ff2d-fb5b-45d1-aa2a-6fc99cad2232",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Fetch Follower Local Time (Mean)",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Mean total time for follower fetch requests (replication)",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "83728cf4-bbd3-4e0e-9852-bc271d596bc1",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_fetchfollowertotaltimemsmean",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "d13d05dd-45a0-4cb4-be0a-fbc3f7157f77",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "53d56c75-dab1-4cfb-908a-325350dfebcd",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8a079713-4118-431d-b916-952bea5bea9c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Fetch Follower Total Time (Mean)",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Average fraction of time request handler threads are idle. Below 0.3 (30%) indicates saturation.",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "86a4fcd6-9698-4b34-80b8-e534bb480d17",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_requesthandleravgidle_percent",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "8dc378eb-056a-4a98-8847-6079db679e1d",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "e8412ac6-57d2-4f70-92ae-73e2cdacf14b",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9c235306-2144-4d99-a30f-28c3d913bfbe",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [
+        {
+          "color": "#ff4d4f",
+          "index": 0,
+          "isDefult": false,
+          "value": 0
+        },
+        {
+          "color": "#faad14",
+          "index": 1,
+          "isDefult": false,
+          "value": 0.3
+        },
+        {
+          "color": "#52c41a",
+          "index": 2,
+          "isDefult": false,
+          "value": 0.7
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Handler Avg Idle %",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Average fraction of time network processor threads are idle. Below 0.3 (30%) indicates network saturation.",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "7e270c5b-b465-46fe-90c0-faf9f9f2e3d0",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_networkprocessoravgidle_percent",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "b124d851-7ed5-46c5-a58a-10ad3907dcd4",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "700dd83e-263c-4593-a774-f822fdc30911",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ae810c2a-38c5-4ae3-8b8b-fb0959ede4cc",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [
+        {
+          "color": "#ff4d4f",
+          "index": 0,
+          "isDefult": false,
+          "value": 0
+        },
+        {
+          "color": "#faad14",
+          "index": 1,
+          "isDefult": false,
+          "value": 0.3
+        },
+        {
+          "color": "#52c41a",
+          "index": 2,
+          "isDefult": false,
+          "value": 0.7
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Network Processor Avg Idle %",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Mean request size in bytes",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "117d0fd8-e4b4-4af8-938f-31426cc023ed",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_requestbytesmean",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "073889a3-0f0d-4215-8d88-634b07d42a32",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "2cd75462-ee94-417c-8b1f-80fa7558065d",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "3d8b1012-ead9-4ff9-a213-3e955559a7b7",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Bytes Mean",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Mean response size in bytes",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "06d7ebc6-d4a8-4d21-8133-9196c4ca792a",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_responsebytesmean",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "b7e6f4c1-222d-49a3-8d5f-14d197a741cc",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "fd873c5e-49c8-4f5d-9402-a3a739d1cdd6",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "93726c8f-a4aa-411e-9948-56a8a71d7734",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Response Bytes Mean",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "Disk usage metrics for Kafka data logs, application logs, and root volumes",
+      "id": "58889ad8-d262-4871-9eba-5ef7100a6f73",
+      "panelTypes": "row",
+      "title": "Storage"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Percentage of disk space used by Kafka data logs per broker",
+      "fillMode": "solid",
+      "fillSpans": false,
+      "id": "3f494f72-323e-4f8d-8649-6d4ca29180a1",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_kafkadatalogsdiskused",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "0aecedbf-1b36-4883-af61-810df8f51038",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "cbdd1cdb-04b7-44b4-9d1a-ea3380cad40b",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "734c3c9b-7993-4620-9834-71ac3c8e0770",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [
+        {
+          "color": "#52c41a",
+          "index": 0,
+          "isDefult": false,
+          "value": 0
+        },
+        {
+          "color": "#faad14",
+          "index": 1,
+          "isDefult": false,
+          "value": 70
+        },
+        {
+          "color": "#ff4d4f",
+          "index": 2,
+          "isDefult": false,
+          "value": 85
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Kafka Data Logs Disk Used",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Percentage of disk space used by Kafka application logs per broker",
+      "fillMode": "solid",
+      "fillSpans": false,
+      "id": "52c975b1-9c1a-4a24-bfb2-7114798154eb",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_kafkaappslogsdiskused",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "332595b7-ffa9-4398-a195-7f9ec219703f",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "36637727-541e-48e8-aa21-f812bead20ea",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "09f2932b-424f-4c1a-8104-14196182a48b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Kafka App Logs Disk Used",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Root volume disk usage percentage per broker",
+      "fillMode": "solid",
+      "fillSpans": false,
+      "id": "5b688ca0-18ea-4f20-a789-5657814b7f9b",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_rootdiskused",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "85d7573c-66d1-45bc-9d99-c4033842abcf",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "424b907c-04e0-4d5d-9aaa-f259951b98b1",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0161b66a-2c7c-4ac5-88a9-4dd634f1aadd",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [
+        {
+          "color": "#52c41a",
+          "index": 0,
+          "isDefult": false,
+          "value": 0
+        },
+        {
+          "color": "#faad14",
+          "index": 1,
+          "isDefult": false,
+          "value": 70
+        },
+        {
+          "color": "#ff4d4f",
+          "index": 2,
+          "isDefult": false,
+          "value": 85
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Root Disk Used",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Peak Kafka data disk usage across all brokers",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "92016c38-fa84-42e9-8056-830bee64b157",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_kafkadatalogsdiskused",
+                  "reduceTo": "max",
+                  "spaceAggregation": "max",
+                  "temporality": "",
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "055464f3-c306-4eed-b06f-f3313a287f1e",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "25b1492d-e963-4293-8fd5-93471dfdb7eb",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Kafka Data Logs Disk Used (Value)",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Peak root disk usage across all brokers",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "be078ad8-7cc7-4213-b93b-ffa0e8a15a9c",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_rootdiskused",
+                  "reduceTo": "max",
+                  "spaceAggregation": "max",
+                  "temporality": "",
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "35dcc0ae-752d-4896-8513-e50dfc2e07be",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "02506dff-d8a2-444d-adb2-8bc813b9f4dc",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Root Disk Used (Value)",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Number of partitions per broker. High partition count increases memory and disk overhead.",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "9f69b97e-489e-4f4a-b27a-d993ebc2c38b",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_partitioncount",
+                  "reduceTo": "latest",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "adad9712-4884-4ea7-9338-ca2e1f1ff18f",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "b895fb11-b9b1-4b6e-abce-85d589bcf460",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "334365b0-345f-453d-aa10-33e57ae36a00",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Partition Count by Broker (Storage)",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Number of log segments per broker. High counts may indicate retention policy issues.",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "40a11ae3-42bc-427c-a25c-887c091b0fad",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_logsegmentcount",
+                  "reduceTo": "latest",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "21f5f0b2-0f06-4f98-b743-019884fd817c",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "1437ecc5-3482-461a-90f7-1846e2d1c5cc",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "18afcdc2-50d6-4473-a7c7-2c508992bb08",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Log Segment Count by Broker",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Estimated maximum time lag. High values indicate consumers falling behind which can lead to disk pressure.",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "2d9361c6-24c9-4ca3-82ab-717f0bf23ea5",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_estimatedmaxtimellag",
+                  "reduceTo": "max",
+                  "spaceAggregation": "max",
+                  "temporality": "",
+                  "timeAggregation": "max"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "7515f324-2bc5-4b2d-ab02-a82e001d5e9d",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "32c651b1-b0b3-4318-838c-f3955bf779b2",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ConsumerGroup",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.consumer_group}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "ConsumerGroup",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{ConsumerGroup}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b565096e-a797-4930-a427-2441e8f795d7",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Estimated Max Time Lag (Storage View)",
+      "yAxisUnit": "s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Average time produce requests are throttled. Non-zero indicates quota enforcement or disk pressure.",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "8bc041bb-ff14-473a-be4a-ec4f83d1820f",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_producethrottletime",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "ff7d34bd-80a5-4967-bb01-ec94392235de",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "733f09cf-c525-43ee-8e4c-06a0557a9966",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "26d30ba7-392c-4ae4-b120-2b5c847a1cbf",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Produce Throttle Time",
+      "yAxisUnit": "ms"
+    },
+    {
+      "description": "Consumer group lag and health metrics for monitoring consumer performance",
+      "id": "964f2820-e0d5-468d-bff3-27e845f6e185",
+      "panelTypes": "row",
+      "title": "Consumer Group"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Maximum offset lag across all partitions for each consumer group. High lag indicates slow consumers.",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "ec1f7313-0cbb-4b0b-a06c-2f9aa02e2459",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_maxoffsetlag",
+                  "reduceTo": "max",
+                  "spaceAggregation": "max",
+                  "temporality": "",
+                  "timeAggregation": "max"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "7ecace56-9293-46d9-ac21-13fe5f453f7b",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "e1af9671-a4f0-48c7-ba7a-ea3784b19a51",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ConsumerGroup",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.consumer_group}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "ConsumerGroup",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{ConsumerGroup}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "97be346e-4306-4383-8ded-e204ea84ed94",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Max Offset Lag",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Total offset lag across all partitions for each consumer group",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "96afc832-4262-4028-892f-f21996ec74f2",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_sumoffsetlag",
+                  "reduceTo": "latest",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "b100aadc-5d13-4e5a-a304-75f1167cb974",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "386d75f9-e52f-434b-9b95-a57787232374",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ConsumerGroup",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.consumer_group}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "ConsumerGroup",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{ConsumerGroup}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ef8b93c1-cb8f-4daf-98e1-634abb043dd3",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Sum Offset Lag",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Estimated maximum time lag in seconds. How far behind the consumer group is from the latest message.",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "d2eff157-9ff4-4afc-9c17-42e6b674faf6",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_estimatedmaxtimellag",
+                  "reduceTo": "max",
+                  "spaceAggregation": "max",
+                  "temporality": "",
+                  "timeAggregation": "max"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "43515567-8214-426d-b732-16a6149ee9c7",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "f55544ca-c467-44fc-af48-bdf04d7993e1",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ConsumerGroup",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.consumer_group}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "ConsumerGroup",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{ConsumerGroup}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "2a1bf701-58c2-4551-89d3-e318fda1a0d8",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Estimated Max Time Lag",
+      "yAxisUnit": "s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Peak max offset lag across all consumer groups",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "d815a127-a36a-4a15-a5af-0a79f72b47bd",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_maxoffsetlag",
+                  "reduceTo": "max",
+                  "spaceAggregation": "max",
+                  "temporality": "",
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "7e8be6e3-cb27-4e34-a258-9107fe100933",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ff7b32c9-0a7f-4478-9970-d323efde095f",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [
+        {
+          "color": "#52c41a",
+          "index": 0,
+          "isDefult": false,
+          "value": 0
+        },
+        {
+          "color": "#faad14",
+          "index": 1,
+          "isDefult": false,
+          "value": 1000
+        },
+        {
+          "color": "#ff4d4f",
+          "index": 2,
+          "isDefult": false,
+          "value": 10000
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Max Offset Lag (Value)",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Peak estimated time lag across all consumer groups",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "7b9d6e7c-92d6-4881-81d3-3002d1693d69",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_estimatedmaxtimellag",
+                  "reduceTo": "max",
+                  "spaceAggregation": "max",
+                  "temporality": "",
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "acef7b1d-c032-49d4-a6bc-6a357b831eb6",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9a476efd-f577-4566-8968-dcb1cdc2a297",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Estimated Max Time Lag (Value)",
+      "yAxisUnit": "s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Total offset lag across all consumer groups and partitions",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "e1678935-7910-4bfa-8d87-8a9d246942ca",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_sumoffsetlag",
+                  "reduceTo": "sum",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "e8c37223-c29d-49da-8aa0-9c831d1417e5",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c2dba37c-729a-440f-bc5c-fff53fc78859",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Sum Offset Lag (Value)",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Offset lag broken down by consumer group and topic for detailed analysis",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "46774466-3de6-48ab-a2a7-eeeea50648f2",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_maxoffsetlag",
+                  "reduceTo": "max",
+                  "spaceAggregation": "max",
+                  "temporality": "",
+                  "timeAggregation": "max"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "bbdc8f2a-69cd-4d94-806f-834e17f4143d",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "620f3ffe-0755-400f-80c1-3e23d55550a0",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ConsumerGroup",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.consumer_group}}"
+                  },
+                  {
+                    "id": "a4ab9d72-01c3-48ae-b4e0-0e82f70bcb18",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "Topic",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.topic}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "ConsumerGroup",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "Topic",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{ConsumerGroup}} - {{Topic}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "46ca78b9-f5c8-4b7d-bc3e-7b43a3ee4955",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Offset Lag by Topic-Partition",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Number of partitions being consumed by each consumer group",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "3f56bdfd-6fb1-43b6-8b5f-180e589ca5b6",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_sumoffsetlag",
+                  "reduceTo": "sum",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "count"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "ec1ba210-c6ac-465d-96b3-a8c1e2063853",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "1692f5d0-eeb5-4a38-86b4-9e16eb31d9e0",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ConsumerGroup",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.consumer_group}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "ConsumerGroup",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{ConsumerGroup}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "2de99b89-603a-4688-95d9-2feb5b829b2a",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Consumer Group Partition Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Average fetch throttle time. Non-zero values indicate consumer quota enforcement.",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "62a8380c-2989-4891-b9e0-0ef807959760",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_fetchthrottletime",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "7f710b22-d289-4f9c-add9-0883784a229f",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "f4825e08-5ced-4d7a-b6eb-d27427f006f6",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0ee70f2f-69dc-47c3-b82b-33344e800332",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Fetch Throttle Time",
+      "yAxisUnit": "ms"
+    },
+    {
+      "description": "Broker-level compute resource utilization including CPU, memory, swap, and network I/O",
+      "id": "eae76018-3ff7-444f-b3b4-58a91d2ba866",
+      "panelTypes": "row",
+      "title": "CPU & Memory"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Percentage of CPU time spent in user space per broker",
+      "fillMode": "solid",
+      "fillSpans": false,
+      "id": "a8266c5b-a230-4703-a828-983c7810c60d",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_cpuuser",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "aa626efe-ad01-470f-b78c-d289c2d62763",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "bc9adc20-39ab-4f29-aa36-f6612a8e579b",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "cf44073f-bc7d-4fe7-9e2b-514659699a5a",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "CPU User %",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Percentage of CPU time spent in kernel/system space per broker",
+      "fillMode": "solid",
+      "fillSpans": false,
+      "id": "8c514a65-68b6-4a56-b718-27b97522d628",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_cpusystem",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "8251face-87c2-4109-9a5a-0f76af6bb9c3",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "208a1ae6-b57f-4a07-9bb2-e2bbce4ca94d",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ebc2b1d8-6a9e-421d-8d85-f3a87ea3f9a7",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "CPU System %",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Percentage of CPU time spent idle per broker. Low idle indicates high utilization.",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "a1155cb4-ab4b-4729-b3e1-e88b67de502e",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_cpuidle",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "77c90430-81aa-40fd-bf6d-d25f9928a7eb",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "5fc60b0a-f993-4762-9488-9dbd196d93f1",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "e8a2c992-7f2d-4491-9e02-2c6277a894a1",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "CPU Idle %",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "CPU utilization breakdown averaged across all brokers in the cluster",
+      "fillMode": "solid",
+      "fillSpans": false,
+      "id": "6738fe18-bbe5-4426-b617-e36f659bd5d0",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_cpuuser",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "b53dafc2-d743-46ae-98f8-dd17cf7d730b",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "ClusterName",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "User",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_cpusystem",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "920a4111-68cc-4b63-be1b-20246cb6a41a",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "ClusterName",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "System",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "source": "",
+              "stepInterval": null
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_cpuidle",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "C",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "b0f0a73d-f8fd-4556-a5a5-ee12e9f79276",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "ClusterName",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Idle",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "C",
+              "source": "",
+              "stepInterval": null
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_cpuiowait",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "D",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "2154bd2b-03ae-4ace-9deb-8188131f2e10",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "ClusterName",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "IOWait",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "D",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "339bffd7-562b-4900-9e1f-3bdb1ab39a0e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "CPU Breakdown (Cluster Average)",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "CPU IOWait percentage. High values indicate disk I/O bottleneck.",
+      "fillMode": "solid",
+      "fillSpans": false,
+      "id": "73203aa7-62da-4e40-bd21-2f312610388e",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_cpuiowait",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "a9f29747-91e5-4d5d-bf56-7a87ff2b0c1a",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "09f1bb22-be9c-4cc9-bfbf-f388a8c5744b",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "098447ea-1bde-4f4d-8ab8-d222ac94075c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "CPU IOWait %",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Memory used per broker in bytes",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "672e36f7-31ca-49f9-9069-357d82d5515e",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_memoryused",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "111a941f-6609-4d0f-bd52-692f18c85e86",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "d8a24230-233e-4a3b-b6fa-182230b00d1a",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6b1d2830-e623-4886-aa45-36cc789fc0e7",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memory Used",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Free memory per broker in bytes",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "6a37957a-5788-4d7b-a0fe-b30146e67640",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_memoryfree",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "05002e20-0234-4310-9621-203d93db70d6",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "a5db0db6-99f7-4db2-ab05-0490faec6adb",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "718705b7-d70a-4e61-89db-8b6e0f0ab11d",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memory Free",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Buffered and cached memory by broker. Kafka relies heavily on page cache for performance.",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "b4d9b8ed-ad88-4484-aa0a-e1929efd48ee",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_memorybuffered",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "ffbf10f5-d071-4c3a-83d3-fd55503a3c0d",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "90741ba5-84a2-4a28-96e3-493a2540ee51",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Buffered - Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_memorycached",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "65c5f3df-5555-449a-b906-e2b66bc2b0fd",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "4d47c3f3-98bb-443a-afe9-74d20ce5da70",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Cached - Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "faaecc3b-a52c-4cfb-88b1-35d8073e2d08",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memory Buffered & Cached",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Swap space usage per broker. Any swap usage can severely degrade Kafka performance.",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "282d090e-2648-4782-a1d5-a9ce4ee9ee30",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_swapused",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "987283ff-0c97-4d5f-a6e8-aaf7e5eba83b",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "948c0a9a-dfc8-46ab-8520-6c2967a5660b",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ebe58a0e-f36e-4bec-88e6-f0bc4a199563",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [
+        {
+          "color": "#52c41a",
+          "index": 0,
+          "isDefult": false,
+          "value": 0
+        },
+        {
+          "color": "#ff4d4f",
+          "index": 1,
+          "isDefult": false,
+          "value": 1
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Swap Used",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Available swap space per broker",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "86c8b361-c501-4efd-be5d-53c5e0611ef7",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_swapfree",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "94b0e0f1-5d7c-4c32-8454-bb85e5237912",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "171abb73-d56a-4f99-8c83-72935b049903",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "5eefe138-9eba-41b0-8cf0-283fae2f60b2",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Swap Free",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Network receive packet rate per broker",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "e56797ac-6047-4149-9a8d-252d8cd76df8",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_networkrxpackets",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "005c6ddb-bc5f-454f-a61b-c5697471534b",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "a121c626-865b-4a26-bfc9-7b5b91bccf95",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b3e798fb-c517-415a-bcb1-a3a1ccd03a77",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Network RX Packets/sec",
+      "yAxisUnit": "pps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Network transmit packet rate per broker",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "697f9d73-b764-402a-b3e8-a18a4ac01e54",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_networktxpackets",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "ba9e9270-a4b7-48cf-9ac4-860729ae00ee",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "fc1e083d-e185-4d70-91ff-0d27ada67d66",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "e5d1ba57-0b99-42ff-92e1-13a4bf21ffa8",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Network TX Packets/sec",
+      "yAxisUnit": "pps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Network receive dropped packets per broker. Non-zero indicates network issues.",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "debe56d5-371c-496a-9dd0-816fe408e174",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_networkrxdropped",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "73aa2e52-3da9-4830-85b0-8217eaf78cdd",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "563a1cd3-192e-4c8d-ac49-d317db7a353e",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9ca698b1-40b4-41f4-a229-0119b7aba104",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Network RX Dropped",
+      "yAxisUnit": "cps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Network transmit dropped packets per broker. Non-zero indicates network issues.",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "69d51446-bd31-4153-a1e7-ccb0f8d0774e",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_networktxdropped",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "6b9f1ada-54ec-4375-9d19-37146a09309f",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "75611c77-9171-4467-b144-3a3223a31336",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "23501f48-c091-4f8e-8b37-af8df4113739",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Network TX Dropped",
+      "yAxisUnit": "cps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Network receive error rate per broker",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "6f03d9fd-97b8-43df-af14-37c74d3cbcbe",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_networkrxerrors",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "f5876384-cd75-44e4-99bf-c4323cbb6b76",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "af2b65f2-6467-463e-ac97-523e98cb6371",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "44eec259-c670-4b33-8c08-5a2f55d19730",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Network RX Errors",
+      "yAxisUnit": "cps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Network transmit error rate per broker",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "5c7dcdb8-3b45-4047-a620-b0cb5ccece2d",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_networktxerrors",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "311ad645-0ca2-46ba-a2a5-bf7c5cd6212b",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "0deeb2c2-4d4f-4ecc-bd82-2fdd65fc3e61",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c7d318b9-0878-4297-b03a-8aa433d4ed1a",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Network TX Errors",
+      "yAxisUnit": "cps"
+    },
+    {
+      "description": "Kafka replication health metrics including ISR dynamics, leader distribution, and partition reassignment status",
+      "id": "8f474378-7bb0-4b59-adf7-3429564686e7",
+      "panelTypes": "row",
+      "title": "Replication"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Rate of ISR shrink events per broker. Frequent shrinks indicate brokers failing to keep up with replication.",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "fe5d5aa8-f090-431c-ae89-444e60307be7",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_isrshrinkspersec",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "bb9dca6a-8e91-41fb-b898-e3184d3db9d8",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "a9940777-5a29-47ef-99fb-bbb4e94f35b4",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "527fa11e-2a10-4574-9a0f-33ae1bb49ce0",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "ISR Shrink Rate",
+      "yAxisUnit": "cps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Rate of ISR expand events per broker. Should follow ISR shrinks as replicas catch up.",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "c4222a2a-d055-437d-9135-9a92cb6a462c",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_isrexpandspersec",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "035d062f-76e6-4932-b86b-340fe2f582a5",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "74b9541c-0bd5-4505-8b4b-657232195cd6",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "5f669006-0f36-47b3-91f2-98ea7d483895",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "ISR Expand Rate",
+      "yAxisUnit": "cps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Partitions below min.insync.replicas. Critical: producers with acks=all will fail for these partitions.",
+      "fillMode": "solid",
+      "fillSpans": false,
+      "id": "775930af-caeb-425e-ae2d-5b06e5f8c82b",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_underminisrpartitioncount",
+                  "reduceTo": "latest",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "793c7b11-d865-470a-99ca-cf48845ceca4",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "a308fbcb-56a0-453f-aa11-3b24824c2b65",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "bef8e761-285f-4c0f-a321-2305680846bd",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [
+        {
+          "color": "#52c41a",
+          "index": 0,
+          "isDefult": false,
+          "value": 0
+        },
+        {
+          "color": "#ff4d4f",
+          "index": 1,
+          "isDefult": false,
+          "value": 1
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Under Min ISR Partition Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Partitions at exactly min.insync.replicas. One more replica loss would put them under min ISR.",
+      "fillMode": "solid",
+      "fillSpans": false,
+      "id": "888152a9-32f8-4e3b-921e-49aad2669751",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_atminisrpartitioncount",
+                  "reduceTo": "latest",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "89aea61e-3666-4159-b34d-13153c1509e8",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "43f26903-b59c-4b48-9c81-bb98d3473a31",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a7770939-c88b-492e-9fbe-d26f39438b32",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "At Min ISR Partition Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Leader count per broker. Uneven distribution indicates preferred leader election should be triggered.",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "b6f42733-ca04-459f-aa2d-c51b24dfe244",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_leadercount",
+                  "reduceTo": "latest",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "73ed8f46-a4bc-4a8d-9bd7-659bcf8e5a27",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "8f0dc7c2-4231-4b0d-ac92-3bad8c9db6a7",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "94744058-a840-4f88-af9e-ae73688f2bab",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Leader Count Distribution",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Percentage of partitions where the preferred replica is not the leader. High values indicate sub-optimal leader distribution.",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "fb8f1c24-a9c0-4600-9ed8-142e389db2b4",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_preferredreplicaimbalance",
+                  "reduceTo": "max",
+                  "spaceAggregation": "max",
+                  "temporality": "",
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "9b784802-d30b-4bef-a697-bec98073576a",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "737812bf-b8d1-4f60-92f1-a04cbdce8e97",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "e78d4ea3-7743-4a6b-a680-94447f14a1fb",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Preferred Replica Imbalance",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Whether partition reassignment is currently in progress. 1 = yes, 0 = no.",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "937ec46b-de8a-49cd-b214-4f9a54a15ac4",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_reassignmentinprogress",
+                  "reduceTo": "max",
+                  "spaceAggregation": "max",
+                  "temporality": "",
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "36a18053-3425-41f3-8a74-5256008303b1",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "ClusterName",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{ClusterName}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "bd7ac14b-c2ac-4229-8101-2e85c8e10153",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Partition Reassignment In Progress",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Under-replicated partitions by broker. Persistent non-zero values indicate replication issues.",
+      "fillMode": "solid",
+      "fillSpans": false,
+      "id": "0e4615a6-8aa6-4282-9ef1-f49a58a594d2",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_underreplicatedpartitions",
+                  "reduceTo": "latest",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "2d4052f9-6731-45b9-93eb-5d039f8378f0",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "604a003e-883e-479d-94fa-b37399817fe8",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "47ee2280-165c-48f7-a3e4-7dad02be53f1",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [
+        {
+          "color": "#52c41a",
+          "index": 0,
+          "isDefult": false,
+          "value": 0
+        },
+        {
+          "color": "#ff4d4f",
+          "index": 1,
+          "isDefult": false,
+          "value": 1
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Under-Replicated Partitions (Replication View)",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Replication traffic in vs out by broker. Asymmetric traffic may indicate unbalanced partition assignment.",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "d00354c6-6431-4787-9a78-ad60c352dfaa",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_replicationbytesinpersec",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "8d508013-2655-4c1b-8f11-1887e49925c6",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "76b009af-c42b-4881-8198-988b760ef38f",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "In - Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_replicationbytesoutpersec",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "bc5907b0-e39d-4a55-9e58-827a47d09734",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "53196454-9c57-4a0d-9004-0ba55e156845",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Out - Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "1ae38957-e99b-4d1e-9f9c-ca94df973776",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Replication Bytes In vs Out (by Broker)",
+      "yAxisUnit": "binBps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Rate of failed replication requests per broker. Non-zero indicates replication pipeline issues.",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "e62e8347-720f-4267-9d44-ae97109d01c7",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_failedreplicationpersec",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "8160a282-21fb-4fc8-a085-4c4a53995390",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "3317d0a8-0a6b-4426-8f2f-7fc9a30bf6fe",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "66ce8dd8-1cd6-4374-a19c-179f104ddeca",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Failed Replication Rate",
+      "yAxisUnit": "cps"
+    },
+    {
+      "description": "Client connection metrics including connection counts, creation/close rates, and authentication errors",
+      "id": "b032d75a-aa5b-4f5d-8767-b5290c76ef98",
+      "panelTypes": "row",
+      "title": "Connections"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Number of active connections per broker",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "1b1a1e1a-3d32-48c7-92c1-85e1be3205c6",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_connectioncount",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "dfac3e21-c729-421b-afd3-0b8219281821",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "ac5064b7-72e0-451b-af72-5e3df2e8df9e",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "00e4c989-1597-4127-a91e-27a8eea17940",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Connection Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Total active connections across all brokers",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "409b3724-1dc7-452e-aab3-75e93246174a",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_connectioncount",
+                  "reduceTo": "sum",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "15ab3a4b-46a5-4fae-9d5d-2a9eb2894d4d",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "24589086-843c-4b9f-b830-5df7325f8be5",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Connection Count (Value)",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Rate of new client connections per broker. Spikes may indicate connection churn issues.",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "eeb6d7c8-36d1-4863-afb4-b20281dd40bb",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_connectioncreationrate",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "e119cff3-e430-45ac-8773-2fdb025dae3d",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "fd01e56c-f19b-42c7-aaff-be931482d9e9",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "95156ff5-734f-43d3-b131-60846e8312d7",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Connection Creation Rate",
+      "yAxisUnit": "cps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Rate of client connection closures per broker",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "4d676368-5318-4ac5-9b02-cae260eaa811",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_connectioncloserate",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "428940df-7126-416e-84f1-8e2b7ef63a48",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "e96e4af6-5a88-4d41-ae39-c92cbb1a22a2",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ad0aba50-459e-4c70-b405-6f62557e66ef",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Connection Close Rate",
+      "yAxisUnit": "cps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Cluster-wide connection creation vs close rate. Sustained imbalance indicates connection leak or churn.",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "def56b05-1dc9-4bfe-a147-e831a03fb76f",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_connectioncreationrate",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "3c4f6b49-506b-4a63-9282-10210ccb4da6",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "ClusterName",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Creation Rate",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_connectioncloserate",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "3a5ab4c6-44f9-47bc-9596-8f82c00017f0",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "ClusterName",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Close Rate",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "fa1cc5e5-eae5-4968-9e72-3c7e8f44b76e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Connection Creation vs Close Rate",
+      "yAxisUnit": "cps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "SASL/IAM authentication failure rate per broker. Non-zero indicates misconfigured client credentials.",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "1db36cd1-8bdd-499f-bd6c-038e1f48c2a5",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_clientauthenticationfailure",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "0d8913c8-2392-413a-b46b-34a2592f2b0c",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "bf5f9fe4-7ed6-416c-90fd-3d926e60eb34",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a903bd76-59dc-4e5d-8a8a-22c8abfcab57",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Client Auth Errors (SASL)",
+      "yAxisUnit": "cps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Successful client authentication rate per broker",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "6532c061-0ac5-4aab-b865-bb37bf3b75f5",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_clientauthenticationsuccess",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "9126ff62-3041-4946-9233-1367fac5e9a3",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "13437761-2632-4d7c-828f-c626f7ed80f2",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b64af606-8909-423d-9f6e-dbe4f8c995ec",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Client Auth Success Rate",
+      "yAxisUnit": "cps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Total authentication failures across the cluster",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "fa6cc78d-ac45-4788-beac-1bf9c98b6ae0",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_clientauthenticationfailure",
+                  "reduceTo": "sum",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "a2d2529d-d031-49b5-ba1a-4a70f6beb3ba",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "3fe66d25-7865-4a25-93ca-264ad2a007fd",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [
+        {
+          "color": "#52c41a",
+          "index": 0,
+          "isDefult": false,
+          "value": 0
+        },
+        {
+          "color": "#ff4d4f",
+          "index": 1,
+          "isDefult": false,
+          "value": 1
+        }
+      ],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Auth Error Rate (Value)",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "TLS handshake failure rate per broker",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "1ac92fb7-36e3-4a27-840a-41c8e062cfc6",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_clientauthenticationtlsfailure",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "1b283741-cd30-4910-b20c-361122cb110d",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "05967793-97d3-4c66-8f85-fac503134491",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "59d664d1-3142-4530-926c-b9cd8ff982cd",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "TLS Handshake Errors",
+      "yAxisUnit": "cps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Tabular view of connection count per broker for quick comparison",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "89792ad6-2676-4c30-a181-4d054c38aa18",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "table",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_connectioncount",
+                  "reduceTo": "latest",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "a9688df9-88b4-4030-bac8-8fe5775e8a8d",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "deee2bd0-f450-45a7-859e-6daa4732f84d",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "ClusterName",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "479e9e0d-0fcc-463e-ade2-1aeec8e7d90d",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Connection Count by Broker (Table)",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Rate at which produce requests are throttled per broker due to quota enforcement",
+      "fillMode": "none",
+      "fillSpans": false,
+      "id": "f6d2fa4e-83b9-4841-9090-e6b53ce5b138",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "lineInterpolation": "spline",
+      "lineStyle": "solid",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "aws_kafka_producethrottlebyterate",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {
+                "expression": ""
+              },
+              "filters": {
+                "items": [
+                  {
+                    "id": "4c96cf72-4cd3-4b1d-9662-c3597ee53a19",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "ClusterName",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.cluster_name}}"
+                  },
+                  {
+                    "id": "f7d68b46-debe-4c8d-bed9-c5b9f6a91838",
+                    "key": {
+                      "dataType": "string",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "BrokerId",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.broker_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "BrokerId",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "Broker {{BrokerId}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "3aa0642e-96df-4b63-aefc-6cfb193d889a",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "timestamp",
+          "signal": "logs",
+          "type": "log"
+        },
+        {
+          "dataType": "",
+          "fieldContext": "log",
+          "fieldDataType": "",
+          "isIndexed": false,
+          "name": "body",
+          "signal": "logs",
+          "type": "log"
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "fieldContext": "resource",
+          "fieldDataType": "string",
+          "name": "service.name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "string",
+          "name": "name",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "duration_nano",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "http_method",
+          "signal": "traces"
+        },
+        {
+          "fieldContext": "span",
+          "fieldDataType": "",
+          "name": "response_status_code",
+          "signal": "traces"
+        }
+      ],
+      "showPointsOnLines": false,
+      "softMax": null,
+      "softMin": null,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Produce Throttle Byte Rate",
+      "yAxisUnit": "binBps"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Comprehensive AWS MSK (Managed Streaming for Apache Kafka) monitoring dashboard built on Prometheus JMX Exporter and CloudWatch metrics.

**103 panels** across **8 sections**:

1. **Cluster Overview** (12 panels) — active controller count, offline/under-replicated partitions, broker count, global topic/partition count, ZooKeeper latency
2. **Throughput** (14 panels) — messages/bytes in/out per second, replication bytes, produce/fetch message conversions
3. **Request Performance** (12 panels) — produce/fetch local and total time, request handler idle %, network processor idle %
4. **Storage** (10 panels) — Kafka data/app logs disk used, root disk used, partition count, log segments
5. **Consumer Group** (10 panels) — max offset lag, estimated time lag, sum offset lag, partition count per group
6. **CPU & Memory** (14 panels) — CPU user/system/idle, memory free/used, swap, network Rx/Tx
7. **Replication** (12 panels) — ISR shrink/expand rate, leader count, under-min-ISR, reassignment status
8. **Connections** (10 panels) — connection count, creation/close rate, auth errors

### Dashboard Variables
- `cluster_name` — MSK cluster name
- `broker_id` — filter by broker
- `topic` — filter by topic
- `consumer_group` — filter by consumer group

### Data Source
MSK Open Monitoring (JMX Exporter port 11001) → OpenTelemetry Collector → SigNoz

Closes SigNoz/signoz#6036

🤖 Generated with [Claude Code](https://claude.com/claude-code)