### PR TITLE
feat: OpenTelemetry Collector monitoring dashboard (Prometheus v1)

### DIFF
--- a/otel-collector/README.md
+++ b/otel-collector/README.md
@@ -1,0 +1,38 @@
+# OpenTelemetry Collector Monitoring Dashboard
+
+Comprehensive monitoring dashboard for the OpenTelemetry Collector's internal telemetry metrics.
+
+## Overview
+
+This dashboard provides full visibility into OTel Collector health and performance, covering all three signal types (traces, metrics, logs) across the complete pipeline.
+
+## Sections
+
+| Section | Panels | Description |
+|---------|--------|-------------|
+| **Overview** | 8 | Uptime, memory RSS, heap allocation, CPU usage |
+| **Receivers** | 18 | Accepted/refused data points per receiver and transport |
+| **Processors** | 22 | Accepted/refused/dropped data, batch send size histograms |
+| **Exporters** | 21 | Sent/failed data, queue size and utilization |
+| **Runtime** | 8 | Heap, RSS, total alloc rate, CPU over time |
+| **HTTP Server** | 12 | Request duration percentiles, content length, status codes |
+
+**Total: 98 panels**
+
+## Metrics Covered
+
+- **Receiver metrics**: `otelcol_receiver_accepted_*`, `otelcol_receiver_refused_*`
+- **Processor metrics**: `otelcol_processor_accepted_*`, `otelcol_processor_refused_*`, `otelcol_processor_dropped_*`, `otelcol_processor_batch_*`
+- **Exporter metrics**: `otelcol_exporter_sent_*`, `otelcol_exporter_failed_*`, `otelcol_exporter_queue_*`, `otelcol_exporter_enqueue_failed_*`
+- **Process metrics**: `otelcol_process_uptime`, `otelcol_process_runtime_*`, `otelcol_process_cpu_seconds`, `otelcol_process_memory_rss`
+- **HTTP metrics**: `http_server_request_content_length`, `http_server_response_content_length`, `http_server_duration`
+
+## Variables
+
+- **collector_name**: Filter by `service.instance.id` to monitor specific collector instances
+
+## Prerequisites
+
+The OTel Collector must have internal telemetry enabled. This is the default configuration. Metrics are exposed via the Collector's own telemetry pipeline.
+
+See: [OTel Collector Internal Telemetry](https://opentelemetry.io/docs/collector/internal-telemetry/)

--- a/otel-collector/otel-collector.json
+++ b/otel-collector/otel-collector.json
@@ -1,0 +1,16071 @@
+{
+  "description": "Comprehensive monitoring dashboard for the OpenTelemetry Collector. Tracks receivers, processors, exporters, runtime metrics, and HTTP server performance using OTel Collector internal telemetry metrics.",
+  "dotMigrated": true,
+  "image": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNOS4wMDAxMiAxMi43NUM3LjkzNDI2IDEyLjc1IDYuOTc3NCAxMi4zMjgxIDYuMjI0NjEgMTEuNTc1M0M1LjQ3MTgzIDEwLjgyMjUgNS4wNSA5Ljg2NTcxIDUuMDUgOC44QzUuMDUgNy43MzQyOSA1LjQ3MTgzIDYuNzc3NDYgNi4yMjQ2MSA2LjAyNDY3QzYuOTc3NCA1LjI3MTg5IDcuOTM0MjYgNC44NSA5LjAwMDEyIDQuODVDMTAuMDY2IDQuODUgMTEuMDIyOCA1LjI3MTg5IDExLjc3NTYgNi4wMjQ2N0MxMi41Mjg0IDYuNzc3NDYgMTIuOTUgNy43MzQyOSAxMi45NSA4LjhDMTIuOTUgOS44NjU3MSAxMi41Mjg0IDEwLjgyMjUgMTEuNzc1NiAxMS41NzUzQzExLjAyMjggMTIuMzI4MSAxMC4wNjYgMTIuNzUgOS4wMDAxMiAxMi43NVpNMTQuODUgOS45VjcuN0wxMy4wNSA3LjQ1TDE0LjMgNS43TDE0LjE1IDUuNTVMMTIuNiA0LjFMMTIuNDUgMy45NUwxMC43IDUuMkwxMC40NSAzLjRIOC4yNUw4IDUuMkw2LjI1IDMuOTVMNi4xIDQuMUw0LjU1IDUuNTVMNC40IDUuN0w1LjY1IDcuNDVMMy44NSA3LjdWOS45TDUuNjUgMTAuMTVMNC40IDExLjlMNC41NSAxMi4wNUw2LjEgMTMuNUw2LjI1IDEzLjY1TDggMTIuNEw4LjI1IDE0LjJIMTAuNDVMMTAuNyAxMi40TDEyLjQ1IDEzLjY1TDEyLjYgMTMuNUwxNC4xNSAxMi4wNUwxNC4zIDExLjlMMTMuMDUgMTAuMTVMMTQuODUgOS45WiIgZmlsbD0iIzQzOTNGOCIvPjwvc3ZnPg==",
+  "layout": [
+    {
+      "h": 1,
+      "i": "498564bc-2fcf-49a7-9c6d-2c63f92b1880",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 3,
+      "i": "3c619a2a-b1ce-4946-8ace-edcb2b52cf28",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 0,
+      "y": 1
+    },
+    {
+      "h": 3,
+      "i": "e2a9750b-2199-4537-92e5-9a88b764cb7f",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 2,
+      "y": 1
+    },
+    {
+      "h": 3,
+      "i": "6d78546f-12a9-4298-841b-7afa6d42a743",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 4,
+      "y": 1
+    },
+    {
+      "h": 3,
+      "i": "79bab064-cf7f-40de-a62a-63b6d3544898",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 6,
+      "y": 1
+    },
+    {
+      "h": 3,
+      "i": "907ca736-205b-4922-9983-d863430200b4",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 8,
+      "y": 1
+    },
+    {
+      "h": 3,
+      "i": "0881687e-dd0c-421c-8216-3dd60d94bb8e",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 10,
+      "y": 1
+    },
+    {
+      "h": 6,
+      "i": "5f1c820a-b76b-49f6-a53e-7b9eff22157e",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 4
+    },
+    {
+      "h": 6,
+      "i": "05b7e736-c24e-47c7-bea8-b1282d9617f6",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 4
+    },
+    {
+      "h": 1,
+      "i": "8d912f2e-ca6f-4578-b565-663c1548f4e8",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 10
+    },
+    {
+      "h": 3,
+      "i": "70261ba2-dbe5-4dea-baf0-c30084d9340e",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 0,
+      "y": 11
+    },
+    {
+      "h": 3,
+      "i": "49a7dec5-a0cd-4d10-8074-b358a74a0a87",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 2,
+      "y": 11
+    },
+    {
+      "h": 3,
+      "i": "26aa7ba3-bb7e-4d91-b430-f53bff778fd2",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 4,
+      "y": 11
+    },
+    {
+      "h": 3,
+      "i": "9656a76d-e99c-4f3e-b5eb-c80174d3ed1d",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 6,
+      "y": 11
+    },
+    {
+      "h": 3,
+      "i": "ec4bcaa2-00ce-4e95-a237-d8662ba7ee20",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 8,
+      "y": 11
+    },
+    {
+      "h": 3,
+      "i": "c150718d-621d-4329-9e74-19e34eadbce4",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 10,
+      "y": 11
+    },
+    {
+      "h": 6,
+      "i": "554eaa04-38f1-4811-8f85-665ec078dadd",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 14
+    },
+    {
+      "h": 6,
+      "i": "7009e5bf-6c81-4fde-b105-22f986e78167",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 14
+    },
+    {
+      "h": 6,
+      "i": "94dd2617-3e0f-4248-9c65-931fa30f2440",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 20
+    },
+    {
+      "h": 6,
+      "i": "c504912c-bdee-4619-994d-3395505f7c06",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 20
+    },
+    {
+      "h": 6,
+      "i": "0e04d772-6002-4536-91d4-cd980ecc401b",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 26
+    },
+    {
+      "h": 6,
+      "i": "367adf4e-de0b-49c0-aede-fb521bb82088",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 26
+    },
+    {
+      "h": 6,
+      "i": "10143247-a2e2-4604-8081-5d49f858ce18",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 32
+    },
+    {
+      "h": 6,
+      "i": "a24a257d-cc82-48fb-a641-4ddeb6f0be8a",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 32
+    },
+    {
+      "h": 6,
+      "i": "47e907d7-f907-42af-b501-095105c10244",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 38
+    },
+    {
+      "h": 6,
+      "i": "697ab4b1-3b62-4fca-9534-ba50427165f7",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 38
+    },
+    {
+      "h": 6,
+      "i": "cea5a98e-08f2-44cb-aa1e-cc1423ebe529",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 44
+    },
+    {
+      "h": 6,
+      "i": "53d05d8d-6b7f-49c4-a31d-ebf5151ab0d2",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 44
+    },
+    {
+      "h": 1,
+      "i": "b9711bee-134e-4b1f-803f-6a16a5a0256c",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 50
+    },
+    {
+      "h": 3,
+      "i": "82c389b9-17e6-45ec-b8b3-bb73277d93f7",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 0,
+      "y": 51
+    },
+    {
+      "h": 3,
+      "i": "14d88852-630f-47cc-9121-a03b5fa458a0",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 2,
+      "y": 51
+    },
+    {
+      "h": 3,
+      "i": "9e38b614-d64c-4a57-8c4c-f4f8f6cc67b9",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 4,
+      "y": 51
+    },
+    {
+      "h": 3,
+      "i": "33df4d02-fc23-4bf1-a754-f71c6027371e",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 6,
+      "y": 51
+    },
+    {
+      "h": 3,
+      "i": "e30d4f85-623f-482c-add9-ef9c9c94d257",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 8,
+      "y": 51
+    },
+    {
+      "h": 3,
+      "i": "9051d1f1-e153-4721-bb99-baf82ea53d7f",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 10,
+      "y": 51
+    },
+    {
+      "h": 3,
+      "i": "34eb6b48-8ab1-4bd2-8b63-c1c7fafb15d6",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 0,
+      "y": 54
+    },
+    {
+      "h": 3,
+      "i": "f3842772-2ac0-4884-9021-38053e257aa5",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 2,
+      "y": 54
+    },
+    {
+      "h": 3,
+      "i": "f11bbe0a-9c39-4381-9082-1dd4fbeb3087",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 4,
+      "y": 54
+    },
+    {
+      "h": 6,
+      "i": "a6c70f99-30ff-46cf-8ce6-6fb9e7d78cc2",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 57
+    },
+    {
+      "h": 6,
+      "i": "e1524382-e96d-4b69-a6a6-2290c9229536",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 57
+    },
+    {
+      "h": 6,
+      "i": "abc0474e-9217-4cb5-8211-1c01fd5365e4",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 63
+    },
+    {
+      "h": 6,
+      "i": "31bf0012-2626-4951-9efb-7654a880c88b",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 63
+    },
+    {
+      "h": 6,
+      "i": "6d1f0df6-0441-4f4c-aef8-c38c7aed1fb9",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 69
+    },
+    {
+      "h": 6,
+      "i": "f3ec3fc6-7042-4563-81b4-785adb9f61ba",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 69
+    },
+    {
+      "h": 6,
+      "i": "aabbb6a4-f2c9-4bac-aa8f-f3b74a450206",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 75
+    },
+    {
+      "h": 6,
+      "i": "003d2496-57f3-48be-8c00-b693ba97e8f5",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 75
+    },
+    {
+      "h": 6,
+      "i": "9cc60501-ffe5-46f4-84d9-75d56ac071b2",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 81
+    },
+    {
+      "h": 6,
+      "i": "136428da-b321-4241-be49-e06077adfead",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 81
+    },
+    {
+      "h": 6,
+      "i": "cede1134-4a36-4c74-93a7-67405197c5be",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 87
+    },
+    {
+      "h": 6,
+      "i": "0ed7df8d-41f4-4fb4-b9be-950e7756acd6",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 87
+    },
+    {
+      "h": 6,
+      "i": "f962ad4d-1a4e-4c10-bd36-f02bf241b3e5",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 93
+    },
+    {
+      "h": 6,
+      "i": "5827e5ca-b7d8-484d-9367-63db53bc6cef",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 93
+    },
+    {
+      "h": 6,
+      "i": "bf584a4a-70c6-4222-a95f-d97f8dd504bf",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 99
+    },
+    {
+      "h": 6,
+      "i": "2d3e78ea-cf41-417c-b4c1-121e73cef0e1",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 99
+    },
+    {
+      "h": 1,
+      "i": "4b1b29bf-26d5-4aa5-8374-dca18cea7141",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 105
+    },
+    {
+      "h": 3,
+      "i": "f2d6ad05-6318-40ba-9023-8990d59fbbfb",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 0,
+      "y": 106
+    },
+    {
+      "h": 3,
+      "i": "39add25f-144a-4be2-b418-2cea7f036fe1",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 2,
+      "y": 106
+    },
+    {
+      "h": 3,
+      "i": "714ee821-3d24-4b5e-85cc-5884199e3863",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 4,
+      "y": 106
+    },
+    {
+      "h": 3,
+      "i": "38b31944-cc22-4cad-9075-53622f7502fa",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 6,
+      "y": 106
+    },
+    {
+      "h": 3,
+      "i": "df76a0ea-b20d-4f4b-b42a-86cd27a02719",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 8,
+      "y": 106
+    },
+    {
+      "h": 3,
+      "i": "e0f80776-cba3-442f-b5dd-37d778d063ab",
+      "moved": false,
+      "static": false,
+      "w": 2,
+      "x": 10,
+      "y": 106
+    },
+    {
+      "h": 6,
+      "i": "47a44787-f2b7-44e8-bb29-c8badc2a3936",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 109
+    },
+    {
+      "h": 6,
+      "i": "f5ae224f-f15f-4d2c-990e-0e3f2100f235",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 109
+    },
+    {
+      "h": 6,
+      "i": "48175605-c518-43ce-8b44-56cf1fe0cddf",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 115
+    },
+    {
+      "h": 6,
+      "i": "eece9161-c732-4f94-9544-44445f14041a",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 115
+    },
+    {
+      "h": 6,
+      "i": "f0ece911-92e7-41f4-98dc-0694af9dd18e",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 121
+    },
+    {
+      "h": 6,
+      "i": "2c2e9622-68b6-4048-96c7-bacf6ceea4d7",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 121
+    },
+    {
+      "h": 6,
+      "i": "3d780f3c-8033-4a57-a2e0-c98e7384c9a1",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 127
+    },
+    {
+      "h": 6,
+      "i": "a21030ca-ed8a-49f8-9a7e-80bd7dddcc2a",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 127
+    },
+    {
+      "h": 6,
+      "i": "bc685b88-943b-4e43-adb1-606a5c79c472",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 133
+    },
+    {
+      "h": 6,
+      "i": "07134208-bdbe-40e5-9a8e-a4921fd6e006",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 133
+    },
+    {
+      "h": 6,
+      "i": "e4afbcc3-4d9d-42a7-95e6-8edc9638b880",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 139
+    },
+    {
+      "h": 6,
+      "i": "fe0217d6-9f1b-48f1-a5c3-cce35aa5dccf",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 139
+    },
+    {
+      "h": 6,
+      "i": "bcb2e21a-83c1-4b6e-b041-7ff93dc2105d",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 145
+    },
+    {
+      "h": 6,
+      "i": "3c038336-86c5-4668-94b8-ebb51c79088f",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 145
+    },
+    {
+      "h": 6,
+      "i": "a8e3e585-d275-4cdb-8681-a61b959ab8f4",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 151
+    },
+    {
+      "h": 1,
+      "i": "96b2bbd1-b352-48da-a705-dab6d3b13979",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 157
+    },
+    {
+      "h": 6,
+      "i": "eaa6b66a-62be-4aa6-8e81-67b764838dd0",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 158
+    },
+    {
+      "h": 6,
+      "i": "178b655a-8ced-4bb0-bb61-2423da3cfcb5",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 158
+    },
+    {
+      "h": 6,
+      "i": "b00f2625-90f8-429d-bd01-c3fec9fba913",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 164
+    },
+    {
+      "h": 6,
+      "i": "807b0690-b156-4fad-ba37-c88c7c02685a",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 164
+    },
+    {
+      "h": 6,
+      "i": "80a64850-dde1-48dd-9d2d-7c6e844f30ba",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 170
+    },
+    {
+      "h": 6,
+      "i": "677432ac-aca6-4e91-bc95-8f7f6aef3aea",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 170
+    },
+    {
+      "h": 6,
+      "i": "7c7d2f72-0443-4fea-8b26-150a73b2d150",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 176
+    },
+    {
+      "h": 6,
+      "i": "8b5af7c3-8aa7-4e22-93d2-fc65e945f931",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 176
+    },
+    {
+      "h": 1,
+      "i": "23a23b70-8ccb-46c5-aa62-755eb6e91bb8",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 182
+    },
+    {
+      "h": 6,
+      "i": "4485f4ef-6e18-4440-b4a6-7eee76004478",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 183
+    },
+    {
+      "h": 6,
+      "i": "90c966ee-e6f0-47aa-9595-b50c30bd5234",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 183
+    },
+    {
+      "h": 6,
+      "i": "c5a64da4-77fd-4e06-8cb5-84f7592f2f78",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 189
+    },
+    {
+      "h": 6,
+      "i": "6e0dea4d-0a95-462e-8a14-8a6c05d56197",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 189
+    },
+    {
+      "h": 6,
+      "i": "8e44cb80-b317-4910-a6b4-9263ddbbb940",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 195
+    },
+    {
+      "h": 6,
+      "i": "b42bd0bf-1339-4ae0-96b6-bca918d0ca1d",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 195
+    },
+    {
+      "h": 6,
+      "i": "1ee4de36-4bfc-4c3a-993d-3999fabfc5cc",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 201
+    },
+    {
+      "h": 6,
+      "i": "fbdad8e2-cb5a-4157-bd17-54c6135e59a4",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 201
+    },
+    {
+      "h": 6,
+      "i": "05c20229-2560-42bb-bd5c-7eb5645c02f6",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 207
+    },
+    {
+      "h": 6,
+      "i": "94ac54ea-a6fe-408c-b51e-f458ada146e2",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 207
+    },
+    {
+      "h": 6,
+      "i": "40eade53-6f7e-4994-85b9-1c682eb9b223",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 213
+    },
+    {
+      "h": 6,
+      "i": "fe40549e-7522-4423-b2a1-818d09d63b07",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 213
+    }
+  ],
+  "panelMap": {
+    "498564bc-2fcf-49a7-9c6d-2c63f92b1880": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 3,
+          "i": "3c619a2a-b1ce-4946-8ace-edcb2b52cf28",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 0,
+          "y": 1
+        },
+        {
+          "h": 3,
+          "i": "e2a9750b-2199-4537-92e5-9a88b764cb7f",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 2,
+          "y": 1
+        },
+        {
+          "h": 3,
+          "i": "6d78546f-12a9-4298-841b-7afa6d42a743",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 4,
+          "y": 1
+        },
+        {
+          "h": 3,
+          "i": "79bab064-cf7f-40de-a62a-63b6d3544898",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 6,
+          "y": 1
+        },
+        {
+          "h": 3,
+          "i": "907ca736-205b-4922-9983-d863430200b4",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 8,
+          "y": 1
+        },
+        {
+          "h": 3,
+          "i": "0881687e-dd0c-421c-8216-3dd60d94bb8e",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 10,
+          "y": 1
+        },
+        {
+          "h": 6,
+          "i": "5f1c820a-b76b-49f6-a53e-7b9eff22157e",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 4
+        },
+        {
+          "h": 6,
+          "i": "05b7e736-c24e-47c7-bea8-b1282d9617f6",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 4
+        }
+      ]
+    },
+    "8d912f2e-ca6f-4578-b565-663c1548f4e8": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 3,
+          "i": "70261ba2-dbe5-4dea-baf0-c30084d9340e",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 0,
+          "y": 11
+        },
+        {
+          "h": 3,
+          "i": "49a7dec5-a0cd-4d10-8074-b358a74a0a87",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 2,
+          "y": 11
+        },
+        {
+          "h": 3,
+          "i": "26aa7ba3-bb7e-4d91-b430-f53bff778fd2",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 4,
+          "y": 11
+        },
+        {
+          "h": 3,
+          "i": "9656a76d-e99c-4f3e-b5eb-c80174d3ed1d",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 6,
+          "y": 11
+        },
+        {
+          "h": 3,
+          "i": "ec4bcaa2-00ce-4e95-a237-d8662ba7ee20",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 8,
+          "y": 11
+        },
+        {
+          "h": 3,
+          "i": "c150718d-621d-4329-9e74-19e34eadbce4",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 10,
+          "y": 11
+        },
+        {
+          "h": 6,
+          "i": "554eaa04-38f1-4811-8f85-665ec078dadd",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 14
+        },
+        {
+          "h": 6,
+          "i": "7009e5bf-6c81-4fde-b105-22f986e78167",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 14
+        },
+        {
+          "h": 6,
+          "i": "94dd2617-3e0f-4248-9c65-931fa30f2440",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 20
+        },
+        {
+          "h": 6,
+          "i": "c504912c-bdee-4619-994d-3395505f7c06",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 20
+        },
+        {
+          "h": 6,
+          "i": "0e04d772-6002-4536-91d4-cd980ecc401b",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 26
+        },
+        {
+          "h": 6,
+          "i": "367adf4e-de0b-49c0-aede-fb521bb82088",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 26
+        },
+        {
+          "h": 6,
+          "i": "10143247-a2e2-4604-8081-5d49f858ce18",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 32
+        },
+        {
+          "h": 6,
+          "i": "a24a257d-cc82-48fb-a641-4ddeb6f0be8a",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 32
+        },
+        {
+          "h": 6,
+          "i": "47e907d7-f907-42af-b501-095105c10244",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 38
+        },
+        {
+          "h": 6,
+          "i": "697ab4b1-3b62-4fca-9534-ba50427165f7",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 38
+        },
+        {
+          "h": 6,
+          "i": "cea5a98e-08f2-44cb-aa1e-cc1423ebe529",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 44
+        },
+        {
+          "h": 6,
+          "i": "53d05d8d-6b7f-49c4-a31d-ebf5151ab0d2",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 44
+        }
+      ]
+    },
+    "b9711bee-134e-4b1f-803f-6a16a5a0256c": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 3,
+          "i": "82c389b9-17e6-45ec-b8b3-bb73277d93f7",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 0,
+          "y": 51
+        },
+        {
+          "h": 3,
+          "i": "14d88852-630f-47cc-9121-a03b5fa458a0",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 2,
+          "y": 51
+        },
+        {
+          "h": 3,
+          "i": "9e38b614-d64c-4a57-8c4c-f4f8f6cc67b9",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 4,
+          "y": 51
+        },
+        {
+          "h": 3,
+          "i": "33df4d02-fc23-4bf1-a754-f71c6027371e",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 6,
+          "y": 51
+        },
+        {
+          "h": 3,
+          "i": "e30d4f85-623f-482c-add9-ef9c9c94d257",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 8,
+          "y": 51
+        },
+        {
+          "h": 3,
+          "i": "9051d1f1-e153-4721-bb99-baf82ea53d7f",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 10,
+          "y": 51
+        },
+        {
+          "h": 3,
+          "i": "34eb6b48-8ab1-4bd2-8b63-c1c7fafb15d6",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 0,
+          "y": 54
+        },
+        {
+          "h": 3,
+          "i": "f3842772-2ac0-4884-9021-38053e257aa5",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 2,
+          "y": 54
+        },
+        {
+          "h": 3,
+          "i": "f11bbe0a-9c39-4381-9082-1dd4fbeb3087",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 4,
+          "y": 54
+        },
+        {
+          "h": 6,
+          "i": "a6c70f99-30ff-46cf-8ce6-6fb9e7d78cc2",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 57
+        },
+        {
+          "h": 6,
+          "i": "e1524382-e96d-4b69-a6a6-2290c9229536",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 57
+        },
+        {
+          "h": 6,
+          "i": "abc0474e-9217-4cb5-8211-1c01fd5365e4",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 63
+        },
+        {
+          "h": 6,
+          "i": "31bf0012-2626-4951-9efb-7654a880c88b",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 63
+        },
+        {
+          "h": 6,
+          "i": "6d1f0df6-0441-4f4c-aef8-c38c7aed1fb9",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 69
+        },
+        {
+          "h": 6,
+          "i": "f3ec3fc6-7042-4563-81b4-785adb9f61ba",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 69
+        },
+        {
+          "h": 6,
+          "i": "aabbb6a4-f2c9-4bac-aa8f-f3b74a450206",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 75
+        },
+        {
+          "h": 6,
+          "i": "003d2496-57f3-48be-8c00-b693ba97e8f5",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 75
+        },
+        {
+          "h": 6,
+          "i": "9cc60501-ffe5-46f4-84d9-75d56ac071b2",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 81
+        },
+        {
+          "h": 6,
+          "i": "136428da-b321-4241-be49-e06077adfead",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 81
+        },
+        {
+          "h": 6,
+          "i": "cede1134-4a36-4c74-93a7-67405197c5be",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 87
+        },
+        {
+          "h": 6,
+          "i": "0ed7df8d-41f4-4fb4-b9be-950e7756acd6",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 87
+        },
+        {
+          "h": 6,
+          "i": "f962ad4d-1a4e-4c10-bd36-f02bf241b3e5",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 93
+        },
+        {
+          "h": 6,
+          "i": "5827e5ca-b7d8-484d-9367-63db53bc6cef",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 93
+        },
+        {
+          "h": 6,
+          "i": "bf584a4a-70c6-4222-a95f-d97f8dd504bf",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 99
+        },
+        {
+          "h": 6,
+          "i": "2d3e78ea-cf41-417c-b4c1-121e73cef0e1",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 99
+        }
+      ]
+    },
+    "4b1b29bf-26d5-4aa5-8374-dca18cea7141": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 3,
+          "i": "f2d6ad05-6318-40ba-9023-8990d59fbbfb",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 0,
+          "y": 106
+        },
+        {
+          "h": 3,
+          "i": "39add25f-144a-4be2-b418-2cea7f036fe1",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 2,
+          "y": 106
+        },
+        {
+          "h": 3,
+          "i": "714ee821-3d24-4b5e-85cc-5884199e3863",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 4,
+          "y": 106
+        },
+        {
+          "h": 3,
+          "i": "38b31944-cc22-4cad-9075-53622f7502fa",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 6,
+          "y": 106
+        },
+        {
+          "h": 3,
+          "i": "df76a0ea-b20d-4f4b-b42a-86cd27a02719",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 8,
+          "y": 106
+        },
+        {
+          "h": 3,
+          "i": "e0f80776-cba3-442f-b5dd-37d778d063ab",
+          "moved": false,
+          "static": false,
+          "w": 2,
+          "x": 10,
+          "y": 106
+        },
+        {
+          "h": 6,
+          "i": "47a44787-f2b7-44e8-bb29-c8badc2a3936",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 109
+        },
+        {
+          "h": 6,
+          "i": "f5ae224f-f15f-4d2c-990e-0e3f2100f235",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 109
+        },
+        {
+          "h": 6,
+          "i": "48175605-c518-43ce-8b44-56cf1fe0cddf",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 115
+        },
+        {
+          "h": 6,
+          "i": "eece9161-c732-4f94-9544-44445f14041a",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 115
+        },
+        {
+          "h": 6,
+          "i": "f0ece911-92e7-41f4-98dc-0694af9dd18e",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 121
+        },
+        {
+          "h": 6,
+          "i": "2c2e9622-68b6-4048-96c7-bacf6ceea4d7",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 121
+        },
+        {
+          "h": 6,
+          "i": "3d780f3c-8033-4a57-a2e0-c98e7384c9a1",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 127
+        },
+        {
+          "h": 6,
+          "i": "a21030ca-ed8a-49f8-9a7e-80bd7dddcc2a",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 127
+        },
+        {
+          "h": 6,
+          "i": "bc685b88-943b-4e43-adb1-606a5c79c472",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 133
+        },
+        {
+          "h": 6,
+          "i": "07134208-bdbe-40e5-9a8e-a4921fd6e006",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 133
+        },
+        {
+          "h": 6,
+          "i": "e4afbcc3-4d9d-42a7-95e6-8edc9638b880",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 139
+        },
+        {
+          "h": 6,
+          "i": "fe0217d6-9f1b-48f1-a5c3-cce35aa5dccf",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 139
+        },
+        {
+          "h": 6,
+          "i": "bcb2e21a-83c1-4b6e-b041-7ff93dc2105d",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 145
+        },
+        {
+          "h": 6,
+          "i": "3c038336-86c5-4668-94b8-ebb51c79088f",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 145
+        },
+        {
+          "h": 6,
+          "i": "a8e3e585-d275-4cdb-8681-a61b959ab8f4",
+          "moved": false,
+          "static": false,
+          "w": 12,
+          "x": 0,
+          "y": 151
+        }
+      ]
+    },
+    "96b2bbd1-b352-48da-a705-dab6d3b13979": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "eaa6b66a-62be-4aa6-8e81-67b764838dd0",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 158
+        },
+        {
+          "h": 6,
+          "i": "178b655a-8ced-4bb0-bb61-2423da3cfcb5",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 158
+        },
+        {
+          "h": 6,
+          "i": "b00f2625-90f8-429d-bd01-c3fec9fba913",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 164
+        },
+        {
+          "h": 6,
+          "i": "807b0690-b156-4fad-ba37-c88c7c02685a",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 164
+        },
+        {
+          "h": 6,
+          "i": "80a64850-dde1-48dd-9d2d-7c6e844f30ba",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 170
+        },
+        {
+          "h": 6,
+          "i": "677432ac-aca6-4e91-bc95-8f7f6aef3aea",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 170
+        },
+        {
+          "h": 6,
+          "i": "7c7d2f72-0443-4fea-8b26-150a73b2d150",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 176
+        },
+        {
+          "h": 6,
+          "i": "8b5af7c3-8aa7-4e22-93d2-fc65e945f931",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 176
+        }
+      ]
+    },
+    "23a23b70-8ccb-46c5-aa62-755eb6e91bb8": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "4485f4ef-6e18-4440-b4a6-7eee76004478",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 183
+        },
+        {
+          "h": 6,
+          "i": "90c966ee-e6f0-47aa-9595-b50c30bd5234",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 183
+        },
+        {
+          "h": 6,
+          "i": "c5a64da4-77fd-4e06-8cb5-84f7592f2f78",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 189
+        },
+        {
+          "h": 6,
+          "i": "6e0dea4d-0a95-462e-8a14-8a6c05d56197",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 189
+        },
+        {
+          "h": 6,
+          "i": "8e44cb80-b317-4910-a6b4-9263ddbbb940",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 195
+        },
+        {
+          "h": 6,
+          "i": "b42bd0bf-1339-4ae0-96b6-bca918d0ca1d",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 195
+        },
+        {
+          "h": 6,
+          "i": "1ee4de36-4bfc-4c3a-993d-3999fabfc5cc",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 201
+        },
+        {
+          "h": 6,
+          "i": "fbdad8e2-cb5a-4157-bd17-54c6135e59a4",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 201
+        },
+        {
+          "h": 6,
+          "i": "05c20229-2560-42bb-bd5c-7eb5645c02f6",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 207
+        },
+        {
+          "h": 6,
+          "i": "94ac54ea-a6fe-408c-b51e-f458ada146e2",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 207
+        },
+        {
+          "h": 6,
+          "i": "40eade53-6f7e-4994-85b9-1c682eb9b223",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 213
+        },
+        {
+          "h": 6,
+          "i": "fe40549e-7522-4423-b2a1-818d09d63b07",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 213
+        }
+      ]
+    }
+  },
+  "tags": [
+    "otel-collector",
+    "opentelemetry",
+    "collector",
+    "receivers",
+    "processors",
+    "exporters"
+  ],
+  "title": "OTel Collector",
+  "uploadedGrafana": false,
+  "variables": {
+    "fbd5e436-e9aa-4b80-bce2-32cfafefa98a": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "The service instance ID of the OTel Collector",
+      "id": "fbd5e436-e9aa-4b80-bce2-32cfafefa98a",
+      "modificationUUID": "ca237107-23d3-498a-ada7-755d2df3102f",
+      "multiSelect": false,
+      "name": "collector_name",
+      "order": 1,
+      "queryValue": "SELECT DISTINCT JSONExtractString(labels, 'service.instance.id') AS `service.instance.id` FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'otelcol_process_uptime' AND JSONExtractString(labels, 'service.instance.id') != '' GROUP BY `service.instance.id`",
+      "selectedValue": "",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "version": "v4",
+  "widgets": [
+    {
+      "description": "",
+      "id": "498564bc-2fcf-49a7-9c6d-2c63f92b1880",
+      "panelTypes": "row",
+      "title": "Overview"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Time since the collector process started",
+      "fillSpans": false,
+      "id": "3c619a2a-b1ce-4946-8ace-edcb2b52cf28",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_process_uptime--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_process_uptime",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "989e6a75",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f2c54fc2-3922-4054-8ab4-add308746dff",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Collector Uptime",
+      "yAxisUnit": "s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Resident set size of the collector process",
+      "fillSpans": false,
+      "id": "e2a9750b-2199-4537-92e5-9a88b764cb7f",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_process_memory_rss--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_process_memory_rss",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "ae3ed1b2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d1baa298-a658-44bc-a6e0-05118ccde34c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memory RSS",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Current heap memory allocated",
+      "fillSpans": false,
+      "id": "6d78546f-12a9-4298-841b-7afa6d42a743",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_process_runtime_heap_alloc_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_process_runtime_heap_alloc_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "501465a6",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "985ef432-b49a-4678-b4a1-5cf909e51c9f",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Heap Alloc",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of CPU seconds consumed",
+      "fillSpans": false,
+      "id": "79bab064-cf7f-40de-a62a-63b6d3544898",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_process_cpu_seconds--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_process_cpu_seconds",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "1166e57f",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c7203ad1-7256-46f0-8a4d-8fe89f76043c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "CPU Usage Rate",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total system memory obtained from the OS",
+      "fillSpans": false,
+      "id": "907ca736-205b-4922-9983-d863430200b4",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_process_runtime_total_sys_memory_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_process_runtime_total_sys_memory_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "1e154f56",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "65deb97b-b73b-4098-93bd-4509bb143c32",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Sys Memory",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Cumulative bytes allocated for heap objects",
+      "fillSpans": false,
+      "id": "0881687e-dd0c-421c-8216-3dd60d94bb8e",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_process_runtime_total_alloc_bytes--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_process_runtime_total_alloc_bytes",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "7d9de6f5",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "943ea40f-2726-4b70-a3d2-5b5bf155c4f3",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Alloc Bytes",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Resident set size over time",
+      "fillSpans": false,
+      "id": "5f1c820a-b76b-49f6-a53e-7b9eff22157e",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_process_memory_rss--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_process_memory_rss",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "e014a8b0",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "RSS",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f17d3f04-a41f-4611-8f86-73ccb273e8e8",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memory RSS Over Time",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of CPU seconds consumed over time",
+      "fillSpans": false,
+      "id": "05b7e736-c24e-47c7-bea8-b1282d9617f6",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_process_cpu_seconds--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_process_cpu_seconds",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "22774be3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "CPU Rate",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "28de7891-f4cd-4a45-899c-7852244e5f75",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "CPU Usage Rate Over Time",
+      "yAxisUnit": ""
+    },
+    {
+      "description": "",
+      "id": "8d912f2e-ca6f-4578-b565-663c1548f4e8",
+      "panelTypes": "row",
+      "title": "Receivers"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total spans accepted by receivers",
+      "fillSpans": false,
+      "id": "70261ba2-dbe5-4dea-baf0-c30084d9340e",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_receiver_accepted_spans--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_receiver_accepted_spans",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "21c69ef7",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "fc7cc241-aeed-41d4-8491-8e9c45d13120",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Accepted Spans (Total)",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total spans refused by receivers",
+      "fillSpans": false,
+      "id": "49a7dec5-a0cd-4d10-8074-b358a74a0a87",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_receiver_refused_spans--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_receiver_refused_spans",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "fc9ee0b1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "51ced3b0-9c89-4b40-83af-736d8a3774da",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Refused Spans (Total)",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total metric points accepted by receivers",
+      "fillSpans": false,
+      "id": "26aa7ba3-bb7e-4d91-b430-f53bff778fd2",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_receiver_accepted_metric_points--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_receiver_accepted_metric_points",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f9f0c255",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "5e6c8862-afdc-4cba-86fd-3bbf09ef3b0d",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Accepted Metric Points (Total)",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total metric points refused by receivers",
+      "fillSpans": false,
+      "id": "9656a76d-e99c-4f3e-b5eb-c80174d3ed1d",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_receiver_refused_metric_points--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_receiver_refused_metric_points",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b39cac9e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f6d2950a-d719-47dc-899e-f1224aaf57d2",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Refused Metric Points (Total)",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total log records accepted by receivers",
+      "fillSpans": false,
+      "id": "ec4bcaa2-00ce-4e95-a237-d8662ba7ee20",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_receiver_accepted_log_records--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_receiver_accepted_log_records",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "426f92aa",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "107107d3-2861-4c08-b2bf-d8163606289c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Accepted Log Records (Total)",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total log records refused by receivers",
+      "fillSpans": false,
+      "id": "c150718d-621d-4329-9e74-19e34eadbce4",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_receiver_refused_log_records--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_receiver_refused_log_records",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "5f693d70",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9476a22e-6a1f-4a32-b2af-cc280c2dc9c6",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Refused Log Records (Total)",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of spans accepted, grouped by receiver",
+      "fillSpans": false,
+      "id": "554eaa04-38f1-4811-8f85-665ec078dadd",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_receiver_accepted_spans--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_receiver_accepted_spans",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "e499e281",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "receiver--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "receiver",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{receiver}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8cb0e623-d7d0-4b43-9a37-a04a46281a7c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Accepted Spans Rate by Receiver",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of spans refused, grouped by receiver",
+      "fillSpans": false,
+      "id": "7009e5bf-6c81-4fde-b105-22f986e78167",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_receiver_refused_spans--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_receiver_refused_spans",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "29fad3a9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "receiver--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "receiver",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{receiver}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a30d368a-205a-4e02-8032-8d08736d8b59",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Refused Spans Rate by Receiver",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of metric points accepted, grouped by receiver",
+      "fillSpans": false,
+      "id": "94dd2617-3e0f-4248-9c65-931fa30f2440",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_receiver_accepted_metric_points--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_receiver_accepted_metric_points",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "abb13b47",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "receiver--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "receiver",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{receiver}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "81ef1a84-5c67-417d-b965-e62fac2e68d9",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Accepted Metric Points Rate by Receiver",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of metric points refused, grouped by receiver",
+      "fillSpans": false,
+      "id": "c504912c-bdee-4619-994d-3395505f7c06",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_receiver_refused_metric_points--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_receiver_refused_metric_points",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "16eee1c7",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "receiver--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "receiver",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{receiver}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a8b0b7ce-beb4-46b1-8a47-376fb9667523",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Refused Metric Points Rate by Receiver",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of log records accepted, grouped by receiver",
+      "fillSpans": false,
+      "id": "0e04d772-6002-4536-91d4-cd980ecc401b",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_receiver_accepted_log_records--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_receiver_accepted_log_records",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "677bcbbb",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "receiver--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "receiver",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{receiver}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6fded4df-43df-4fe4-97e9-265dfe4aa1bb",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Accepted Log Records Rate by Receiver",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of log records refused, grouped by receiver",
+      "fillSpans": false,
+      "id": "367adf4e-de0b-49c0-aede-fb521bb82088",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_receiver_refused_log_records--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_receiver_refused_log_records",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "8e840872",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "receiver--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "receiver",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{receiver}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "4e3965d9-b3dd-4756-a050-4cd8daf2d9c1",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Refused Log Records Rate by Receiver",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Comparison of accepted and refused spans across all receivers",
+      "fillSpans": false,
+      "id": "10143247-a2e2-4604-8081-5d49f858ce18",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_receiver_accepted_spans--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_receiver_accepted_spans",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "850d80a3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Accepted",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_receiver_refused_spans--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_receiver_refused_spans",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f0d34ee0",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Refused",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b8f80491-4976-4749-8c2a-0f3ba2ee9869",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Receiver Spans: Accepted vs Refused",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Comparison of accepted and refused metric points across all receivers",
+      "fillSpans": false,
+      "id": "a24a257d-cc82-48fb-a641-4ddeb6f0be8a",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_receiver_accepted_metric_points--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_receiver_accepted_metric_points",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "3ce4b3c0",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Accepted",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_receiver_refused_metric_points--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_receiver_refused_metric_points",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "cc61f326",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Refused",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "06dbe8a3-5aaf-473b-8625-2900c6043a87",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Receiver Metrics: Accepted vs Refused",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Comparison of accepted and refused log records across all receivers",
+      "fillSpans": false,
+      "id": "47e907d7-f907-42af-b501-095105c10244",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_receiver_accepted_log_records--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_receiver_accepted_log_records",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "0760edcd",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Accepted",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_receiver_refused_log_records--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_receiver_refused_log_records",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b42b0904",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Refused",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "e056dc74-0f75-4e11-b1d5-268861621c7b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Receiver Logs: Accepted vs Refused",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of spans accepted, grouped by transport protocol",
+      "fillSpans": false,
+      "id": "697ab4b1-3b62-4fca-9534-ba50427165f7",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_receiver_accepted_spans--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_receiver_accepted_spans",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f6abd79c",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "transport--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "transport",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{transport}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c003e70d-802d-4ecb-b183-c2a43f48492a",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Accepted Spans Rate by Transport",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of metric points accepted, grouped by transport",
+      "fillSpans": false,
+      "id": "cea5a98e-08f2-44cb-aa1e-cc1423ebe529",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_receiver_accepted_metric_points--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_receiver_accepted_metric_points",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "5abde780",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "transport--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "transport",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{transport}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b7611be8-4185-4aa0-941e-f28524e6f86c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Accepted Metric Points Rate by Transport",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of log records accepted, grouped by transport",
+      "fillSpans": false,
+      "id": "53d05d8d-6b7f-49c4-a31d-ebf5151ab0d2",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_receiver_accepted_log_records--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_receiver_accepted_log_records",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "c2888a1b",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "transport--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "transport",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{transport}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "737c2e75-17ce-4e1e-8409-d7b9014ebd12",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Accepted Log Records Rate by Transport",
+      "yAxisUnit": ""
+    },
+    {
+      "description": "",
+      "id": "b9711bee-134e-4b1f-803f-6a16a5a0256c",
+      "panelTypes": "row",
+      "title": "Processors"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total spans accepted by processors",
+      "fillSpans": false,
+      "id": "82c389b9-17e6-45ec-b8b3-bb73277d93f7",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_processor_accepted_spans--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_processor_accepted_spans",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "666bbe51",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "62c60696-3c39-46a7-bb06-1b45cf6c9094",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Processor Accepted Spans (Total)",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total spans refused by processors",
+      "fillSpans": false,
+      "id": "14d88852-630f-47cc-9121-a03b5fa458a0",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_processor_refused_spans--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_processor_refused_spans",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d92101b6",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6d2fbf7b-00ee-4bf2-a1c3-0fabf028ecf3",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Processor Refused Spans (Total)",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total spans dropped by processors",
+      "fillSpans": false,
+      "id": "9e38b614-d64c-4a57-8c4c-f4f8f6cc67b9",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_processor_dropped_spans--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_processor_dropped_spans",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "6159c6a1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f299e2df-1d8b-4be6-ab79-adee2b828745",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Processor Dropped Spans (Total)",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total metric points accepted by processors",
+      "fillSpans": false,
+      "id": "33df4d02-fc23-4bf1-a754-f71c6027371e",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_processor_accepted_metric_points--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_processor_accepted_metric_points",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "6ecc8950",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6811a09d-3dfa-4b39-9668-fe860c4cb8fb",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Processor Accepted Metric Points (Total)",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total metric points refused by processors",
+      "fillSpans": false,
+      "id": "e30d4f85-623f-482c-add9-ef9c9c94d257",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_processor_refused_metric_points--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_processor_refused_metric_points",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "ae3cc4e9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "38e7a0ad-f1fd-4bdc-9724-644211842b9a",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Processor Refused Metric Points (Total)",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total metric points dropped by processors",
+      "fillSpans": false,
+      "id": "9051d1f1-e153-4721-bb99-baf82ea53d7f",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_processor_dropped_metric_points--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_processor_dropped_metric_points",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "dd5bcf70",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a926e226-8383-4778-b44c-d2184c104c81",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Processor Dropped Metric Points (Total)",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total log records accepted by processors",
+      "fillSpans": false,
+      "id": "34eb6b48-8ab1-4bd2-8b63-c1c7fafb15d6",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_processor_accepted_log_records--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_processor_accepted_log_records",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "e5e0453c",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d1de11cf-5b63-4fd6-96c1-0fb5b44146e3",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Processor Accepted Log Records (Total)",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total log records refused by processors",
+      "fillSpans": false,
+      "id": "f3842772-2ac0-4884-9021-38053e257aa5",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_processor_refused_log_records--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_processor_refused_log_records",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "eb131aff",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "db9616f9-ebeb-4ccc-994c-ed27593736bf",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Processor Refused Log Records (Total)",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total log records dropped by processors",
+      "fillSpans": false,
+      "id": "f11bbe0a-9c39-4381-9082-1dd4fbeb3087",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_processor_dropped_log_records--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_processor_dropped_log_records",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "e1995b6e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "4c0c5bba-a9f2-4c0d-9964-7c580cb87d0c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Processor Dropped Log Records (Total)",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of spans accepted, grouped by processor",
+      "fillSpans": false,
+      "id": "a6c70f99-30ff-46cf-8ce6-6fb9e7d78cc2",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_processor_accepted_spans--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_processor_accepted_spans",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "9883c58a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "processor--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "processor",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{processor}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "53770c2c-2276-491a-b0b1-5950d39c81ec",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Processor Accepted Spans Rate by Processor",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of spans refused, grouped by processor",
+      "fillSpans": false,
+      "id": "e1524382-e96d-4b69-a6a6-2290c9229536",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_processor_refused_spans--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_processor_refused_spans",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "441f7d90",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "processor--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "processor",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{processor}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "228d683e-9de0-450c-ad9e-289169399bee",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Processor Refused Spans Rate by Processor",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of spans dropped, grouped by processor",
+      "fillSpans": false,
+      "id": "abc0474e-9217-4cb5-8211-1c01fd5365e4",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_processor_dropped_spans--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_processor_dropped_spans",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "6fe26e5f",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "processor--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "processor",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{processor}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a0acc79b-3253-446d-9cd3-dbe6e47f648c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Processor Dropped Spans Rate by Processor",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of metric points accepted, grouped by processor",
+      "fillSpans": false,
+      "id": "31bf0012-2626-4951-9efb-7654a880c88b",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_processor_accepted_metric_points--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_processor_accepted_metric_points",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "ddd45f8e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "processor--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "processor",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{processor}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a46f4097-c0b9-4684-a75e-df0e8c690828",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Processor Accepted Metric Points Rate",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of metric points refused, grouped by processor",
+      "fillSpans": false,
+      "id": "6d1f0df6-0441-4f4c-aef8-c38c7aed1fb9",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_processor_refused_metric_points--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_processor_refused_metric_points",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "5f18b827",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "processor--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "processor",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{processor}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "4e8b8b81-2ddd-4068-aa8c-7741b7c7798b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Processor Refused Metric Points Rate",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of metric points dropped, grouped by processor",
+      "fillSpans": false,
+      "id": "f3ec3fc6-7042-4563-81b4-785adb9f61ba",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_processor_dropped_metric_points--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_processor_dropped_metric_points",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "1f802e90",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "processor--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "processor",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{processor}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "55160be3-15ae-43c8-9ef5-fbf73079c39f",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Processor Dropped Metric Points Rate",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of log records accepted, grouped by processor",
+      "fillSpans": false,
+      "id": "aabbb6a4-f2c9-4bac-aa8f-f3b74a450206",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_processor_accepted_log_records--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_processor_accepted_log_records",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "a3d83593",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "processor--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "processor",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{processor}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "efa0188a-765e-49b8-b68f-aadffe9dff72",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Processor Accepted Log Records Rate",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of log records refused, grouped by processor",
+      "fillSpans": false,
+      "id": "003d2496-57f3-48be-8c00-b693ba97e8f5",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_processor_refused_log_records--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_processor_refused_log_records",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "a17ab02d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "processor--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "processor",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{processor}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "32cbd201-735d-4880-99d4-5f2bac6fd02f",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Processor Refused Log Records Rate",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of log records dropped, grouped by processor",
+      "fillSpans": false,
+      "id": "9cc60501-ffe5-46f4-84d9-75d56ac071b2",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_processor_dropped_log_records--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_processor_dropped_log_records",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "baa11e02",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "processor--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "processor",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{processor}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "abec51d3-f0da-4681-9d7b-06f4c1bb670f",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Processor Dropped Log Records Rate",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Comparison across all processors",
+      "fillSpans": false,
+      "id": "136428da-b321-4241-be49-e06077adfead",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_processor_accepted_spans--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_processor_accepted_spans",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "269ccce0",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Accepted",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_processor_refused_spans--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_processor_refused_spans",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "53a0f946",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Refused",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_processor_dropped_spans--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_processor_dropped_spans",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "C",
+              "filters": {
+                "items": [
+                  {
+                    "id": "5149b9a5",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Dropped",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "C",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "844624a2-e65d-4b3d-bf7a-11ace2b39cba",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Processor Spans: Accepted vs Refused vs Dropped",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Comparison across all processors",
+      "fillSpans": false,
+      "id": "cede1134-4a36-4c74-93a7-67405197c5be",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_processor_accepted_metric_points--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_processor_accepted_metric_points",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "607b359c",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Accepted",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_processor_refused_metric_points--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_processor_refused_metric_points",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "8bc9e5a8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Refused",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_processor_dropped_metric_points--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_processor_dropped_metric_points",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "C",
+              "filters": {
+                "items": [
+                  {
+                    "id": "452c3225",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Dropped",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "C",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "bb26df6b-0946-42c3-82fb-d6b1dca0fc48",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Processor Metrics: Accepted vs Refused vs Dropped",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Comparison across all processors",
+      "fillSpans": false,
+      "id": "0ed7df8d-41f4-4fb4-b9be-950e7756acd6",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_processor_accepted_log_records--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_processor_accepted_log_records",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f9ffcd63",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Accepted",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_processor_refused_log_records--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_processor_refused_log_records",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f0c345c1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Refused",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_processor_dropped_log_records--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_processor_dropped_log_records",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "C",
+              "filters": {
+                "items": [
+                  {
+                    "id": "8fff843e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Dropped",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "C",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a7580eee-90ee-4ce9-b4e7-a062a36f5d2d",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Processor Logs: Accepted vs Refused vs Dropped",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "50th percentile of batch send sizes",
+      "fillSpans": false,
+      "id": "f962ad4d-1a4e-4c10-bd36-f02bf241b3e5",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_processor_batch_send_size--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_processor_batch_send_size",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p50",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "a2d385fb",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "processor--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "processor",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{processor}} p50",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "p50"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "144ee9d0-4841-42ec-bac8-0681deb98d43",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Batch Processor Send Size (p50)",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "95th percentile of batch send sizes",
+      "fillSpans": false,
+      "id": "5827e5ca-b7d8-484d-9367-63db53bc6cef",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_processor_batch_send_size--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_processor_batch_send_size",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p95",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "c83f0e23",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "processor--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "processor",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{processor}} p95",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "p95"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "eeaf7daa-8ca1-417e-960d-de92b0941596",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Batch Processor Send Size (p95)",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "99th percentile of batch send sizes",
+      "fillSpans": false,
+      "id": "bf584a4a-70c6-4222-a95f-d97f8dd504bf",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_processor_batch_send_size--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_processor_batch_send_size",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p99",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "38a5838c",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "processor--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "processor",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{processor}} p99",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "p99"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8df64d74-1d30-41d9-b822-5fc1840f4b77",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Batch Processor Send Size (p99)",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of batch sends triggered by timeout, grouped by processor",
+      "fillSpans": false,
+      "id": "2d3e78ea-cf41-417c-b4c1-121e73cef0e1",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_processor_batch_timeout_trigger_send--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_processor_batch_timeout_trigger_send",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "ecfb93f5",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "processor--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "processor",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{processor}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "fb3448cb-af17-4f86-9614-01aa003728d2",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Batch Timeout Trigger Send Rate",
+      "yAxisUnit": ""
+    },
+    {
+      "description": "",
+      "id": "4b1b29bf-26d5-4aa5-8374-dca18cea7141",
+      "panelTypes": "row",
+      "title": "Exporters"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total spans successfully sent by exporters",
+      "fillSpans": false,
+      "id": "f2d6ad05-6318-40ba-9023-8990d59fbbfb",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_exporter_sent_spans--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_exporter_sent_spans",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "c490809e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "be9f382a-6b82-45c0-b141-e5ccd84f47f6",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Exporter Sent Spans (Total)",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total spans that failed to send",
+      "fillSpans": false,
+      "id": "39add25f-144a-4be2-b418-2cea7f036fe1",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_exporter_failed_spans--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_exporter_failed_spans",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "1ec263dd",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "451b9514-4cfd-4cde-9971-94a7191b0c0e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Exporter Failed Spans (Total)",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total metric points successfully sent",
+      "fillSpans": false,
+      "id": "714ee821-3d24-4b5e-85cc-5884199e3863",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_exporter_sent_metric_points--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_exporter_sent_metric_points",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "c22eaaa0",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c4a4cab2-8336-49b7-a6b7-25dcd9bfac56",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Exporter Sent Metric Points (Total)",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total metric points that failed to send",
+      "fillSpans": false,
+      "id": "38b31944-cc22-4cad-9075-53622f7502fa",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_exporter_failed_metric_points--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_exporter_failed_metric_points",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "a315031e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a335e37c-b6d0-4a6a-89dc-d8ec9197724d",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Exporter Failed Metric Points (Total)",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total log records successfully sent",
+      "fillSpans": false,
+      "id": "df76a0ea-b20d-4f4b-b42a-86cd27a02719",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_exporter_sent_log_records--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_exporter_sent_log_records",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "cf156d00",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "7ef05201-b5b9-4cdb-8f67-bce9fb073399",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Exporter Sent Log Records (Total)",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total log records that failed to send",
+      "fillSpans": false,
+      "id": "e0f80776-cba3-442f-b5dd-37d778d063ab",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_exporter_failed_log_records--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_exporter_failed_log_records",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "347c5b8f",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ccfcc577-e252-4698-a3f7-1cf3cf8bc910",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Exporter Failed Log Records (Total)",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of spans sent, grouped by exporter",
+      "fillSpans": false,
+      "id": "47a44787-f2b7-44e8-bb29-c8badc2a3936",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_exporter_sent_spans--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_exporter_sent_spans",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "03fdaadc",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "exporter--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "exporter",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{exporter}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "bd96bb7f-5115-4f7f-a1e4-29578ec7d73c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Exporter Sent Spans Rate by Exporter",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of spans failed, grouped by exporter",
+      "fillSpans": false,
+      "id": "f5ae224f-f15f-4d2c-990e-0e3f2100f235",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_exporter_failed_spans--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_exporter_failed_spans",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "dfb7fcf3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "exporter--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "exporter",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{exporter}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "30d22126-dd6e-483f-9723-b4d6d7c2afaa",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Exporter Failed Spans Rate by Exporter",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of metric points sent, grouped by exporter",
+      "fillSpans": false,
+      "id": "48175605-c518-43ce-8b44-56cf1fe0cddf",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_exporter_sent_metric_points--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_exporter_sent_metric_points",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "0b3806de",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "exporter--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "exporter",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{exporter}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "2cdac95e-1aa5-4513-af65-fa85e7fff020",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Exporter Sent Metric Points Rate by Exporter",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of metric points failed, grouped by exporter",
+      "fillSpans": false,
+      "id": "eece9161-c732-4f94-9544-44445f14041a",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_exporter_failed_metric_points--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_exporter_failed_metric_points",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "2cd67d2f",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "exporter--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "exporter",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{exporter}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d7b7ba73-2b02-4201-977a-b8f936ad96aa",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Exporter Failed Metric Points Rate by Exporter",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of log records sent, grouped by exporter",
+      "fillSpans": false,
+      "id": "f0ece911-92e7-41f4-98dc-0694af9dd18e",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_exporter_sent_log_records--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_exporter_sent_log_records",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "350e57bb",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "exporter--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "exporter",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{exporter}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "19800c9c-dbe7-4014-93bb-8a1970898b58",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Exporter Sent Log Records Rate by Exporter",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of log records failed, grouped by exporter",
+      "fillSpans": false,
+      "id": "2c2e9622-68b6-4048-96c7-bacf6ceea4d7",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_exporter_failed_log_records--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_exporter_failed_log_records",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "91d59e75",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "exporter--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "exporter",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{exporter}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6d23008a-9edb-4a7f-ad5d-d7de093708c4",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Exporter Failed Log Records Rate by Exporter",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Comparison of sent and failed spans across all exporters",
+      "fillSpans": false,
+      "id": "3d780f3c-8033-4a57-a2e0-c98e7384c9a1",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_exporter_sent_spans--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_exporter_sent_spans",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "47c09118",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Sent",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_exporter_failed_spans--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_exporter_failed_spans",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d5164eb3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Failed",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "108f1be7-4059-4bb8-af3b-6a06478047ff",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Exporter Spans: Sent vs Failed",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Comparison of sent and failed metric points across all exporters",
+      "fillSpans": false,
+      "id": "a21030ca-ed8a-49f8-9a7e-80bd7dddcc2a",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_exporter_sent_metric_points--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_exporter_sent_metric_points",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "0f82efcc",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Sent",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_exporter_failed_metric_points--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_exporter_failed_metric_points",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b39ca3c4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Failed",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6f640c37-815e-44b7-a95b-d815b40e60c0",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Exporter Metrics: Sent vs Failed",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Comparison of sent and failed log records across all exporters",
+      "fillSpans": false,
+      "id": "bc685b88-943b-4e43-adb1-606a5c79c472",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_exporter_sent_log_records--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_exporter_sent_log_records",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "4e994b13",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Sent",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_exporter_failed_log_records--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_exporter_failed_log_records",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "82eba5ff",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Failed",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "1584f2b4-8ae3-4760-a557-e310bbcd4140",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Exporter Logs: Sent vs Failed",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Current queue size, grouped by exporter",
+      "fillSpans": false,
+      "id": "07134208-bdbe-40e5-9a8e-a4921fd6e006",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_exporter_queue_size--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_exporter_queue_size",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "78bf4253",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "exporter--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "exporter",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{exporter}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "3bc28d1c-015a-405c-bb3d-3ac3424c242f",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Exporter Queue Size by Exporter",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Queue capacity, grouped by exporter",
+      "fillSpans": false,
+      "id": "e4afbcc3-4d9d-42a7-95e6-8edc9638b880",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_exporter_queue_capacity--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_exporter_queue_capacity",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f52b0b84",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "exporter--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "exporter",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{exporter}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c8dc0df4-bcea-40f2-bb6f-09c81ba5cb0f",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Exporter Queue Capacity by Exporter",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Queue size as percentage of capacity, per exporter",
+      "fillSpans": false,
+      "id": "fe0217d6-9f1b-48f1-a5c3-cce35aa5dccf",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_exporter_queue_size--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_exporter_queue_size",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "ff2f887b",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "exporter--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "exporter",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_exporter_queue_capacity--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_exporter_queue_capacity",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "55d87b24",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "exporter--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "exporter",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "A/B",
+              "legend": "{{exporter}}",
+              "queryName": "F1"
+            }
+          ]
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6ac0bcac-e72b-4f4b-8a8c-742140688823",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Exporter Queue Utilization (%)",
+      "yAxisUnit": "percentunit"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of spans that failed to enqueue, grouped by exporter",
+      "fillSpans": false,
+      "id": "bcb2e21a-83c1-4b6e-b041-7ff93dc2105d",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_exporter_enqueue_failed_spans--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_exporter_enqueue_failed_spans",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "596bf2a9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "exporter--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "exporter",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{exporter}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0b1acb4e-00c3-4844-8449-4069f535aa0c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Exporter Enqueue Failed Spans Rate",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of metric points that failed to enqueue, grouped by exporter",
+      "fillSpans": false,
+      "id": "3c038336-86c5-4668-94b8-ebb51c79088f",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_exporter_enqueue_failed_metric_points--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_exporter_enqueue_failed_metric_points",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "29f444b5",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "exporter--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "exporter",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{exporter}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "42877009-87ed-4ee2-b38f-8c32774db3c3",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Exporter Enqueue Failed Metric Points Rate",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of log records that failed to enqueue, grouped by exporter",
+      "fillSpans": false,
+      "id": "a8e3e585-d275-4cdb-8681-a61b959ab8f4",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_exporter_enqueue_failed_log_records--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_exporter_enqueue_failed_log_records",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d99d6324",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "exporter--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "exporter",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{exporter}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "63e43e20-7c6f-4ba8-aec7-cb2cd09f17e4",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Exporter Enqueue Failed Log Records Rate",
+      "yAxisUnit": ""
+    },
+    {
+      "description": "",
+      "id": "96b2bbd1-b352-48da-a705-dab6d3b13979",
+      "panelTypes": "row",
+      "title": "Runtime"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Resident set size of collector process over time",
+      "fillSpans": false,
+      "id": "eaa6b66a-62be-4aa6-8e81-67b764838dd0",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_process_memory_rss--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_process_memory_rss",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d699cea2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "RSS",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9ff783f4-8303-43ea-8a8b-e3e21f94bef3",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Process Memory RSS Over Time",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Current heap memory allocation over time",
+      "fillSpans": false,
+      "id": "178b655a-8ced-4bb0-bb61-2423da3cfcb5",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_process_runtime_heap_alloc_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_process_runtime_heap_alloc_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "8e15806b",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Heap Alloc",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ef835119-44f4-4142-be03-55f9961124b1",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Heap Alloc Bytes Over Time",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of cumulative heap allocation over time",
+      "fillSpans": false,
+      "id": "b00f2625-90f8-429d-bd01-c3fec9fba913",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_process_runtime_total_alloc_bytes--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_process_runtime_total_alloc_bytes",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "c742c49d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Total Alloc Rate",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "3cb15bca-4db6-46ec-9237-94a9517f584d",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Alloc Bytes Rate Over Time",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total system memory obtained from the OS over time",
+      "fillSpans": false,
+      "id": "807b0690-b156-4fad-ba37-c88c7c02685a",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_process_runtime_total_sys_memory_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_process_runtime_total_sys_memory_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "07965332",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Total Sys Memory",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "4228102a-f8f1-4dfb-9989-e50a94cceea9",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Sys Memory Over Time",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of CPU time consumed by the collector",
+      "fillSpans": false,
+      "id": "80a64850-dde1-48dd-9d2d-7c6e844f30ba",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_process_cpu_seconds--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_process_cpu_seconds",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "2e5c77be",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "CPU Rate",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "911d6fba-64fc-45e8-b516-8fd129e730ea",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "CPU Seconds Rate Over Time",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Collector process uptime",
+      "fillSpans": false,
+      "id": "677432ac-aca6-4e91-bc95-8f7f6aef3aea",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_process_uptime--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_process_uptime",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "6d63c5c8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Uptime Rate",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "5663a4c6-42ef-4d72-80e3-1150467af702",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Process Uptime Over Time",
+      "yAxisUnit": "s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Compare different memory metrics of the collector",
+      "fillSpans": false,
+      "id": "7c7d2f72-0443-4fea-8b26-150a73b2d150",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_process_memory_rss--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_process_memory_rss",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "314a5bff",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "RSS",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_process_runtime_heap_alloc_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_process_runtime_heap_alloc_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f4b2b45e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Heap Alloc",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_process_runtime_total_sys_memory_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_process_runtime_total_sys_memory_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "C",
+              "filters": {
+                "items": [
+                  {
+                    "id": "376a199f",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Total Sys",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "C",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "648088b9-038f-4c5a-86f9-53ccc049df28",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memory Comparison: RSS vs Heap vs Sys",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Heap allocation as percentage of total system memory",
+      "fillSpans": false,
+      "id": "8b5af7c3-8aa7-4e22-93d2-fc65e945f931",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_process_runtime_heap_alloc_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_process_runtime_heap_alloc_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "dd638e17",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "otelcol_process_runtime_total_sys_memory_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "otelcol_process_runtime_total_sys_memory_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "474d98f2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "A/B",
+              "legend": "Heap Utilization",
+              "queryName": "F1"
+            }
+          ]
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "e5c392c9-c1f3-44be-80c0-a9804630e617",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Heap Utilization (%)",
+      "yAxisUnit": "percentunit"
+    },
+    {
+      "description": "",
+      "id": "23a23b70-8ccb-46c5-aa62-755eb6e91bb8",
+      "panelTypes": "row",
+      "title": "HTTP Server"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "50th percentile of HTTP server request duration",
+      "fillSpans": false,
+      "id": "4485f4ef-6e18-4440-b4a6-7eee76004478",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http_server_duration--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http_server_duration",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p50",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "35bf1141",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p50",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "p50"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "e2040c5e-506a-427d-86ef-60c819042e3c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "HTTP Server Request Duration (p50)",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "95th percentile of HTTP server request duration",
+      "fillSpans": false,
+      "id": "90c966ee-e6f0-47aa-9595-b50c30bd5234",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http_server_duration--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http_server_duration",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p95",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "7e08713e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p95",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "p95"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "fa463f87-75f1-4339-9b72-cb8838d4eef7",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "HTTP Server Request Duration (p95)",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "99th percentile of HTTP server request duration",
+      "fillSpans": false,
+      "id": "c5a64da4-77fd-4e06-8cb5-84f7592f2f78",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http_server_duration--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http_server_duration",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p99",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "145b2e51",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p99",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "p99"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "278aeb12-4612-4157-a66f-51663ab0710e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "HTTP Server Request Duration (p99)",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "p50, p95, p99 on single chart",
+      "fillSpans": false,
+      "id": "6e0dea4d-0a95-462e-8a14-8a6c05d56197",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http_server_duration--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http_server_duration",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p50",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "c0750d07",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p50",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "p50"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http_server_duration--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http_server_duration",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p95",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "990b7724",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p95",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "p95"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http_server_duration--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http_server_duration",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p99",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "C",
+              "filters": {
+                "items": [
+                  {
+                    "id": "06ed23e4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p99",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "C",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "p99"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "2840ae61-368d-4e59-af53-4e22d204b17c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "HTTP Server Request Duration (All Percentiles)",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "50th percentile of request body size",
+      "fillSpans": false,
+      "id": "8e44cb80-b317-4910-a6b4-9263ddbbb940",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http_server_request_content_length--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http_server_request_content_length",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p50",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "25296ff3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p50",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "p50"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "aac9381b-6682-4aa8-8297-e2e5cad1439d",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "HTTP Server Request Content Length (p50)",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "95th percentile of request body size",
+      "fillSpans": false,
+      "id": "b42bd0bf-1339-4ae0-96b6-bca918d0ca1d",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http_server_request_content_length--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http_server_request_content_length",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p95",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d067e514",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p95",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "p95"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d09ade7b-e137-451f-aa9e-31964266b462",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "HTTP Server Request Content Length (p95)",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "50th percentile of response body size",
+      "fillSpans": false,
+      "id": "1ee4de36-4bfc-4c3a-993d-3999fabfc5cc",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http_server_response_content_length--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http_server_response_content_length",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p50",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "bc55c8b0",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p50",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "p50"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "fa7c8be6-1a65-48c3-9585-d800f818a0ed",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "HTTP Server Response Content Length (p50)",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "95th percentile of response body size",
+      "fillSpans": false,
+      "id": "fbdad8e2-cb5a-4157-bd17-54c6135e59a4",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http_server_response_content_length--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http_server_response_content_length",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p95",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f9c9c73d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p95",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "p95"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f8fe0326-b71c-434e-a4ae-9d2b0c322dd8",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "HTTP Server Response Content Length (p95)",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Request duration grouped by HTTP status code",
+      "fillSpans": false,
+      "id": "05c20229-2560-42bb-bd5c-7eb5645c02f6",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http_server_duration--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http_server_duration",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p50",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "884e58cd",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "http.status_code--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "http.status_code",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{http.status_code}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "p50"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "834eef7b-b9c7-4f0a-80fd-33414889980b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "HTTP Server Duration by Status Code",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Request duration grouped by HTTP method",
+      "fillSpans": false,
+      "id": "94ac54ea-a6fe-408c-b51e-f458ada146e2",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http_server_duration--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http_server_duration",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p50",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "03d763cc",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "http.method--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "http.method",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{http.method}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "p50"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9ff9ba6f-5459-416a-8744-978f7593a712",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "HTTP Server Duration by Method",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Compare request and response body sizes",
+      "fillSpans": false,
+      "id": "40eade53-6f7e-4994-85b9-1c682eb9b223",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http_server_request_content_length--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http_server_request_content_length",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p50",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "1089b7b7",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Request p50",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "p50"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http_server_response_content_length--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http_server_response_content_length",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p50",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "830b228c",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Response p50",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "p50"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6278f95a-68d5-4777-a51d-376a0faa0042",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "HTTP Content Length: Request vs Response (p50)",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of HTTP requests by status code",
+      "fillSpans": false,
+      "id": "fe40549e-7522-4423-b2a1-818d09d63b07",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "http_server_duration--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "http_server_duration",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "47bf0da3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "service.instance.id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "service.instance.id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$collector_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "http.status_code--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "http.status_code",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{http.status_code}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "count"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d29f1f1d-1c08-4434-8fca-d8887fd06f6e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "HTTP Server Request Rate",
+      "yAxisUnit": ""
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a comprehensive **98-panel** monitoring dashboard for the OpenTelemetry Collector's internal telemetry metrics.

Closes #126

## Dashboard Sections

| Section | Panels | Coverage |
|---------|--------|----------|
| **Overview** | 8 | Uptime, memory RSS, heap allocation, CPU usage |
| **Receivers** | 18 | Accepted/refused data points per receiver and transport |
| **Processors** | 22 | Accepted/refused/dropped, batch send size histograms (p50/p95/p99) |
| **Exporters** | 21 | Sent/failed, queue size, capacity, utilization formula |
| **Runtime** | 8 | Heap, RSS, total alloc rate, CPU, heap utilization formula |
| **HTTP Server** | 12 | Request duration percentiles, content length, status codes |

## Metrics Covered

- **Receivers**: `otelcol_receiver_accepted_*`, `otelcol_receiver_refused_*` (spans, metric_points, log_records)
- **Processors**: `otelcol_processor_accepted_*`, `otelcol_processor_refused_*`, `otelcol_processor_dropped_*`, `otelcol_processor_batch_*`
- **Exporters**: `otelcol_exporter_sent_*`, `otelcol_exporter_failed_*`, `otelcol_exporter_queue_*`, `otelcol_exporter_enqueue_failed_*`
- **Process**: `otelcol_process_uptime`, `otelcol_process_runtime_*`, `otelcol_process_cpu_seconds`, `otelcol_process_memory_rss`
- **HTTP**: `http_server_duration`, `http_server_request_content_length`, `http_server_response_content_length`

## Variables

- **collector_name**: Filter by `service.instance.id` to monitor specific collector instances

## Reference

Based on the [OTel Collector internal telemetry specification](https://opentelemetry.io/docs/collector/internal-telemetry/).

/claim #126