### PR TITLE
feat: add Keycloak Prometheus monitoring dashboard

### DIFF
--- a/keycloak/keycloak-prometheus-v1.json
+++ b/keycloak/keycloak-prometheus-v1.json
@@ -1,0 +1,9947 @@
+{
+  "description": "Comprehensive Keycloak monitoring dashboard using Prometheus metrics. Covers HTTP requests, authentication, token operations, JVM memory, threads, and database connection pool.",
+  "image": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxOCIgaGVpZ2h0PSIxOCIgdmlld0JveD0iMCAwIDE4IDE4Ij48cGF0aCBkPSJNMTQuNCAzLjZMMTIuNiAwSDUuNEwzLjYgMy42TDAgOWwzLjYgNS40TDUuNCAxOGg3LjJsMS44LTMuNkwxOCA5bC0zLjYtNS40eiIgZmlsbD0iIzRENEQ0RCIvPjxwYXRoIGQ9Ik0xMi4xNSA0LjVMOSAyLjcgNS44NSA0LjUgNC41IDcuNjV2Mi43bDEuMzUgMy4xNUw5IDE1LjNsMy4xNS0xLjggMS4zNS0zLjE1di0yLjdMMTIuMTUgNC41eiIgZmlsbD0iI0UyRTJFMiIvPjxwYXRoIGQ9Ik05IDYuM0w3LjIgNy42NVYxMC4zNUw5IDExLjdsMS44LTEuMzVWNy42NUw5IDYuM3oiIGZpbGw9IiM0RDRENEQiLz48L3N2Zz4=",
+  "layout": [
+    {
+      "h": 1,
+      "i": "87ad6dd8-cbca-499f-818a-148d392587e6",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 4,
+      "i": "bcc21780-56da-43f5-9240-d0ba1173e673",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 0,
+      "y": 1
+    },
+    {
+      "h": 4,
+      "i": "641f7a06-c36a-4377-b50f-cb6a8c1d4c66",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 3,
+      "y": 1
+    },
+    {
+      "h": 4,
+      "i": "379e6d87-7792-4c91-99cd-d7480208e37a",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 6,
+      "y": 1
+    },
+    {
+      "h": 4,
+      "i": "22555879-016d-4715-9978-4643ca8a51f1",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 9,
+      "y": 1
+    },
+    {
+      "h": 1,
+      "i": "f454806d-36dc-458b-b78d-37e47fe03d94",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 5
+    },
+    {
+      "h": 6,
+      "i": "9f0d4d13-da36-438f-979d-d02cb5464da1",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 6
+    },
+    {
+      "h": 6,
+      "i": "07ec1613-b053-40ff-8599-d2804bb828dc",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 6
+    },
+    {
+      "h": 6,
+      "i": "e1bfd169-c286-4da4-b836-96167f5c7b1c",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 12
+    },
+    {
+      "h": 4,
+      "i": "654e70cb-010d-47e8-9a51-87944ef5e07a",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 18
+    },
+    {
+      "h": 4,
+      "i": "6252ffbd-6bb0-4608-95b2-a2c8586e1476",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 18
+    },
+    {
+      "h": 4,
+      "i": "d86e258a-fe7a-4edb-b878-93e715860c05",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 18
+    },
+    {
+      "h": 6,
+      "i": "e7a809fe-8be7-45ad-af62-bee658a5a1e0",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 22
+    },
+    {
+      "h": 6,
+      "i": "8f0e28e8-6f9a-4165-9fdc-cdae1574e484",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 22
+    },
+    {
+      "h": 1,
+      "i": "0d7e1ab5-9d13-4f84-9fdf-2d22b8d29b77",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 28
+    },
+    {
+      "h": 6,
+      "i": "496c5e38-6000-491a-bf9f-476d63cbd8c0",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 29
+    },
+    {
+      "h": 6,
+      "i": "6b2b1c2e-338d-4b49-a99b-b478a9e710bd",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 29
+    },
+    {
+      "h": 4,
+      "i": "d2c72e79-86f8-4359-8bdb-59eacb94cfab",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 35
+    },
+    {
+      "h": 4,
+      "i": "ec291f42-df4e-4ed1-9968-2ae9ecd94d61",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 35
+    },
+    {
+      "h": 4,
+      "i": "a032c634-2d61-4401-b3e4-ba082a8bd282",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 35
+    },
+    {
+      "h": 6,
+      "i": "5e51c913-2453-45eb-addc-e47581488771",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 39
+    },
+    {
+      "h": 6,
+      "i": "8b1634dc-8d26-4980-af0d-cfbf411f9b7c",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 39
+    },
+    {
+      "h": 6,
+      "i": "8151962f-3304-4ad3-9f61-ea9c614ff4a3",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 45
+    },
+    {
+      "h": 6,
+      "i": "0e9d3e35-275f-40ce-9611-ec6a6412191c",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 45
+    },
+    {
+      "h": 1,
+      "i": "2a28e6c8-ee67-49c6-bf04-dd7a58591fdf",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 51
+    },
+    {
+      "h": 6,
+      "i": "e5f73a76-d1b9-4a22-b966-01bcba2fd356",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 52
+    },
+    {
+      "h": 6,
+      "i": "07a27e9d-a3a9-4489-a752-5274a52b6822",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 52
+    },
+    {
+      "h": 6,
+      "i": "79d4cb5d-66da-4824-99f7-e88ed5a6fe89",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 58
+    },
+    {
+      "h": 6,
+      "i": "dbfa7b7c-da98-41cd-aae7-30ecd6857a23",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 58
+    },
+    {
+      "h": 6,
+      "i": "f5dc11d9-036a-42ee-8829-60ccf7170a29",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 64
+    },
+    {
+      "h": 6,
+      "i": "a8863425-4844-4587-a515-0a8c0dc858c2",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 64
+    },
+    {
+      "h": 4,
+      "i": "97893498-faf1-4397-b09a-b4f559d8bfc0",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 64
+    },
+    {
+      "h": 1,
+      "i": "99fd5be0-3298-425e-a466-98a65ea5ec49",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 70
+    },
+    {
+      "h": 6,
+      "i": "3976db26-d6ca-45fd-acf3-1f3dafb0f930",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 71
+    },
+    {
+      "h": 6,
+      "i": "2e32a731-d96b-4aa7-a594-f1e38bbf3d2d",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 71
+    },
+    {
+      "h": 6,
+      "i": "7ff16bde-ea38-4687-935f-098e2b355114",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 77
+    },
+    {
+      "h": 4,
+      "i": "1e944138-1d9b-4b7b-8ca7-04eb02937791",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 83
+    },
+    {
+      "h": 6,
+      "i": "4e002618-2ee9-43d0-bc74-169fb9749643",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 87
+    },
+    {
+      "h": 6,
+      "i": "487eb997-d868-41fc-8227-044e41cd1068",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 87
+    },
+    {
+      "h": 6,
+      "i": "66ecf100-aa5f-4f42-a4b9-11f0a51acfdb",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 93
+    },
+    {
+      "h": 1,
+      "i": "fdbe9a61-43dd-492b-bc92-6550aabc49db",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 99
+    },
+    {
+      "h": 6,
+      "i": "83f3cb4f-7339-40f5-8379-feffcbc25d4b",
+      "moved": false,
+      "static": false,
+      "w": 8,
+      "x": 0,
+      "y": 100
+    },
+    {
+      "h": 6,
+      "i": "9d91eb90-eea7-4c91-a920-868d4ebc1dae",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 100
+    },
+    {
+      "h": 4,
+      "i": "1f934832-c120-4979-918c-55b773f15dca",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 106
+    },
+    {
+      "h": 4,
+      "i": "feabfee8-9301-45b5-97cf-c605eb8bc37e",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 106
+    },
+    {
+      "h": 4,
+      "i": "27623a08-97bf-4dc2-9b41-317627cb5352",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 106
+    },
+    {
+      "h": 1,
+      "i": "4df81c88-6439-40a3-a79b-82d57bad4886",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 110
+    },
+    {
+      "h": 6,
+      "i": "402ad832-d387-47cf-bafe-6c4397138de6",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 111
+    },
+    {
+      "h": 6,
+      "i": "d2c786f2-5bef-4bd0-b2ca-40a7b0f7aa01",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 111
+    },
+    {
+      "h": 6,
+      "i": "507293f1-746f-4804-ab1b-c4a77f7810b8",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 111
+    },
+    {
+      "h": 4,
+      "i": "0656b8a4-2c5c-4395-bfdf-942d990a524d",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 117
+    },
+    {
+      "h": 4,
+      "i": "02a69475-4fca-4d9a-beb4-592345b25bc3",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 117
+    },
+    {
+      "h": 1,
+      "i": "7155f0ab-1b97-46fc-ae43-9fbf5a4dee67",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 121
+    },
+    {
+      "h": 6,
+      "i": "b36c1748-b212-4099-b2d0-844df29eccd4",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 122
+    },
+    {
+      "h": 6,
+      "i": "a46a4ee9-60c9-4d4d-8523-a51b696613aa",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 122
+    },
+    {
+      "h": 4,
+      "i": "643d6ece-a540-488c-be40-fa426e9aa920",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 122
+    }
+  ],
+  "panelMap": {
+    "87ad6dd8-cbca-499f-818a-148d392587e6": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 4,
+          "i": "bcc21780-56da-43f5-9240-d0ba1173e673",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 0,
+          "y": 101
+        },
+        {
+          "h": 4,
+          "i": "641f7a06-c36a-4377-b50f-cb6a8c1d4c66",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 3,
+          "y": 101
+        },
+        {
+          "h": 4,
+          "i": "379e6d87-7792-4c91-99cd-d7480208e37a",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 6,
+          "y": 101
+        },
+        {
+          "h": 4,
+          "i": "22555879-016d-4715-9978-4643ca8a51f1",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 9,
+          "y": 101
+        }
+      ]
+    },
+    "f454806d-36dc-458b-b78d-37e47fe03d94": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "9f0d4d13-da36-438f-979d-d02cb5464da1",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 106
+        },
+        {
+          "h": 6,
+          "i": "07ec1613-b053-40ff-8599-d2804bb828dc",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 106
+        },
+        {
+          "h": 6,
+          "i": "e1bfd169-c286-4da4-b836-96167f5c7b1c",
+          "moved": false,
+          "static": false,
+          "w": 12,
+          "x": 0,
+          "y": 112
+        },
+        {
+          "h": 4,
+          "i": "654e70cb-010d-47e8-9a51-87944ef5e07a",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 0,
+          "y": 118
+        },
+        {
+          "h": 4,
+          "i": "6252ffbd-6bb0-4608-95b2-a2c8586e1476",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 4,
+          "y": 118
+        },
+        {
+          "h": 4,
+          "i": "d86e258a-fe7a-4edb-b878-93e715860c05",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 8,
+          "y": 118
+        },
+        {
+          "h": 6,
+          "i": "e7a809fe-8be7-45ad-af62-bee658a5a1e0",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 122
+        },
+        {
+          "h": 6,
+          "i": "8f0e28e8-6f9a-4165-9fdc-cdae1574e484",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 122
+        }
+      ]
+    },
+    "0d7e1ab5-9d13-4f84-9fdf-2d22b8d29b77": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "496c5e38-6000-491a-bf9f-476d63cbd8c0",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 129
+        },
+        {
+          "h": 6,
+          "i": "6b2b1c2e-338d-4b49-a99b-b478a9e710bd",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 129
+        },
+        {
+          "h": 4,
+          "i": "d2c72e79-86f8-4359-8bdb-59eacb94cfab",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 0,
+          "y": 135
+        },
+        {
+          "h": 4,
+          "i": "ec291f42-df4e-4ed1-9968-2ae9ecd94d61",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 4,
+          "y": 135
+        },
+        {
+          "h": 4,
+          "i": "a032c634-2d61-4401-b3e4-ba082a8bd282",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 8,
+          "y": 135
+        },
+        {
+          "h": 6,
+          "i": "5e51c913-2453-45eb-addc-e47581488771",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 139
+        },
+        {
+          "h": 6,
+          "i": "8b1634dc-8d26-4980-af0d-cfbf411f9b7c",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 139
+        },
+        {
+          "h": 6,
+          "i": "8151962f-3304-4ad3-9f61-ea9c614ff4a3",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 145
+        },
+        {
+          "h": 6,
+          "i": "0e9d3e35-275f-40ce-9611-ec6a6412191c",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 145
+        }
+      ]
+    },
+    "2a28e6c8-ee67-49c6-bf04-dd7a58591fdf": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "e5f73a76-d1b9-4a22-b966-01bcba2fd356",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 152
+        },
+        {
+          "h": 6,
+          "i": "07a27e9d-a3a9-4489-a752-5274a52b6822",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 152
+        },
+        {
+          "h": 6,
+          "i": "79d4cb5d-66da-4824-99f7-e88ed5a6fe89",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 158
+        },
+        {
+          "h": 6,
+          "i": "dbfa7b7c-da98-41cd-aae7-30ecd6857a23",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 158
+        },
+        {
+          "h": 6,
+          "i": "f5dc11d9-036a-42ee-8829-60ccf7170a29",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 164
+        },
+        {
+          "h": 6,
+          "i": "a8863425-4844-4587-a515-0a8c0dc858c2",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 164
+        },
+        {
+          "h": 4,
+          "i": "97893498-faf1-4397-b09a-b4f559d8bfc0",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 4,
+          "y": 164
+        }
+      ]
+    },
+    "99fd5be0-3298-425e-a466-98a65ea5ec49": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "3976db26-d6ca-45fd-acf3-1f3dafb0f930",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 171
+        },
+        {
+          "h": 6,
+          "i": "2e32a731-d96b-4aa7-a594-f1e38bbf3d2d",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 171
+        },
+        {
+          "h": 6,
+          "i": "7ff16bde-ea38-4687-935f-098e2b355114",
+          "moved": false,
+          "static": false,
+          "w": 12,
+          "x": 0,
+          "y": 177
+        },
+        {
+          "h": 4,
+          "i": "1e944138-1d9b-4b7b-8ca7-04eb02937791",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 0,
+          "y": 183
+        },
+        {
+          "h": 6,
+          "i": "4e002618-2ee9-43d0-bc74-169fb9749643",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 187
+        },
+        {
+          "h": 6,
+          "i": "487eb997-d868-41fc-8227-044e41cd1068",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 187
+        },
+        {
+          "h": 6,
+          "i": "66ecf100-aa5f-4f42-a4b9-11f0a51acfdb",
+          "moved": false,
+          "static": false,
+          "w": 12,
+          "x": 0,
+          "y": 193
+        }
+      ]
+    },
+    "fdbe9a61-43dd-492b-bc92-6550aabc49db": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "83f3cb4f-7339-40f5-8379-feffcbc25d4b",
+          "moved": false,
+          "static": false,
+          "w": 8,
+          "x": 0,
+          "y": 200
+        },
+        {
+          "h": 6,
+          "i": "9d91eb90-eea7-4c91-a920-868d4ebc1dae",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 8,
+          "y": 200
+        },
+        {
+          "h": 4,
+          "i": "1f934832-c120-4979-918c-55b773f15dca",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 0,
+          "y": 206
+        },
+        {
+          "h": 4,
+          "i": "feabfee8-9301-45b5-97cf-c605eb8bc37e",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 4,
+          "y": 206
+        },
+        {
+          "h": 4,
+          "i": "27623a08-97bf-4dc2-9b41-317627cb5352",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 8,
+          "y": 206
+        }
+      ]
+    },
+    "4df81c88-6439-40a3-a79b-82d57bad4886": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "402ad832-d387-47cf-bafe-6c4397138de6",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 0,
+          "y": 211
+        },
+        {
+          "h": 6,
+          "i": "d2c786f2-5bef-4bd0-b2ca-40a7b0f7aa01",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 4,
+          "y": 211
+        },
+        {
+          "h": 6,
+          "i": "507293f1-746f-4804-ab1b-c4a77f7810b8",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 8,
+          "y": 211
+        },
+        {
+          "h": 4,
+          "i": "0656b8a4-2c5c-4395-bfdf-942d990a524d",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 217
+        },
+        {
+          "h": 4,
+          "i": "02a69475-4fca-4d9a-beb4-592345b25bc3",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 217
+        }
+      ]
+    },
+    "7155f0ab-1b97-46fc-ae43-9fbf5a4dee67": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "b36c1748-b212-4099-b2d0-844df29eccd4",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 222
+        },
+        {
+          "h": 6,
+          "i": "a46a4ee9-60c9-4d4d-8523-a51b696613aa",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 222
+        },
+        {
+          "h": 4,
+          "i": "643d6ece-a540-488c-be40-fa426e9aa920",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 4,
+          "y": 222
+        }
+      ]
+    }
+  },
+  "tags": [
+    "keycloak",
+    "prometheus",
+    "iam",
+    "authentication"
+  ],
+  "title": "Keycloak Monitoring (Prometheus)",
+  "uploadedGrafana": false,
+  "variables": {
+    "d396e2e1-83d7-41ac-8a15-4881278fd102": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "Kubernetes Namespace",
+      "id": "d396e2e1-83d7-41ac-8a15-4881278fd102",
+      "key": "d396e2e1-83d7-41ac-8a15-4881278fd102",
+      "modificationUUID": "e307282b-02b0-4cc6-a16d-d3eb42f0321e",
+      "multiSelect": false,
+      "name": "namespace",
+      "order": 0,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'namespace'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name like '%keycloak%'",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "34077934-8d6c-4b7c-9a9a-263b24ae3a04": {
+      "allSelected": false,
+      "customValue": "keycloak",
+      "description": "Keycloak job label",
+      "id": "34077934-8d6c-4b7c-9a9a-263b24ae3a04",
+      "key": "34077934-8d6c-4b7c-9a9a-263b24ae3a04",
+      "modificationUUID": "4301c72b-8213-4bb9-a07c-8a50c5bb0b8d",
+      "multiSelect": false,
+      "name": "job",
+      "order": 1,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'job'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name like '%keycloak%'",
+      "showALLOption": false,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "b2d0b990-36be-489f-8c6f-efe385ee34a3": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Keycloak instance",
+      "id": "b2d0b990-36be-489f-8c6f-efe385ee34a3",
+      "key": "b2d0b990-36be-489f-8c6f-efe385ee34a3",
+      "modificationUUID": "1e37cceb-0660-4781-ab83-8722f761ec10",
+      "multiSelect": true,
+      "name": "instance",
+      "order": 2,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'instance'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name like '%keycloak%'",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "version": "v4",
+  "widgets": [
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "87ad6dd8-cbca-499f-818a-148d392587e6",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "row",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "75b4b84e-f4a1-4313-b8bf-3b398a992d12",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "General Overview",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "f454806d-36dc-458b-b78d-37e47fe03d94",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "row",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6ec7189d-ba07-4778-acd1-ed66e97febaa",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "HTTP Requests",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "0d7e1ab5-9d13-4f84-9fdf-2d22b8d29b77",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "row",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "4f89c36f-e31f-4825-a615-0afcf3808d5a",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Authentication",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "2a28e6c8-ee67-49c6-bf04-dd7a58591fdf",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "row",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "5e6f7b72-c783-42d2-9127-be657725cec7",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Token Operations",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "99fd5be0-3298-425e-a466-98a65ea5ec49",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "row",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "904be230-310e-439b-a8b7-15da7ab469c9",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "JVM Memory",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "fdbe9a61-43dd-492b-bc92-6550aabc49db",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "row",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "e2855968-8238-4467-9699-d3e34406c6cd",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "JVM Threads",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "4df81c88-6439-40a3-a79b-82d57bad4886",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "row",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "68b23f34-7dd3-4cc0-b1bc-3d012ff6e8c9",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Database Connection Pool",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "",
+      "fillSpans": false,
+      "id": "7155f0ab-1b97-46fc-ae43-9fbf5a4dee67",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "row",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f8c87bec-af33-4064-b5e6-14d4be923494",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "System Resources",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Process uptime in seconds",
+      "fillSpans": false,
+      "id": "bcc21780-56da-43f5-9240-d0ba1173e673",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "process_uptime_seconds--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "process_uptime_seconds",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "5bdd5388",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "7ded486d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c7fa532e-a0ab-40b7-9914-ff3d1f9704d1",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "process_uptime_seconds{job=\"$job\", instance=\"$instance\"}"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Uptime",
+      "yAxisUnit": "s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "CPU usage by the Keycloak process (0-1)",
+      "fillSpans": false,
+      "id": "641f7a06-c36a-4377-b50f-cb6a8c1d4c66",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "process_cpu_usage--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "process_cpu_usage",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "4071c068",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "157f474c",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d7df05e5-5eb2-496f-9356-dcffcccf4851",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "process_cpu_usage{job=\"$job\", instance=\"$instance\"}"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Process CPU Usage",
+      "yAxisUnit": "percentunit"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "System-wide CPU usage (0-1)",
+      "fillSpans": false,
+      "id": "379e6d87-7792-4c91-99cd-d7480208e37a",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "system_cpu_usage--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "system_cpu_usage",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f34d348d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "362c4c6e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "e7531ab4-f366-4c7f-9eb6-bc0c86b96a13",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "system_cpu_usage{job=\"$job\", instance=\"$instance\"}"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "System CPU Usage",
+      "yAxisUnit": "percentunit"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Current number of live JVM threads",
+      "fillSpans": false,
+      "id": "22555879-016d-4715-9978-4643ca8a51f1",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm_threads_live_threads--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm_threads_live_threads",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "a792e6f2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "f8a42556",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "3eba5abd-7ac2-4b07-94e4-b69c406a505f",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "jvm_threads_live_threads{job=\"$job\", instance=\"$instance\"}"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Live Threads",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "HTTP request rate by status code",
+      "fillSpans": false,
+      "id": "9f0d4d13-da36-438f-979d-d02cb5464da1",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "keycloak_request_duration_seconds_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "keycloak_request_duration_seconds_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "0c7d3cd9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "e0d3004d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "status--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "status",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{status}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "082c3b66-e2b6-46d0-924e-c11adb5c3610",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "sum(rate(keycloak_request_duration_seconds_count{job=\"$job\", instance=\"$instance\"}[5m])) by (status)"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Rate",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "HTTP error request rate by status code",
+      "fillSpans": false,
+      "id": "07ec1613-b053-40ff-8599-d2804bb828dc",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "keycloak_request_duration_seconds_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "keycloak_request_duration_seconds_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "6a7d818b",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "95d971ff",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  },
+                  {
+                    "id": "1cba5aad",
+                    "key": {
+                      "dataType": "string",
+                      "id": "status--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "status",
+                      "type": "tag"
+                    },
+                    "op": "contains",
+                    "value": "4xx"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "status--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "status",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{status}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "90ad36d6-1fa0-4ef8-b943-93a9db2a7729",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "sum(rate(keycloak_request_duration_seconds_count{job=\"$job\", instance=\"$instance\", status=~\"4..|5..\"}[5m])) by (status)"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Errors (4xx/5xx)",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "HTTP request latency percentiles",
+      "fillSpans": false,
+      "id": "e1bfd169-c286-4da4-b836-96167f5c7b1c",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "keycloak_request_duration_seconds_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "keycloak_request_duration_seconds_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "6268f964",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "4e3e0bff",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p50",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "keycloak_request_duration_seconds_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "keycloak_request_duration_seconds_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "5497c6dc",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "0ff19b6f",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p95",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "keycloak_request_duration_seconds_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "keycloak_request_duration_seconds_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "C",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d2a89760",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "94d9f3a6",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p99",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "C",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0ca8a522-844e-4707-be7d-79823d7896d4",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "histogram_quantile(0.95, sum(rate(keycloak_request_duration_seconds_bucket{job=\"$job\", instance=\"$instance\"}[5m])) by (le))"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Duration (p50/p95/p99)",
+      "yAxisUnit": "s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total HTTP request count",
+      "fillSpans": false,
+      "id": "654e70cb-010d-47e8-9a51-87944ef5e07a",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "keycloak_request_duration_seconds_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "keycloak_request_duration_seconds_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "cf62d17f",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "3285fe30",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "2c14ec51-0fef-4cb2-a777-702e8c496d08",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "sum(keycloak_request_duration_seconds_count{job=\"$job\", instance=\"$instance\"})"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Requests",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Percentage of requests returning 4xx or 5xx",
+      "fillSpans": false,
+      "id": "6252ffbd-6bb0-4608-95b2-a2c8586e1476",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "keycloak_request_duration_seconds_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "keycloak_request_duration_seconds_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "ff1cdcac",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "1f5a3be3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  },
+                  {
+                    "id": "e5664a28",
+                    "key": {
+                      "dataType": "string",
+                      "id": "status--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "status",
+                      "type": "tag"
+                    },
+                    "op": "contains",
+                    "value": "4xx"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a94d5b5d-283b-4c3e-9cb8-fcc199cf7541",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "100 * sum(rate(keycloak_request_duration_seconds_count{job=\"$job\", instance=\"$instance\", status=~\"4..|5..\"}[5m])) / sum(rate(keycloak_request_duration_seconds_count{job=\"$job\", instance=\"$instance\"}[5m]))"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Error Rate %",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Average HTTP request duration",
+      "fillSpans": false,
+      "id": "d86e258a-fe7a-4edb-b878-93e715860c05",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "keycloak_request_duration_seconds_sum--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "keycloak_request_duration_seconds_sum",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "69af62cf",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "ba4f02cc",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b649e51a-5af1-4766-b7a6-e4d1f83f1816",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "sum(rate(keycloak_request_duration_seconds_sum{job=\"$job\", instance=\"$instance\"}[5m])) / sum(rate(keycloak_request_duration_seconds_count{job=\"$job\", instance=\"$instance\"}[5m]))"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Avg Request Duration",
+      "yAxisUnit": "s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "HTTP request rate broken down by URI endpoint",
+      "fillSpans": false,
+      "id": "e7a809fe-8be7-45ad-af62-bee658a5a1e0",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "keycloak_request_duration_seconds_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "keycloak_request_duration_seconds_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "907c3d1b",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "067cdd5a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "uri--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "uri",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{uri}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b6644f21-6372-4248-b59c-2bbe0a4be82b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "sum(rate(keycloak_request_duration_seconds_count{job=\"$job\", instance=\"$instance\"}[5m])) by (uri)"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Rate by URI",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "HTTP request rate broken down by HTTP method",
+      "fillSpans": false,
+      "id": "8f0e28e8-6f9a-4165-9fdc-cdae1574e484",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "keycloak_request_duration_seconds_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "keycloak_request_duration_seconds_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "609979bd",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "18e2614a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "method--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "method",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{method}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "69f4d990-b2de-4f2d-bf0b-f67f57d43a35",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "sum(rate(keycloak_request_duration_seconds_count{job=\"$job\", instance=\"$instance\"}[5m])) by (method)"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Rate by Method",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Login rate by realm",
+      "fillSpans": false,
+      "id": "496c5e38-6000-491a-bf9f-476d63cbd8c0",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "keycloak_logins--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "keycloak_logins",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "47f52817",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "9313290d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "realm--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "realm",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{realm}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8a73b8c9-23dc-46ea-9b28-2da494e37732",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "sum(rate(keycloak_logins{job=\"$job\", instance=\"$instance\"}[5m])) by (realm)"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Successful Logins",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Login error rate by realm and error type",
+      "fillSpans": false,
+      "id": "6b2b1c2e-338d-4b49-a99b-b478a9e710bd",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "keycloak_login_errors--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "keycloak_login_errors",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "83633c19",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "a06fa99c",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "realm--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "realm",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "error--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "error",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{realm}} - {{error}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "dfd8c680-ae41-4ec4-8235-cca8017c29ad",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "sum(rate(keycloak_login_errors{job=\"$job\", instance=\"$instance\"}[5m])) by (realm, error)"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Failed Logins",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Percentage of successful logins",
+      "fillSpans": false,
+      "id": "d2c72e79-86f8-4359-8bdb-59eacb94cfab",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "keycloak_logins--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "keycloak_logins",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "397f4510",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "157e5dca",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9bcceefc-6c90-4fdb-bdee-4e236a994340",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "100 * sum(rate(keycloak_logins{job=\"$job\", instance=\"$instance\"}[5m])) / (sum(rate(keycloak_logins{job=\"$job\", instance=\"$instance\"}[5m])) + sum(rate(keycloak_login_errors{job=\"$job\", instance=\"$instance\"}[5m])))"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Login Success Rate %",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total successful login count",
+      "fillSpans": false,
+      "id": "ec291f42-df4e-4ed1-9968-2ae9ecd94d61",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "keycloak_logins--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "keycloak_logins",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b8cf4351",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "c00f1040",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0280e1d4-14a3-49f0-83f3-70755079136d",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "sum(keycloak_logins{job=\"$job\", instance=\"$instance\"})"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Logins",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total failed login count",
+      "fillSpans": false,
+      "id": "a032c634-2d61-4401-b3e4-ba082a8bd282",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "keycloak_login_errors--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "keycloak_login_errors",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d9cd302c",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "4e97442c",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8be51c44-97d3-4f6b-a881-85578e07411e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "sum(keycloak_login_errors{job=\"$job\", instance=\"$instance\"})"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Login Errors",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "User registration rate by realm",
+      "fillSpans": false,
+      "id": "5e51c913-2453-45eb-addc-e47581488771",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "keycloak_registrations--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "keycloak_registrations",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "128d0483",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "066ea3e4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "realm--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "realm",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{realm}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f82ad8f8-b340-4965-8ce0-e0f82b4774a4",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "sum(rate(keycloak_registrations{job=\"$job\", instance=\"$instance\"}[5m])) by (realm)"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Registrations",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "User registration error rate",
+      "fillSpans": false,
+      "id": "8b1634dc-8d26-4980-af0d-cfbf411f9b7c",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "keycloak_registrations_errors--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "keycloak_registrations_errors",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "0ff7b446",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "67db99e1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "realm--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "realm",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{realm}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "49a0e017-4ca4-4c35-96c5-9ed8d792d73d",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "sum(rate(keycloak_registrations_errors{job=\"$job\", instance=\"$instance\"}[5m])) by (realm)"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Registration Errors",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Login rate broken down by identity provider",
+      "fillSpans": false,
+      "id": "8151962f-3304-4ad3-9f61-ea9c614ff4a3",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "keycloak_logins--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "keycloak_logins",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "1f1041d3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "ebc19568",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "provider--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "provider",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{provider}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "88bbc3ff-092d-4828-add2-a7ed79b6504f",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "sum(rate(keycloak_logins{job=\"$job\", instance=\"$instance\"}[5m])) by (provider)"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Login Rate by Provider",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Login rate broken down by client_id",
+      "fillSpans": false,
+      "id": "0e9d3e35-275f-40ce-9611-ec6a6412191c",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "keycloak_logins--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "keycloak_logins",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "c90bf402",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "362c9f38",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "client_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "client_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{client_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "40139c95-6529-4b80-b6c3-5ffbae2fe6de",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "sum(rate(keycloak_logins{job=\"$job\", instance=\"$instance\"}[5m])) by (client_id)"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Login Rate by Client",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of token refresh operations by realm",
+      "fillSpans": false,
+      "id": "e5f73a76-d1b9-4a22-b966-01bcba2fd356",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "keycloak_refresh_tokens--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "keycloak_refresh_tokens",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "0922db37",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "9249bda4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "realm--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "realm",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{realm}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d2d80ae9-458e-477e-b4a3-0b75723f4723",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "sum(rate(keycloak_refresh_tokens{job=\"$job\", instance=\"$instance\"}[5m])) by (realm)"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Token Refresh Rate",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of token refresh failures by realm",
+      "fillSpans": false,
+      "id": "07a27e9d-a3a9-4489-a752-5274a52b6822",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "keycloak_refresh_tokens_errors--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "keycloak_refresh_tokens_errors",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "55bc929d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "fc844700",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "realm--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "realm",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{realm}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8f552907-26bf-4da4-a856-9b5c4f380bb3",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "sum(rate(keycloak_refresh_tokens_errors{job=\"$job\", instance=\"$instance\"}[5m])) by (realm)"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Token Refresh Errors",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Authorization code exchange rate by realm",
+      "fillSpans": false,
+      "id": "79d4cb5d-66da-4824-99f7-e88ed5a6fe89",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "keycloak_code_to_tokens--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "keycloak_code_to_tokens",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "a6955433",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "0743166a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "realm--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "realm",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{realm}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8d708e9d-8342-4c6f-ab09-3df84481974b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "sum(rate(keycloak_code_to_tokens{job=\"$job\", instance=\"$instance\"}[5m])) by (realm)"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Code-to-Token Exchanges",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Authorization code exchange error rate",
+      "fillSpans": false,
+      "id": "dbfa7b7c-da98-41cd-aae7-30ecd6857a23",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "keycloak_code_to_token_errors--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "keycloak_code_to_token_errors",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "3cc72e3b",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "527e6540",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "realm--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "realm",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{realm}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "3e8a6bf7-51e4-4226-b1e4-c4a40699b878",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "sum(rate(keycloak_code_to_token_errors{job=\"$job\", instance=\"$instance\"}[5m])) by (realm)"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Code-to-Token Errors",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Client credential grant login rate by realm",
+      "fillSpans": false,
+      "id": "f5dc11d9-036a-42ee-8829-60ccf7170a29",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "keycloak_client_logins--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "keycloak_client_logins",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "73fe71e7",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "38025628",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "realm--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "realm",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{realm}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "faf9da61-e3b3-4222-b482-154fd5a6c8b9",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "sum(rate(keycloak_client_logins{job=\"$job\", instance=\"$instance\"}[5m])) by (realm)"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Client Credential Logins",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Client credential login error rate by realm",
+      "fillSpans": false,
+      "id": "a8863425-4844-4587-a515-0a8c0dc858c2",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "keycloak_client_login_errors--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "keycloak_client_login_errors",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "59ea3a59",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "bb395a16",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "realm--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "realm",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{realm}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0ce078c4-3174-49c5-9d6d-e41de126838f",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "sum(rate(keycloak_client_login_errors{job=\"$job\", instance=\"$instance\"}[5m])) by (realm)"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Client Login Errors",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Percentage of successful token refresh operations",
+      "fillSpans": false,
+      "id": "97893498-faf1-4397-b09a-b4f559d8bfc0",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "keycloak_refresh_tokens--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "keycloak_refresh_tokens",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "5de53ee8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "6a86c989",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9b0da6f0-5034-4bb6-9b2f-971a69bb8fe5",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "100 * sum(rate(keycloak_refresh_tokens{job=\"$job\", instance=\"$instance\"}[5m])) / (sum(rate(keycloak_refresh_tokens{job=\"$job\", instance=\"$instance\"}[5m])) + sum(rate(keycloak_refresh_tokens_errors{job=\"$job\", instance=\"$instance\"}[5m])))"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Token Success Rate %",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "JVM heap memory usage over time",
+      "fillSpans": false,
+      "id": "3976db26-d6ca-45fd-acf3-1f3dafb0f930",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm_memory_used_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm_memory_used_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "3c3db5c8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "4bcfc9d3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  },
+                  {
+                    "id": "9ab5e743",
+                    "key": {
+                      "dataType": "string",
+                      "id": "area--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "area",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "heap"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "heap used",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "1459cf41-832d-40a5-8ac7-8d331a1f3630",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "sum(jvm_memory_used_bytes{job=\"$job\", instance=\"$instance\", area=\"heap\"})"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Heap Memory Used",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "JVM non-heap memory usage over time",
+      "fillSpans": false,
+      "id": "2e32a731-d96b-4aa7-a594-f1e38bbf3d2d",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm_memory_used_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm_memory_used_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "149fbdbe",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "19ca08ec",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  },
+                  {
+                    "id": "ce0da710",
+                    "key": {
+                      "dataType": "string",
+                      "id": "area--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "area",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "nonheap"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "non-heap used",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d30c0391-6ade-44ea-a1ae-b3c13da05d05",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "sum(jvm_memory_used_bytes{job=\"$job\", instance=\"$instance\", area=\"nonheap\"})"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Non-Heap Memory Used",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "JVM memory used, committed, and max compared",
+      "fillSpans": false,
+      "id": "7ff16bde-ea38-4687-935f-098e2b355114",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm_memory_used_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm_memory_used_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "98e27929",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "0f3986bf",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "used",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm_memory_max_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm_memory_max_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "09e5e278",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "21e33824",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "max",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm_memory_committed_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm_memory_committed_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "C",
+              "filters": {
+                "items": [
+                  {
+                    "id": "34d315dc",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "3b3e0c68",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "committed",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "C",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8ad9d30b-e914-49d1-b129-84807dffca7e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "sum(jvm_memory_used_bytes{job=\"$job\", instance=\"$instance\"})"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memory Used vs Max vs Committed",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "JVM heap memory utilization percentage",
+      "fillSpans": false,
+      "id": "1e944138-1d9b-4b7b-8ca7-04eb02937791",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm_memory_used_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm_memory_used_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f1694ae6",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "bf4a70da",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  },
+                  {
+                    "id": "e92f7b82",
+                    "key": {
+                      "dataType": "string",
+                      "id": "area--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "area",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "heap"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9e3353ce-11d2-4dcd-b87e-c8830c303f9d",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "100 * sum(jvm_memory_used_bytes{job=\"$job\", instance=\"$instance\", area=\"heap\"}) / sum(jvm_memory_max_bytes{job=\"$job\", instance=\"$instance\", area=\"heap\"})"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Heap Used %",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of garbage collection pauses by cause",
+      "fillSpans": false,
+      "id": "4e002618-2ee9-43d0-bc74-169fb9749643",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm_gc_pause_seconds_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm_gc_pause_seconds_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "04585a5e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "3e61cd58",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "cause--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "cause",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "action--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "action",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{cause}} - {{action}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8a779374-9284-446d-834b-19353a737ff0",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "sum(rate(jvm_gc_pause_seconds_count{job=\"$job\", instance=\"$instance\"}[5m])) by (cause, action)"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "GC Pause Rate",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total GC pause time per second by cause",
+      "fillSpans": false,
+      "id": "487eb997-d868-41fc-8227-044e41cd1068",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm_gc_pause_seconds_sum--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm_gc_pause_seconds_sum",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "2462f813",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "c05125e6",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "cause--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "cause",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{cause}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "1cd49bff-5bc9-49e3-a796-f4af5376da94",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "sum(rate(jvm_gc_pause_seconds_sum{job=\"$job\", instance=\"$instance\"}[5m])) by (cause)"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "GC Pause Duration",
+      "yAxisUnit": "s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "JVM memory usage broken down by pool",
+      "fillSpans": false,
+      "id": "66ecf100-aa5f-4f42-a4b9-11f0a51acfdb",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm_memory_used_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm_memory_used_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "81a34bf4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "22d85906",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "78694b2f-601c-48c7-ad4b-589d9f03cfb9",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "jvm_memory_used_bytes{job=\"$job\", instance=\"$instance\"}"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memory Pool Usage",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Live, daemon, and peak JVM thread counts",
+      "fillSpans": false,
+      "id": "83f3cb4f-7339-40f5-8379-feffcbc25d4b",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm_threads_live_threads--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm_threads_live_threads",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "14db1f48",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "76ab7ee8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "live",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm_threads_daemon_threads--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm_threads_daemon_threads",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "bae2b70f",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "33a1512c",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "daemon",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm_threads_peak_threads--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm_threads_peak_threads",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "C",
+              "filters": {
+                "items": [
+                  {
+                    "id": "812ec1b4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "6e843269",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "peak",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "C",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b7e490c0-be99-4c90-a066-af0ea42bbfd4",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "jvm_threads_live_threads{job=\"$job\", instance=\"$instance\"}"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Thread Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Thread count by state (RUNNABLE, WAITING, BLOCKED, etc.)",
+      "fillSpans": false,
+      "id": "9d91eb90-eea7-4c91-a920-868d4ebc1dae",
+      "isStacked": true,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm_threads_states_threads--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm_threads_states_threads",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "6b849441",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "a00cb70d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "state--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "state",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{state}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d1615254-ae2e-4d7b-ad51-dc19e0305459",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "jvm_threads_states_threads{job=\"$job\", instance=\"$instance\"}"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Thread States Distribution",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Peak JVM thread count",
+      "fillSpans": false,
+      "id": "1f934832-c120-4979-918c-55b773f15dca",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm_threads_peak_threads--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm_threads_peak_threads",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "571d73a2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "e5df755f",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "98dd2413-3f82-49cb-895c-52165f298a44",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "jvm_threads_peak_threads{job=\"$job\", instance=\"$instance\"}"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Peak Threads",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Current daemon thread count",
+      "fillSpans": false,
+      "id": "feabfee8-9301-45b5-97cf-c605eb8bc37e",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm_threads_daemon_threads--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm_threads_daemon_threads",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "23846742",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "48352b53",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "da83f30e-2c9a-4b18-935d-96cec305ba30",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "jvm_threads_daemon_threads{job=\"$job\", instance=\"$instance\"}"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Daemon Threads",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Current live JVM thread count",
+      "fillSpans": false,
+      "id": "27623a08-97bf-4dc2-9b41-317627cb5352",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm_threads_live_threads--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm_threads_live_threads",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "4cf9c084",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "da43905f",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "84b0cebc-fb7d-4c5d-818a-b4c202a41afe",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "jvm_threads_live_threads{job=\"$job\", instance=\"$instance\"}"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Live Threads",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Database connection pool active connections over time",
+      "fillSpans": false,
+      "id": "402ad832-d387-47cf-bafe-6c4397138de6",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "vendor_statistics_active_count--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "vendor_statistics_active_count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "095a9f49",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "3d210b91",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "active",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b3259cea-6083-4e97-b0c1-52eb27bab6a1",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "vendor_statistics_active_count{job=\"$job\", instance=\"$instance\"}"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active DB Connections",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Database connection pool idle connections over time",
+      "fillSpans": false,
+      "id": "d2c786f2-5bef-4bd0-b2ca-40a7b0f7aa01",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "vendor_statistics_idle_count--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "vendor_statistics_idle_count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "8dd679d5",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "53c414b6",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "idle",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "63c6d28b-c277-4e11-8c5e-3fd76fa325e1",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "vendor_statistics_idle_count{job=\"$job\", instance=\"$instance\"}"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Idle DB Connections",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Database connection pool pending/waiting requests",
+      "fillSpans": false,
+      "id": "507293f1-746f-4804-ab1b-c4a77f7810b8",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "vendor_statistics_pending_count--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "vendor_statistics_pending_count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "0e5cdcd1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "d551d0d4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "pending",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "52a2c43b-06a9-476e-a63b-2dc09343bdd1",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "vendor_statistics_pending_count{job=\"$job\", instance=\"$instance\"}"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Pending DB Connections",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "DB connection pool utilization percentage",
+      "fillSpans": false,
+      "id": "0656b8a4-2c5c-4395-bfdf-942d990a524d",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "vendor_statistics_active_count--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "vendor_statistics_active_count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "3b2abfc7",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "caef457b",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "7f731427-e341-491e-891a-d85d3e62366d",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "100 * vendor_statistics_active_count{job=\"$job\", instance=\"$instance\"} / vendor_statistics_pool_size{job=\"$job\", instance=\"$instance\"}"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Pool Utilization %",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total database connection pool size",
+      "fillSpans": false,
+      "id": "02a69475-4fca-4d9a-beb4-592345b25bc3",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "vendor_statistics_pool_size--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "vendor_statistics_pool_size",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "631e05d0",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "4f39c190",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "2586da7a-7dfd-4a7d-be03-9c05c950aa1b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "vendor_statistics_pool_size{job=\"$job\", instance=\"$instance\"}"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Pool Size",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Process CPU usage over time",
+      "fillSpans": false,
+      "id": "b36c1748-b212-4099-b2d0-844df29eccd4",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "process_cpu_usage--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "process_cpu_usage",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "285bb0cf",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "17c69fb8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "process cpu",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "571a79da-e292-4433-8ac4-ab48fb2fd571",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "process_cpu_usage{job=\"$job\", instance=\"$instance\"}"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "CPU Usage Over Time",
+      "yAxisUnit": "percentunit"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Comparison of process CPU and system CPU usage",
+      "fillSpans": false,
+      "id": "a46a4ee9-60c9-4d4d-8523-a51b696613aa",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "process_cpu_usage--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "process_cpu_usage",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "cf7a2f27",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "4b6ae99b",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "process",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "system_cpu_usage--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "system_cpu_usage",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "1abf25a2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "42d9fea2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "system",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "98d5cb05-eaa8-49d7-9077-cf81aa94a9ca",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "process_cpu_usage{job=\"$job\", instance=\"$instance\"}"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Process CPU vs System CPU",
+      "yAxisUnit": "percentunit"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Process uptime in seconds",
+      "fillSpans": false,
+      "id": "643d6ece-a540-488c-be40-fa426e9aa920",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "process_uptime_seconds--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "process_uptime_seconds",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "88e9ba56",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  },
+                  {
+                    "id": "b87b04ce",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$instance"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "605a07f8-3720-4c7c-8b01-0537974091ab",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "process_uptime_seconds{job=\"$job\", instance=\"$instance\"}"
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Uptime",
+      "yAxisUnit": "s"
+    }
+  ],
+  "uuid": "0615fe51-c60a-412a-ba4c-ccbb0a6c5657"
+}

--- a/keycloak/readme.md
+++ b/keycloak/readme.md
@@ -1,0 +1,67 @@
+# Keycloak Monitoring Dashboard (Prometheus)
+
+Comprehensive monitoring dashboard for Keycloak Identity and Access Management servers using Prometheus metrics.
+
+## Overview
+
+This dashboard provides full observability into Keycloak instances including authentication flows, token operations, JVM health, HTTP performance, and database connection pool status.
+
+## Metrics Source
+
+**Data Source**: Prometheus  
+**Exporter**: Keycloak built-in Micrometer/Quarkus metrics endpoint (`/metrics`)
+
+## Sections
+
+| Section | Panels | Description |
+|---------|--------|-------------|
+| General Overview | 4 | Server uptime, CPU usage, thread count |
+| HTTP Requests | 8 | Request rates, error rates, latency percentiles, breakdown by URI/method |
+| Authentication | 9 | Login success/failure rates, registrations, provider/client breakdown |
+| Token Operations | 7 | Token refresh, code-to-token exchanges, client credential flows |
+| JVM Memory | 7 | Heap/non-heap usage, GC pause metrics, memory pool breakdown |
+| JVM Threads | 5 | Thread count, state distribution, peak/daemon threads |
+| Database Connection Pool | 5 | Active/idle/pending connections, pool utilization |
+| System Resources | 3 | CPU usage trends, uptime |
+
+**Total: 56 panels (8 sections, 18 value panels, 30 graphs)**
+
+## Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `namespace` | Kubernetes namespace filter | - |
+| `job` | Prometheus job name | keycloak |
+| `instance` | Instance filter | - |
+
+## Key Metrics Monitored
+
+### Authentication
+- `keycloak_logins` / `keycloak_login_errors` — Login success and failure rates by realm, provider, and client
+- `keycloak_registrations` / `keycloak_registrations_errors` — User registration metrics
+- `keycloak_refresh_tokens` / `keycloak_refresh_tokens_errors` — Token refresh operations
+- `keycloak_code_to_tokens` / `keycloak_code_to_token_errors` — Authorization code exchanges
+- `keycloak_client_logins` / `keycloak_client_login_errors` — Client credential flows
+
+### HTTP Performance
+- `keycloak_request_duration_seconds_count` — Request throughput by status, method, URI
+- `keycloak_request_duration_seconds_sum` — Request latency analysis
+
+### JVM & System
+- `jvm_memory_used_bytes` / `jvm_memory_max_bytes` — Memory utilization
+- `jvm_gc_pause_seconds_count` / `jvm_gc_pause_seconds_sum` — Garbage collection impact
+- `jvm_threads_live_threads` / `jvm_threads_states_threads` — Thread pool health
+- `process_cpu_usage` / `system_cpu_usage` — CPU utilization
+- `vendor_statistics_active_count` / `vendor_statistics_idle_count` — DB connection pool
+
+## Setup
+
+1. Enable Keycloak metrics endpoint (enabled by default in Keycloak 17+ / Quarkus distribution)
+2. Configure Prometheus to scrape the `/metrics` endpoint
+3. Configure OpenTelemetry Collector with Prometheus receiver to forward metrics to SigNoz
+4. Import this dashboard into SigNoz
+
+## References
+
+- [Keycloak Server Administration Guide — Metrics](https://www.keycloak.org/server/configuration-metrics)
+- [Grafana Dashboard #10441](https://grafana.com/grafana/dashboards/10441-keycloak-metrics-dashboard/)


### PR DESCRIPTION
## Summary

Adds a comprehensive Keycloak Identity and Access Management monitoring dashboard using Prometheus metrics.

**Closes SigNoz/signoz#6022**

### Dashboard Stats
- **56 panels** across 8 sections (18 value panels, 30 graphs, 8 section headers)
- **10,014 lines** of dashboard JSON
- **3 variables**: namespace, job, instance

### Sections

| Section | Panels | Key Metrics |
|---------|--------|-------------|
| General Overview | 4 | Uptime, CPU usage, thread count |
| HTTP Requests | 8 | Request rate by status/method/URI, error rate %, latency p50/p95/p99 |
| Authentication | 9 | Login success/failure by realm/provider/client, registrations |
| Token Operations | 7 | Token refresh, code-to-token, client credentials |
| JVM Memory | 7 | Heap/non-heap, GC pauses, memory pool breakdown |
| JVM Threads | 5 | Thread states distribution, peak/daemon/live |
| Database Connection Pool | 5 | Active/idle/pending connections, pool utilization % |
| System Resources | 3 | CPU trends, uptime |

### Metrics Source
- Keycloak built-in Micrometer/Quarkus metrics endpoint (`/metrics`)
- Compatible with Keycloak 17+ (Quarkus distribution)
- Reference: [Grafana Dashboard #10441](https://grafana.com/grafana/dashboards/10441-keycloak-metrics-dashboard/)

### Files
- `keycloak/keycloak-prometheus-v1.json` — Dashboard definition
- `keycloak/readme.md` — Setup guide and metrics reference

Closes SigNoz/signoz#6022