### PR TITLE
feat: add Apache Spark Prometheus monitoring dashboard

### DIFF
--- a/apache-spark/apache-spark-prometheus-v1.json
+++ b/apache-spark/apache-spark-prometheus-v1.json
@@ -1,0 +1,9760 @@
+{
+  "description": "Comprehensive Apache Spark monitoring dashboard using Prometheus metrics from JMX Exporter or Spark Prometheus sink. Covers cluster overview, job and stage metrics, executor performance, memory, shuffle operations, structured streaming, and JVM health.",
+  "image": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIiB3aWR0aD0iMTAwIiBoZWlnaHQ9IjEwMCI+CiAgPGNpcmNsZSBjeD0iNTAiIGN5PSI1MCIgcj0iNDgiIGZpbGw9IiNFMjVBMUMiLz4KICA8dGV4dCB4PSI1MCIgeT0iNjgiIGZvbnQtc2l6ZT0iNTUiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGZpbGw9IndoaXRlIiBmb250LWZhbWlseT0iQXJpYWwiIGZvbnQtd2VpZ2h0PSJib2xkIj5TPC90ZXh0Pgo8L3N2Zz4=",
+  "layout": [
+    {
+      "h": 1,
+      "i": "e0220a4c-dc28-43cd-aac4-c913f4d27333",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 6,
+      "i": "67817bda-8a41-4707-9d05-1e05212925ba",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 1
+    },
+    {
+      "h": 6,
+      "i": "eeac31c9-529c-41b2-88bf-53d5c222817d",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 1
+    },
+    {
+      "h": 6,
+      "i": "16062e01-aceb-489b-a010-e0c0208d9cc0",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 1
+    },
+    {
+      "h": 6,
+      "i": "c19e5b88-e8f4-4642-b874-ef5b68f6a287",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 7
+    },
+    {
+      "h": 6,
+      "i": "6a01e4c0-957a-49d4-ae44-d7e4fa35d4aa",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 7
+    },
+    {
+      "h": 6,
+      "i": "4bdd5264-615b-421c-a100-9cb13e4d4d3f",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 7
+    },
+    {
+      "h": 1,
+      "i": "26e1bcdf-b046-4740-b20c-47f8ba76bded",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 13
+    },
+    {
+      "h": 6,
+      "i": "fd701850-e5bc-447c-a486-9a64577eaab3",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 14
+    },
+    {
+      "h": 6,
+      "i": "e0cb786d-c6f9-46aa-802d-3f99740ac21c",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 14
+    },
+    {
+      "h": 6,
+      "i": "9643eb33-533b-4809-885f-3304ee7256de",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 20
+    },
+    {
+      "h": 6,
+      "i": "899835ba-abf4-45ff-814d-39a2c36b60a7",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 20
+    },
+    {
+      "h": 6,
+      "i": "e7aa08a9-88e8-4759-b272-e43d40feae5c",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 26
+    },
+    {
+      "h": 6,
+      "i": "3b76145b-67ba-41aa-b259-15b799fa7414",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 26
+    },
+    {
+      "h": 1,
+      "i": "7a638f9d-d8b5-4e2f-8f56-d1e642c85f65",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 32
+    },
+    {
+      "h": 6,
+      "i": "337bbe7d-50d4-4b8f-a67c-423042120697",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 33
+    },
+    {
+      "h": 6,
+      "i": "875c9611-645d-48a6-a7a4-ec27443b0afe",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 33
+    },
+    {
+      "h": 6,
+      "i": "16ffcf92-6020-4003-a882-7ce1626b427c",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 33
+    },
+    {
+      "h": 6,
+      "i": "84b708c4-8e6b-4d2a-9b2a-ccd6660fcfe2",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 39
+    },
+    {
+      "h": 6,
+      "i": "42f78d52-35c6-486e-baa2-a663988bcbf8",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 39
+    },
+    {
+      "h": 6,
+      "i": "1b7b0e1e-fe2d-4671-ae95-e157865e4be5",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 45
+    },
+    {
+      "h": 6,
+      "i": "3ed27a82-5cc3-44ec-a809-15eece633591",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 45
+    },
+    {
+      "h": 6,
+      "i": "c18de954-6888-4126-ac4a-40bc90859dec",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 51
+    },
+    {
+      "h": 6,
+      "i": "165db591-69eb-4cf2-a791-54be22656306",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 51
+    },
+    {
+      "h": 1,
+      "i": "e29d037d-a2c5-4cd3-bde7-fae9f32c8369",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 57
+    },
+    {
+      "h": 6,
+      "i": "66a6cf20-7d25-46bb-884a-b8aba874d3b9",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 58
+    },
+    {
+      "h": 6,
+      "i": "8e51314b-ecc9-4fb6-a3d2-ff57c00a98d3",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 58
+    },
+    {
+      "h": 6,
+      "i": "f66e6438-f605-457e-9aba-ebcb944e428c",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 58
+    },
+    {
+      "h": 6,
+      "i": "23f13089-ed6a-492d-a12e-bc3179f8f889",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 64
+    },
+    {
+      "h": 6,
+      "i": "bea060b6-89d6-4744-aaa6-9d271346e4ad",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 64
+    },
+    {
+      "h": 6,
+      "i": "7f7f63af-b360-40d2-98c7-de849b342d22",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 70
+    },
+    {
+      "h": 6,
+      "i": "f6bcbee9-63f8-444e-b411-914497b8d2f2",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 70
+    },
+    {
+      "h": 1,
+      "i": "40b493be-d308-48f8-a94f-dc0ce7699389",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 76
+    },
+    {
+      "h": 6,
+      "i": "646ee84d-020c-47f8-a2a1-84a65aba9704",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 77
+    },
+    {
+      "h": 6,
+      "i": "76c0218e-6558-4836-8123-c1f00a1a9963",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 77
+    },
+    {
+      "h": 6,
+      "i": "db0e4df1-9e79-4e0d-be2d-5947fb09f7f1",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 83
+    },
+    {
+      "h": 6,
+      "i": "b0673f95-af99-4fc7-be49-afcd225fc35e",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 83
+    },
+    {
+      "h": 6,
+      "i": "967583eb-6752-4bc7-9df8-5fee2d8ed2ca",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 83
+    },
+    {
+      "h": 1,
+      "i": "b9ed4539-d384-4091-ad2d-8182ee2830a1",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 89
+    },
+    {
+      "h": 6,
+      "i": "dfe026ed-20a5-4c39-9cea-b88ed07e7d3e",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 90
+    },
+    {
+      "h": 6,
+      "i": "ac0edb7a-bcec-4dad-a5a6-6b2488e1e6ca",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 90
+    },
+    {
+      "h": 6,
+      "i": "f23825f0-c124-4f29-9089-205864f73618",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 90
+    },
+    {
+      "h": 6,
+      "i": "2794ed70-16cd-4b4a-86d9-bbe3c2ccca77",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 96
+    },
+    {
+      "h": 6,
+      "i": "94885569-2c02-48e1-a322-5256117eb7a3",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 96
+    },
+    {
+      "h": 1,
+      "i": "a131a8cb-75e6-4d33-ba49-d2be0b95b96c",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 102
+    },
+    {
+      "h": 6,
+      "i": "0a9b73a8-4165-443e-b32d-481063e23c50",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 103
+    },
+    {
+      "h": 6,
+      "i": "6e6cd8d5-dd03-4b4d-be42-b0aaee75fb05",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 103
+    },
+    {
+      "h": 6,
+      "i": "86c57f95-5c08-4a99-90e1-4a166d166b83",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 103
+    },
+    {
+      "h": 6,
+      "i": "643765bc-90b9-461c-859d-d10492cb54f9",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 109
+    },
+    {
+      "h": 6,
+      "i": "fc9ee708-47f8-4792-8380-0fa90b7138b1",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 109
+    },
+    {
+      "h": 6,
+      "i": "5d580488-f832-4445-9751-04e44445446a",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 109
+    },
+    {
+      "h": 6,
+      "i": "693f7716-f220-4029-9515-e8c3aa927797",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 115
+    },
+    {
+      "h": 6,
+      "i": "0d097456-0d30-4658-8bb7-3a1b657d4526",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 115
+    },
+    {
+      "h": 6,
+      "i": "73c46f7f-67ea-45ae-87c0-ea5803c183af",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 121
+    },
+    {
+      "h": 6,
+      "i": "f6320efa-32de-46e8-9403-9be4fb9b5154",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 121
+    },
+    {
+      "h": 1,
+      "i": "b903a376-600e-482e-93e8-363dda5f7a59",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 127
+    },
+    {
+      "h": 6,
+      "i": "0e0cd3b1-0509-4692-bbd6-8c9d0a8b4709",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 128
+    },
+    {
+      "h": 6,
+      "i": "617b3174-09c5-4292-adbb-8eaef8794b69",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 128
+    },
+    {
+      "h": 6,
+      "i": "c1de396e-fe87-4d7f-b6c7-902524712c0c",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 128
+    },
+    {
+      "h": 6,
+      "i": "33c4af74-9a43-47b1-9ee2-4beb94857174",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 134
+    },
+    {
+      "h": 6,
+      "i": "a14cb100-a323-4630-861e-25c90a587633",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 134
+    },
+    {
+      "h": 6,
+      "i": "7e9290eb-08b2-48cd-a348-b47db17e3608",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 140
+    },
+    {
+      "h": 6,
+      "i": "9c37d6cd-0f6d-49c0-89d3-6492b51cb05c",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 140
+    }
+  ],
+  "panelMap": {},
+  "tags": [
+    "apache-spark",
+    "prometheus",
+    "big-data",
+    "streaming"
+  ],
+  "title": "Apache Spark Monitoring (Prometheus)",
+  "uploadedGrafana": false,
+  "uuid": "5f257597-310f-4c54-9ff9-c2465f3dc0c6",
+  "variables": [
+    {
+      "allSelected": false,
+      "customValue": "",
+      "description": "Kubernetes namespace or deployment namespace",
+      "id": "53f04471-ea6e-4834-9e35-31ac4ca1fee6",
+      "modificationUUID": "cc062341-7043-4330-a913-e204c8448307",
+      "multiSelect": false,
+      "name": "namespace",
+      "order": 0,
+      "queryValue": "",
+      "selectedValue": "",
+      "showALL": false,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "QUERY",
+      "key": "namespace",
+      "dataSource": "metrics",
+      "aggregateOperator": "noop",
+      "aggregateAttribute": "",
+      "filters": {
+        "items": [],
+        "op": "AND"
+      }
+    },
+    {
+      "allSelected": false,
+      "customValue": "spark",
+      "description": "Prometheus job label for Spark scrape target",
+      "id": "fb04fa02-e35c-4a96-a18a-db083470a9a1",
+      "modificationUUID": "3d9ff335-449e-4bfb-8ed8-a645e6031ef8",
+      "multiSelect": false,
+      "name": "job",
+      "order": 1,
+      "queryValue": "",
+      "selectedValue": "spark",
+      "showALL": false,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "QUERY",
+      "key": "job",
+      "dataSource": "metrics",
+      "aggregateOperator": "noop",
+      "aggregateAttribute": "",
+      "filters": {
+        "items": [],
+        "op": "AND"
+      }
+    },
+    {
+      "allSelected": false,
+      "customValue": "",
+      "description": "Spark application name label",
+      "id": "d40a5894-b9fc-41c2-90d7-42211de978b5",
+      "modificationUUID": "f8f2ed2c-f45b-484e-98cf-2735720e6526",
+      "multiSelect": false,
+      "name": "app_name",
+      "order": 2,
+      "queryValue": "",
+      "selectedValue": "",
+      "showALL": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "QUERY",
+      "key": "app_name",
+      "dataSource": "metrics",
+      "aggregateOperator": "noop",
+      "aggregateAttribute": "",
+      "filters": {
+        "items": [],
+        "op": "AND"
+      }
+    }
+  ],
+  "version": "v4",
+  "widgets": [
+    {
+      "description": "",
+      "id": "e0220a4c-dc28-43cd-aac4-c913f4d27333",
+      "panelTypes": "row",
+      "title": "Cluster Overview"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of currently active Spark jobs",
+      "fillSpans": false,
+      "id": "67817bda-8a41-4707-9d05-1e05212925ba",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_driver_DAGScheduler_job_activeJobs--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_driver_DAGScheduler_job_activeJobs",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "3f2e9fe6",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "80fa3457",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c7706615-a1c2-4e70-890f-1bbaba15f51b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Jobs",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total number of Spark jobs submitted",
+      "fillSpans": false,
+      "id": "eeac31c9-529c-41b2-88bf-53d5c222817d",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_driver_DAGScheduler_job_allJobs--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_driver_DAGScheduler_job_allJobs",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "592ec169",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "5cb70e3a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "7f8d235e-9e1f-409e-b096-58e772b52ccf",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "All Jobs",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of stages currently running",
+      "fillSpans": false,
+      "id": "16062e01-aceb-489b-a010-e0c0208d9cc0",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_driver_DAGScheduler_stage_runningStages--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_driver_DAGScheduler_stage_runningStages",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "ad45726d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "fa7e2db9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "baee47a3-ae0e-4ac1-b3b2-ea2b8ea9a9d1",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Running Stages",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of stages waiting to run",
+      "fillSpans": false,
+      "id": "c19e5b88-e8f4-4642-b874-ef5b68f6a287",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_driver_DAGScheduler_stage_waitingStages--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_driver_DAGScheduler_stage_waitingStages",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d3f3ed5e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "a622f644",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "e3da581c-0e02-4701-873a-27bc09be462e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Waiting Stages",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of failed stages",
+      "fillSpans": false,
+      "id": "6a01e4c0-957a-49d4-ae44-d7e4fa35d4aa",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_driver_DAGScheduler_stage_failedStages--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_driver_DAGScheduler_stage_failedStages",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "6d1fd436",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "e9eb70ed",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "cf254c86-73d1-4571-929d-79187a5da7d9",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Failed Stages",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total active tasks across all executors",
+      "fillSpans": false,
+      "id": "4bdd5264-615b-421c-a100-9cb13e4d4d3f",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_executor_activeTasks--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_executor_activeTasks",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "540f9752",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "1a968a4d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "897aa9d6-4aa5-47d1-b6a7-3477391fcba8",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Tasks",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "id": "26e1bcdf-b046-4740-b20c-47f8ba76bded",
+      "panelTypes": "row",
+      "title": "Job & Stage Metrics"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Trend of active Spark jobs over time",
+      "fillSpans": false,
+      "id": "fd701850-e5bc-447c-a486-9a64577eaab3",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_driver_DAGScheduler_job_activeJobs--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_driver_DAGScheduler_job_activeJobs",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "91bf740d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "601abe5f",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f93a5975-5d3d-4c0e-ab0d-235c15d77c5e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Jobs Over Time",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Comparison of running and waiting stages over time",
+      "fillSpans": false,
+      "id": "e0cb786d-c6f9-46aa-802d-3f99740ac21c",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_driver_DAGScheduler_stage_runningStages--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_driver_DAGScheduler_stage_runningStages",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "85877673",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "e3c1c9c3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Running",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_driver_DAGScheduler_stage_waitingStages--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_driver_DAGScheduler_stage_waitingStages",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "124ef610",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "8e845a02",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Waiting",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "be9e1181-f6d2-48a1-afee-431619a57916",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Running vs Waiting Stages",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of failed stages over time",
+      "fillSpans": false,
+      "id": "9643eb33-533b-4809-885f-3304ee7256de",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_driver_DAGScheduler_stage_failedStages--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_driver_DAGScheduler_stage_failedStages",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f1577c02",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "b55d3718",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "3cfc9f9a-7b50-4da6-ade1-463045d46dd1",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Failed Stages Over Time",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of events posted to LiveListenerBus per second",
+      "fillSpans": false,
+      "id": "899835ba-abf4-45ff-814d-39a2c36b60a7",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_driver_LiveListenerBus_numEventsPosted_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_driver_LiveListenerBus_numEventsPosted_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "7d1f92c3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "dd367716",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "86adb6ad-f0fb-46fe-94a1-1249ce50b394",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Events Posted Rate",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Current size of the LiveListenerBus event queue",
+      "fillSpans": false,
+      "id": "e7aa08a9-88e8-4759-b272-e43d40feae5c",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_driver_LiveListenerBus_queue_listenerBus_size--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_driver_LiveListenerBus_queue_listenerBus_size",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "7aea421d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "3d0d5c1b",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c2462931-d460-4f18-bc8b-45c0a96b6b21",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Listener Bus Queue Size",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total cumulative Spark jobs submitted over time",
+      "fillSpans": false,
+      "id": "3b76145b-67ba-41aa-b259-15b799fa7414",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_driver_DAGScheduler_job_allJobs--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_driver_DAGScheduler_job_allJobs",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "e1c239f6",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "55fe44d7",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a11d8735-94e2-4df7-b0c6-4478e3835190",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "All Jobs Over Time",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "id": "7a638f9d-d8b5-4e2f-8f56-d1e642c85f65",
+      "panelTypes": "row",
+      "title": "Executor Performance"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total active tasks across all executors",
+      "fillSpans": false,
+      "id": "337bbe7d-50d4-4b8f-a67c-423042120697",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_executor_activeTasks--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_executor_activeTasks",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "1669c8a6",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "47f157de",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "cf22e168-5d9f-456d-8e66-59bb1ad25204",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Tasks",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Cumulative completed tasks across all executors",
+      "fillSpans": false,
+      "id": "875c9611-645d-48a6-a7a4-ec27443b0afe",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_executor_completedTasks_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_executor_completedTasks_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "26cb9770",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "4e26ab55",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "157e118f-d09d-4d4a-b489-fc1a6118517b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Tasks Completed",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Cumulative failed tasks across all executors",
+      "fillSpans": false,
+      "id": "16ffcf92-6020-4003-a882-7ce1626b427c",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_executor_failedTasks_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_executor_failedTasks_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "bc88c8e8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "ca6759a0",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "41f67b67-40ea-4814-85c3-4657f8b9ebcc",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Failed Tasks",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of completed tasks per second by executor",
+      "fillSpans": false,
+      "id": "84b708c4-8e6b-4d2a-9b2a-ccd6660fcfe2",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_executor_completedTasks_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_executor_completedTasks_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "4ea1b0f3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "04efbfe8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "executor_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "executor_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{executor_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "71290b23-4575-4d82-a429-94d8ca7a6093",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Task Completion Rate by Executor",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of failed tasks per second by executor",
+      "fillSpans": false,
+      "id": "42f78d52-35c6-486e-baa2-a663988bcbf8",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_executor_failedTasks_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_executor_failedTasks_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "c15fb419",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "e31cd952",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "executor_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "executor_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{executor_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "34e5383c-4f44-41da-9ebb-1494202ab660",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Failed Tasks Over Time",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "CPU time consumed per executor (nanoseconds/sec rate)",
+      "fillSpans": false,
+      "id": "1b7b0e1e-fe2d-4671-ae95-e157865e4be5",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_executor_cpuTime_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_executor_cpuTime_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "2bae6050",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "31a9df84",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "executor_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "executor_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{executor_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "78c95d43-efd2-4818-888c-ce7fc7df5ec1",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "CPU Time by Executor",
+      "yAxisUnit": "ns"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Task run time per executor (milliseconds/sec rate)",
+      "fillSpans": false,
+      "id": "3ed27a82-5cc3-44ec-a809-15eece633591",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_executor_runTime_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_executor_runTime_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f83ec3ef",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "0cd90371",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "executor_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "executor_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{executor_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "4ebda6fc-07de-49ed-a3b1-90eaac21bded",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Run Time by Executor",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Active tasks per executor over time",
+      "fillSpans": false,
+      "id": "c18de954-6888-4126-ac4a-40bc90859dec",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_executor_activeTasks--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_executor_activeTasks",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b6fa07aa",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "2c81e7b4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "executor_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "executor_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{executor_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "68df2cef-e6d3-43e1-b18e-2cd5a642f3f2",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Tasks by Executor",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total task submission rate per executor",
+      "fillSpans": false,
+      "id": "165db591-69eb-4cf2-a791-54be22656306",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_executor_totalTasks_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_executor_totalTasks_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "9f71f7f6",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "223af0c2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "executor_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "executor_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{executor_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "7cd7175c-5c10-4068-8bdc-7f75d5a268ae",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Tasks Rate by Executor",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "id": "e29d037d-a2c5-4cd3-bde7-fae9f32c8369",
+      "panelTypes": "row",
+      "title": "Executor Memory & Disk"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total memory used across all executors",
+      "fillSpans": false,
+      "id": "66a6cf20-7d25-46bb-884a-b8aba874d3b9",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_executor_memoryUsed_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_executor_memoryUsed_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d068b39a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "17dc7469",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "bda0ddff-32b1-47b3-bb49-32eee4dcd164",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Executor Memory Used",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Maximum memory available to executors",
+      "fillSpans": false,
+      "id": "8e51314b-ecc9-4fb6-a3d2-ff57c00a98d3",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_executor_maxMemory_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_executor_maxMemory_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "e49f4bd9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "40b25722",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "bebcebac-15d2-4f6c-b68a-77597f23cc00",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Executor Max Memory",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total disk space used by executors",
+      "fillSpans": false,
+      "id": "f66e6438-f605-457e-9aba-ebcb944e428c",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_executor_diskUsed_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_executor_diskUsed_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f015e3ff",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "48199153",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "1d0959cf-5651-4594-9dfe-c822342632ec",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Executor Disk Used",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Memory usage per executor over time",
+      "fillSpans": false,
+      "id": "23f13089-ed6a-492d-a12e-bc3179f8f889",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_executor_memoryUsed_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_executor_memoryUsed_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "045397cc",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "5f6558fd",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "executor_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "executor_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{executor_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8dbc2b7c-033d-4125-95a7-401f1401b747",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memory Used by Executor",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Percentage of max memory used per executor (A/B*100)",
+      "fillSpans": false,
+      "id": "bea060b6-89d6-4744-aaa6-9d271346e4ad",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_executor_memoryUsed_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_executor_memoryUsed_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "fa30cc0a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "12263458",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "executor_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "executor_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{executor_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_executor_maxMemory_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_executor_maxMemory_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "6a447663",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "fd60c898",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "executor_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "executor_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{executor_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "A / B * 100",
+              "legend": "{{executor_id}}",
+              "queryName": "F1"
+            }
+          ]
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "efbc96f3-ab2b-4218-898b-fab9318e4473",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memory Utilization % by Executor",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Disk usage per executor over time",
+      "fillSpans": false,
+      "id": "7f7f63af-b360-40d2-98c7-de849b342d22",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_executor_diskUsed_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_executor_diskUsed_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "ad7eeab9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "f4823aa3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "executor_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "executor_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{executor_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "95ff36a2-0368-4c92-b15e-9a8dbf04e06e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Disk Used by Executor",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of input bytes read per executor per second",
+      "fillSpans": false,
+      "id": "f6bcbee9-63f8-444e-b411-914497b8d2f2",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_executor_totalInputBytes_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_executor_totalInputBytes_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "6b92b65b",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "98b50c5f",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "executor_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "executor_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{executor_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "38d1abb6-d2e1-43eb-b7d5-b6d61764135a",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Input Bytes Rate by Executor",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "",
+      "id": "40b493be-d308-48f8-a94f-dc0ce7699389",
+      "panelTypes": "row",
+      "title": "Shuffle Operations"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of shuffle read bytes per second per executor",
+      "fillSpans": false,
+      "id": "646ee84d-020c-47f8-a2a1-84a65aba9704",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_executor_totalShuffleRead_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_executor_totalShuffleRead_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "44bafc97",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "e75dc269",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "executor_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "executor_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{executor_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "1e0477d2-ba68-4300-8641-6f278aac5a1b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Shuffle Read Rate by Executor",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of shuffle write bytes per second per executor",
+      "fillSpans": false,
+      "id": "76c0218e-6558-4836-8123-c1f00a1a9963",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_executor_totalShuffleWrite_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_executor_totalShuffleWrite_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "0af27981",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "7c5e4155",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "executor_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "executor_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{executor_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "5a8e9387-40ab-47a4-b66b-efbcf69f2314",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Shuffle Write Rate by Executor",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total bytes read via shuffle across all executors",
+      "fillSpans": false,
+      "id": "db0e4df1-9e79-4e0d-be2d-5947fb09f7f1",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_executor_totalShuffleRead_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_executor_totalShuffleRead_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b9e0b64d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "2976883f",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "510257d8-bd6e-4742-9763-80da2573fda5",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Shuffle Read",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total bytes written via shuffle across all executors",
+      "fillSpans": false,
+      "id": "b0673f95-af99-4fc7-be49-afcd225fc35e",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_executor_totalShuffleWrite_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_executor_totalShuffleWrite_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "05609744",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "a24bbf2c",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "2561dee8-61a4-4f49-b25d-76fdefdbd1ac",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Shuffle Write",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Aggregate shuffle read and write rates over time",
+      "fillSpans": false,
+      "id": "967583eb-6752-4bc7-9df8-5fee2d8ed2ca",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_executor_totalShuffleRead_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_executor_totalShuffleRead_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "4417c67e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "327c8581",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Shuffle Read",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_executor_totalShuffleWrite_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_executor_totalShuffleWrite_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "4566a6fe",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "594c7dd0",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Shuffle Write",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9885600f-c632-40b0-a86d-47362270ded7",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Shuffle Read vs Write",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "",
+      "id": "b9ed4539-d384-4091-ad2d-8182ee2830a1",
+      "panelTypes": "row",
+      "title": "Driver Block Manager"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Driver block manager memory currently in use (MB)",
+      "fillSpans": false,
+      "id": "dfe026ed-20a5-4c39-9cea-b88ed07e7d3e",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_driver_BlockManager_memory_memUsed_MB--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_driver_BlockManager_memory_memUsed_MB",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "33a61a06",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "6a846919",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "1908d788-fa90-4875-9523-00f1f2ad9bd6",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Block Manager Memory Used",
+      "yAxisUnit": "megabytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Maximum memory available to driver block manager (MB)",
+      "fillSpans": false,
+      "id": "ac0edb7a-bcec-4dad-a5a6-6b2488e1e6ca",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_driver_BlockManager_memory_maxMem_MB--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_driver_BlockManager_memory_maxMem_MB",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "c9e866f3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "af6c608d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "3f687813-e67c-4c74-b275-80a90ac79009",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Block Manager Max Memory",
+      "yAxisUnit": "megabytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Remaining free memory in driver block manager (MB)",
+      "fillSpans": false,
+      "id": "f23825f0-c124-4f29-9089-205864f73618",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_driver_BlockManager_memory_remainingMem_MB--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_driver_BlockManager_memory_remainingMem_MB",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "6531b8d8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "052bb3a2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "19efa942-827b-4e70-adaf-aa377797424f",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Block Manager Remaining Memory",
+      "yAxisUnit": "megabytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Driver block manager memory: used, max, and remaining over time",
+      "fillSpans": false,
+      "id": "2794ed70-16cd-4b4a-86d9-bbe3c2ccca77",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_driver_BlockManager_memory_memUsed_MB--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_driver_BlockManager_memory_memUsed_MB",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f50287ae",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "d7000bc1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Used MB",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_driver_BlockManager_memory_maxMem_MB--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_driver_BlockManager_memory_maxMem_MB",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "4da69cf0",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "c66dccd9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Max MB",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_driver_BlockManager_memory_remainingMem_MB--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_driver_BlockManager_memory_remainingMem_MB",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "C",
+              "filters": {
+                "items": [
+                  {
+                    "id": "0fdd55ed",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "b26ad696",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Remaining MB",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "C",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d1309399-d24b-4417-87d8-af2e699597fc",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Block Manager Memory Over Time",
+      "yAxisUnit": "megabytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Driver block manager disk space usage over time (MB)",
+      "fillSpans": false,
+      "id": "94885569-2c02-48e1-a322-5256117eb7a3",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_driver_BlockManager_disk_diskSpaceUsed_MB--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_driver_BlockManager_disk_diskSpaceUsed_MB",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "534a57f4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "1414a90d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "998fe6d6-a52d-4091-867a-6289f8692935",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Block Manager Disk Space Used",
+      "yAxisUnit": "megabytes"
+    },
+    {
+      "description": "",
+      "id": "a131a8cb-75e6-4d33-ba49-d2be0b95b96c",
+      "panelTypes": "row",
+      "title": "Structured Streaming"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of currently running streaming batches",
+      "fillSpans": false,
+      "id": "0a9b73a8-4165-443e-b32d-481063e23c50",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_streaming_runningBatches--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_streaming_runningBatches",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "c66be684",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "429cb653",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "857facc7-00af-430c-9272-2500055a9744",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Running Batches",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of streaming batches waiting to be processed",
+      "fillSpans": false,
+      "id": "6e6cd8d5-dd03-4b4d-be42-b0aaee75fb05",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_streaming_waitingBatches--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_streaming_waitingBatches",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "3221eb63",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "e9dbe730",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b9eb1159-9539-4af8-be80-c54faf388d4c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Waiting Batches",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total number of records processed by streaming",
+      "fillSpans": false,
+      "id": "86c57f95-5c08-4a99-90e1-4a166d166b83",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_streaming_totalProcessedRecords--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_streaming_totalProcessedRecords",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "702d8683",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "329b91d4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "3949a4a6-4d08-4e2a-aba1-290a95934bd3",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Processed Records",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Time taken to process the last completed batch (ms)",
+      "fillSpans": false,
+      "id": "643765bc-90b9-461c-859d-d10492cb54f9",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_streaming_lastCompletedBatch_processingDelay--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_streaming_lastCompletedBatch_processingDelay",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "08ef078c",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "74fc5bfc",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "239e6d14-b028-4683-8999-b5b6ad798c2e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Processing Delay",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Time from batch creation to start of processing (ms)",
+      "fillSpans": false,
+      "id": "fc9ee708-47f8-4792-8380-0fa90b7138b1",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_streaming_lastCompletedBatch_schedulingDelay--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_streaming_lastCompletedBatch_schedulingDelay",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f1248ef2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "466ee3cf",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "767e6335-c949-4e4c-8215-b44c91a3048b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Scheduling Delay",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total end-to-end delay for the last completed batch (ms)",
+      "fillSpans": false,
+      "id": "5d580488-f832-4445-9751-04e44445446a",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_streaming_lastCompletedBatch_totalDelay--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_streaming_lastCompletedBatch_totalDelay",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "86178208",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "fad8e4c3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a8070670-73af-459e-ba63-a9fa9cb2114d",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total End-to-End Delay",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of records received in the last batch",
+      "fillSpans": false,
+      "id": "693f7716-f220-4029-9515-e8c3aa927797",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_streaming_lastReceivedBatch_records--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_streaming_lastReceivedBatch_records",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "e30ab1a3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "83352051",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "431be750-c0d5-4bf5-a955-0807562b8841",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Records Received in Last Batch",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of batches that have not been processed yet",
+      "fillSpans": false,
+      "id": "0d097456-0d30-4658-8bb7-3a1b657d4526",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_streaming_unprocessedBatches--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_streaming_unprocessedBatches",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "975b0ee2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "6cad7ff3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "e5b6df16-cf7b-42e0-860b-85a4076a12f6",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Unprocessed Batches",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Cumulative total records received by the streaming context",
+      "fillSpans": false,
+      "id": "73c46f7f-67ea-45ae-87c0-ea5803c183af",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_streaming_totalReceivedRecords--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_streaming_totalReceivedRecords",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b2f893c6",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "d2cb3377",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ba43e550-4f0e-4545-a9cc-1b0d84e1d5cd",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Received Records",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Cumulative total batches completed by streaming",
+      "fillSpans": false,
+      "id": "f6320efa-32de-46e8-9403-9be4fb9b5154",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "spark_streaming_totalCompletedBatches--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "spark_streaming_totalCompletedBatches",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "08d56485",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "3edf8ca8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "536b7a96-68ce-4e38-9e15-93cf90fd89ce",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Completed Batches",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "id": "b903a376-600e-482e-93e8-363dda5f7a59",
+      "panelTypes": "row",
+      "title": "JVM & System"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of live JVM threads in the Spark driver",
+      "fillSpans": false,
+      "id": "0e0cd3b1-0509-4692-bbd6-8c9d0a8b4709",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm_threads_live_threads--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm_threads_live_threads",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "eea35304",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "86b29a7d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8f1353f7-790c-4dc7-80b6-6daca6cd8175",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Live Threads",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "JVM heap and non-heap memory usage in bytes",
+      "fillSpans": false,
+      "id": "617b3174-09c5-4292-adbb-8eaef8794b69",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm_memory_used_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm_memory_used_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "30a598b0",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "704838c9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "area--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "area",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{area}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "1f911f4d-9442-42ea-bef0-8da431ad0946",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "JVM Memory Used",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "JVM maximum memory (heap and non-heap) in bytes",
+      "fillSpans": false,
+      "id": "c1de396e-fe87-4d7f-b6c7-902524712c0c",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm_memory_max_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm_memory_max_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "48e4bdff",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "ca289f93",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "area--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "area",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{area}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "96aa6774-dd65-4a36-a35a-5e3f9ee69b3c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "JVM Memory Max",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of GC pauses per second by cause",
+      "fillSpans": false,
+      "id": "33c4af74-9a43-47b1-9ee2-4beb94857174",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm_gc_pause_seconds_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm_gc_pause_seconds_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "3e4ed5f5",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "a685c821",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "cause--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "cause",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{cause}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "e91c2af7-7e39-4ffd-91fb-335d1bc4ceb7",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "GC Pause Count Rate",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of GC pause duration (seconds/sec) by cause",
+      "fillSpans": false,
+      "id": "a14cb100-a323-4630-861e-25c90a587633",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm_gc_pause_seconds_sum--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm_gc_pause_seconds_sum",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "23db78f4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "5e348cb3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "cause--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "cause",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{cause}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "52f97883-e490-4a57-ae43-60348001c7e1",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "GC Pause Duration Rate",
+      "yAxisUnit": "s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "CPU usage of the Spark driver process (0.0 to 1.0)",
+      "fillSpans": false,
+      "id": "7e9290eb-08b2-48cd-a348-b47db17e3608",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "process_cpu_usage--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "process_cpu_usage",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "edfd71c4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "c69fc7ae",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "49f60fe5-298c-4737-a1c0-917526e74959",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Process CPU Usage",
+      "yAxisUnit": "percentunit"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Average GC pause duration in seconds (sum/count)",
+      "fillSpans": false,
+      "id": "9c37d6cd-0f6d-49c0-89d3-6492b51cb05c",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm_gc_pause_seconds_sum--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm_gc_pause_seconds_sum",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "c400590c",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "da4b2b67",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "GC Sum",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm_gc_pause_seconds_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm_gc_pause_seconds_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "1873055c",
+                    "key": {
+                      "dataType": "string",
+                      "id": "app_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "app_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$app_name"
+                  },
+                  {
+                    "id": "3b88f0b1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "$job"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "GC Count",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "A / B",
+              "legend": "Avg GC Pause (s)",
+              "queryName": "F1"
+            }
+          ]
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8cd6f0e7-5cfc-4f42-8e3a-9a6f133941bc",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Average GC Pause Duration",
+      "yAxisUnit": "s"
+    }
+  ]
+}

--- a/apache-spark/readme.md
+++ b/apache-spark/readme.md
@@ -1,0 +1,147 @@
+# Apache Spark Monitoring Dashboard (Prometheus)
+
+A comprehensive SigNoz dashboard for monitoring Apache Spark clusters using Prometheus metrics exported via the JMX Exporter or the native Spark Prometheus metrics sink.
+
+## Overview
+
+This dashboard provides full observability into Apache Spark workloads — from cluster-level job and stage health down to per-executor CPU, memory, shuffle I/O, structured streaming latency, and JVM internals. It is designed for production Spark deployments where you need fast triage of performance issues, resource bottlenecks, and streaming pipeline delays.
+
+## Metrics Source
+
+Metrics are scraped from one of two sources:
+
+1. **JMX Exporter** — attach the Prometheus JMX Exporter as a Java agent to Spark driver and executor JVMs. Exposes `spark_driver_*` and `spark_executor_*` metrics.
+2. **Spark Prometheus Sink** — configure `spark.metrics.conf` to use the built-in Prometheus servlet sink. Available from Spark 3.0+.
+
+Both sources expose compatible metric names used in this dashboard.
+
+## Sections
+
+| Section | Panel Count | Description |
+|---|---|---|
+| Cluster Overview | 6 | Active/all jobs, running/waiting/failed stages, total active tasks |
+| Job & Stage Metrics | 6 | Time-series for jobs, stages, events, and listener bus queue size |
+| Executor Performance | 9 | Task completion/failure rates, CPU time, run time, active tasks by executor |
+| Executor Memory & Disk | 5 | Memory used/max/utilization %, disk used, input bytes rate per executor |
+| Shuffle Operations | 5 | Shuffle read/write rate by executor, totals, and read vs write comparison |
+| Driver Block Manager | 5 | Driver-side block manager memory (used/max/remaining) and disk usage |
+| Structured Streaming | 10 | Processing/scheduling/total delay, batch counts, record throughput |
+| JVM & System | 8 | Heap memory, GC pause rate and duration, CPU usage, live threads |
+
+## Variables
+
+| Variable | Description | Default |
+|---|---|---|
+| `namespace` | Kubernetes or deployment namespace label | (all) |
+| `job` | Prometheus scrape job label for Spark targets | `spark` |
+| `app_name` | Spark application name label (`spark.app.name`) | (all) |
+
+## Key Metrics Monitored
+
+| Metric | Type | Description |
+|---|---|---|
+| `spark_driver_DAGScheduler_job_activeJobs` | Gauge | Active Spark jobs |
+| `spark_driver_DAGScheduler_stage_runningStages` | Gauge | Currently running stages |
+| `spark_driver_DAGScheduler_stage_failedStages` | Gauge | Failed stages |
+| `spark_executor_activeTasks` | Gauge | Active tasks per executor |
+| `spark_executor_completedTasks_total` | Counter | Completed tasks (rate) |
+| `spark_executor_failedTasks_total` | Counter | Failed tasks (rate) |
+| `spark_executor_cpuTime_total` | Counter | CPU time consumed (ns) |
+| `spark_executor_memoryUsed_bytes` | Gauge | Executor memory used |
+| `spark_executor_maxMemory_bytes` | Gauge | Executor max memory |
+| `spark_executor_diskUsed_bytes` | Gauge | Executor disk used |
+| `spark_executor_totalShuffleRead_total` | Counter | Shuffle read bytes |
+| `spark_executor_totalShuffleWrite_total` | Counter | Shuffle write bytes |
+| `spark_driver_BlockManager_memory_memUsed_MB` | Gauge | Driver block manager memory used |
+| `spark_streaming_lastCompletedBatch_processingDelay` | Gauge | Streaming processing delay |
+| `spark_streaming_lastCompletedBatch_totalDelay` | Gauge | Streaming end-to-end delay |
+| `spark_streaming_runningBatches` | Gauge | Currently running batches |
+| `spark_streaming_unprocessedBatches` | Gauge | Unprocessed streaming batches |
+| `jvm_memory_used_bytes` | Gauge | JVM heap/non-heap memory |
+| `jvm_gc_pause_seconds_count` | Counter | GC pause count (rate) |
+| `jvm_gc_pause_seconds_sum` | Counter | GC pause total duration |
+| `process_cpu_usage` | Gauge | Driver process CPU usage |
+
+## Setup
+
+### 1. Expose Spark Metrics via Prometheus
+
+**Option A — Spark Prometheus Sink (Spark 3.0+)**
+
+Add to `spark-defaults.conf` or pass as `--conf` flags:
+
+```
+spark.metrics.conf.*.sink.prometheus.class=org.apache.spark.metrics.sink.PrometheusSink
+spark.metrics.conf.*.sink.prometheus.path=/metrics
+spark.metrics.conf.*.sink.prometheus.period=10
+spark.metrics.conf.*.sink.prometheus.unit=seconds
+spark.ui.prometheus.enabled=true
+```
+
+**Option B — JMX Exporter**
+
+Add the JMX Exporter agent to your Spark driver and executor JVM args:
+
+```
+--conf spark.driver.extraJavaOptions="-javaagent:/path/to/jmx_prometheus_javaagent.jar=8090:/path/to/spark_jmx_config.yaml"
+--conf spark.executor.extraJavaOptions="-javaagent:/path/to/jmx_prometheus_javaagent.jar=8091:/path/to/spark_jmx_config.yaml"
+```
+
+### 2. Configure Prometheus Scraping
+
+```yaml
+scrape_configs:
+  - job_name: spark
+    static_configs:
+      - targets:
+          - spark-driver-host:4040
+          - spark-executor-host:8091
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: instance
+```
+
+### 3. Ship Metrics to SigNoz
+
+Use the OpenTelemetry Collector with the Prometheus receiver to scrape and forward metrics to SigNoz:
+
+```yaml
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: spark
+          scrape_interval: 15s
+          static_configs:
+            - targets: ['spark-driver:4040']
+          metric_relabel_configs:
+            - source_labels: [__name__]
+              regex: 'spark_.*|jvm_.*|process_.*'
+              action: keep
+
+exporters:
+  otlp:
+    endpoint: <signoz-otel-collector>:4317
+
+service:
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      exporters: [otlp]
+```
+
+### 4. Import Dashboard
+
+Upload `apache-spark-prometheus-v1.json` via the SigNoz Dashboard UI:
+**Dashboards → New Dashboard → Import JSON**
+
+Set the `namespace`, `job`, and `app_name` template variables to match your Prometheus labels.
+
+## References
+
+- [Apache Spark Monitoring Documentation](https://spark.apache.org/docs/latest/monitoring.html)
+- [Spark Prometheus Metrics Sink](https://spark.apache.org/docs/latest/monitoring.html#prometheus-sink)
+- [Prometheus JMX Exporter](https://github.com/prometheus/jmx_exporter)
+- [SigNoz Dashboard Import](https://signoz.io/docs/userguide/dashboards/)
+- [OpenTelemetry Prometheus Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver)
+- [SigNoz/dashboards Repository](https://github.com/SigNoz/dashboards)


### PR DESCRIPTION
## Summary

Adds a comprehensive Apache Spark monitoring dashboard using Prometheus metrics from JMX Exporter / Spark Prometheus sink.

**Closes SigNoz/signoz#6078**

### Dashboard Stats
- **63 panels** across 8 sections (21 value panels, 34 graphs, 8 section headers)
- **9,907 lines** of dashboard JSON
- **3 variables**: namespace, job, app_name

### Sections

| Section | Panels | Key Metrics |
|---------|--------|-------------|
| Cluster Overview | 6 | Active/all jobs, running/waiting/failed stages |
| Job & Stage Metrics | 6 | Job and stage trends, events posted rate, listener bus queue |
| Executor Performance | 9 | Task counts, CPU/run time by executor, success rate % |
| Executor Memory & Disk | 5 | Memory used/max by executor, disk usage, input bytes rate |
| Shuffle Operations | 5 | Shuffle read/write rates by executor, totals |
| Driver Block Manager | 5 | Memory used/max/remaining, disk space, utilization % |
| Structured Streaming | 10 | Processing/scheduling/total delays, batch throughput, records |
| JVM & System | 8 | Heap memory, GC pauses, CPU usage, threads |

### Metrics Source
- Spark Prometheus sink (`spark.metrics.conf`) or JMX Exporter
- Compatible with Spark 3.x+
- Covers driver, executor, streaming, and JVM metrics

### Files
- `apache-spark/apache-spark-prometheus-v1.json` — Dashboard definition
- `apache-spark/readme.md` — Setup guide and metrics reference

Closes SigNoz/signoz#6078