### PR TITLE
feat: add idle and active connection panels to PostgreSQL dashboard

### DIFF
--- a/postgresql/postgresql.json
+++ b/postgresql/postgresql.json
@@ -100,6 +100,24 @@
       "w": 6,
       "x": 6,
       "y": 3
+    },
+    {
+      "h": 3,
+      "i": "15cbfb3c-30cf-4b8a-b4b8-5a4126a671bd",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 21
+    },
+    {
+      "h": 3,
+      "i": "60943d29-6c94-4d45-82e6-9e763ba808cf",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 21
     }
   ],
   "name": "",
@@ -1863,6 +1881,244 @@
       "thresholds": [],
       "timePreferance": "GLOBAL_TIME",
       "title": "Table stats",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Number of idle backend connections per database",
+      "fillSpans": false,
+      "id": "15cbfb3c-30cf-4b8a-b4b8-5a4126a671bd",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "postgresql.backends--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "postgresql.backends",
+                "type": "Sum"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "ed335b00",
+                    "key": {
+                      "dataType": "string",
+                      "id": "host.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "host.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.host.name}}"
+                    ]
+                  },
+                  {
+                    "id": "20d2a4c5",
+                    "key": {
+                      "dataType": "string",
+                      "id": "postgresql.database.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "postgresql.database.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.db.name}}"
+                    ]
+                  },
+                  {
+                    "id": "04dd32a7",
+                    "key": {
+                      "dataType": "string",
+                      "id": "state--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "state",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "idle"
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "postgresql.database.name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "postgresql.database.name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{postgresql.database.name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "238f453e-000c-4722-9851-c23b5d786dba",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Idle connections per db",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "Number of active backend connections per database",
+      "fillSpans": false,
+      "id": "60943d29-6c94-4d45-82e6-9e763ba808cf",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "postgresql.backends--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "postgresql.backends",
+                "type": "Sum"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "ed335b00",
+                    "key": {
+                      "dataType": "string",
+                      "id": "host.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "host.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.host.name}}"
+                    ]
+                  },
+                  {
+                    "id": "20d2a4c5",
+                    "key": {
+                      "dataType": "string",
+                      "id": "postgresql.database.name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "postgresql.database.name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.db.name}}"
+                    ]
+                  },
+                  {
+                    "id": "36df1bf0",
+                    "key": {
+                      "dataType": "string",
+                      "id": "state--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "state",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "active"
+                  }
+                ],
+                "op": "AND"
+              },
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "postgresql.database.name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "postgresql.database.name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{postgresql.database.name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "87044efa-8354-4fee-ad18-3f627d7eaab5",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active connections per db",
       "yAxisUnit": "none"
     }
   ]


### PR DESCRIPTION
## Summary

Adds idle and active connection breakdown panels to the PostgreSQL overview dashboard.

Closes #135

## Changes

Two new panels added:
- **Idle connections per db** — `postgresql.backends` filtered by `state=idle`, grouped by database
- **Active connections per db** — `postgresql.backends` filtered by `state=active`, grouped by database

These complement the existing "Connections per db" panel which shows total connections without state breakdown.

## Why

The existing dashboard shows total connection count but doesn't distinguish between idle and active connections. This makes it difficult to identify connection pool issues (e.g., too many idle connections consuming `max_connections`).

The `postgresql.backends` metric from the OTel PostgreSQL receiver includes a `state` attribute that supports filtering by: `idle`, `active`, `idle_in_transaction`, `idle_in_transaction_aborted`, `disabled`, `fastpath_function_call`.

/claim #135