### PR TITLE
feat(dashboard): Add Redis Prometheus monitoring dashboard

### DIFF
--- a/redis/README-prometheus.md
+++ b/redis/README-prometheus.md
@@ -1,0 +1,77 @@
+# Redis Monitoring Dashboard - Prometheus
+
+Comprehensive Redis monitoring dashboard for [SigNoz](https://signoz.io/) using Prometheus metrics from [redis_exporter](https://github.com/oliver006/redis_exporter).
+
+## Sections
+
+| #   | Section       | Covers                                                        |
+| --- | ------------- | ------------------------------------------------------------- |
+| 1   | Overview      | Up status, connected clients, memory used, uptime             |
+| 2   | Memory        | Usage over time, fragmentation ratio, RSS, dataset, evictions |
+| 3   | Performance   | Commands/sec, ops/sec, hit rate, latency, slowlog             |
+| 4   | Connections   | Connected/blocked clients, received/rejected connections      |
+| 5   | Persistence   | RDB save status, changes since save, AOF rewrite, AOF size    |
+| 6   | Replication   | Role, connected replicas, replication offset, replica lag     |
+| 7   | Keyspace      | Total keys, expiring keys, expiry rate, eviction rate         |
+| 8   | Network       | Input/output bytes, pub/sub channels and patterns             |
+| 9   | CPU           | System and user CPU usage                                     |
+
+## Metrics Ingestion
+
+### Using OpenTelemetry Collector with Prometheus Receiver
+
+```yaml
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: "redis"
+          scrape_interval: 15s
+          static_configs:
+            - targets: ["redis-exporter:9121"]
+          metric_relabel_configs:
+            - source_labels: [__name__]
+              regex: "redis_.*"
+              action: keep
+
+processors:
+  batch:
+    timeout: 10s
+  resource:
+    attributes:
+      - key: service.name
+        value: "redis"
+        action: insert
+
+exporters:
+  otlp:
+    endpoint: "ingest.<region>.signoz.cloud:443"
+    headers:
+      signoz-ingestion-key: "<your-ingestion-key>"
+
+service:
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      processors: [batch, resource]
+      exporters: [otlp]
+```
+
+### Redis Exporter Setup
+
+```bash
+docker run -d --name redis-exporter \
+  -p 9121:9121 \
+  -e REDIS_ADDR=redis://your-redis-host:6379 \
+  oliver006/redis_exporter:latest
+```
+
+## Variables
+
+- `{{redis_instance}}`: Redis instance address for filtering metrics
+
+## Dashboard Panels (47 total)
+
+- **8 value panels** — instant metrics (up status, clients, memory, uptime, RDB status, role, replicas)
+- **30 time series panels** — trends over time for all key Redis metrics
+- **9 section headers** — organized into logical monitoring categories

--- a/redis/redis-prometheus-v1.json
+++ b/redis/redis-prometheus-v1.json
@@ -1,0 +1,8664 @@
+{
+    "id": "redis-prometheus-v1",
+    "description": "Comprehensive Redis monitoring dashboard using Prometheus metrics from redis_exporter (oliver006/redis_exporter). Covers overview, memory, performance, connections, persistence, replication, keyspace, network, and CPU metrics.",
+    "layout": [
+        {
+            "h": 1,
+            "i": "3a05a54b-e9c0-4817-b6be-2641911867c6",
+            "maxH": 1,
+            "minH": 1,
+            "minW": 12,
+            "moved": false,
+            "static": false,
+            "w": 12,
+            "x": 0,
+            "y": 0
+        },
+        {
+            "h": 3,
+            "i": "4967d3f8-8d6b-4374-a8fd-3d80726aebc7",
+            "moved": false,
+            "static": false,
+            "w": 3,
+            "x": 0,
+            "y": 1
+        },
+        {
+            "h": 3,
+            "i": "f039982e-d1e2-4940-a36b-8a507a7a8b72",
+            "moved": false,
+            "static": false,
+            "w": 3,
+            "x": 3,
+            "y": 1
+        },
+        {
+            "h": 3,
+            "i": "4962b07b-6fdc-482d-9893-dafb026ddd4e",
+            "moved": false,
+            "static": false,
+            "w": 3,
+            "x": 6,
+            "y": 1
+        },
+        {
+            "h": 3,
+            "i": "5a579662-2f18-425f-a151-fb6bd428af0d",
+            "moved": false,
+            "static": false,
+            "w": 3,
+            "x": 9,
+            "y": 1
+        },
+        {
+            "h": 1,
+            "i": "6ff52a5b-c33d-463d-bc78-0d147b0e649a",
+            "maxH": 1,
+            "minH": 1,
+            "minW": 12,
+            "moved": false,
+            "static": false,
+            "w": 12,
+            "x": 0,
+            "y": 4
+        },
+        {
+            "h": 3,
+            "i": "098c8b54-25c3-4d1a-ad50-36b2f4024400",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 5
+        },
+        {
+            "h": 3,
+            "i": "60184ddc-32f8-4897-9473-327ef7d654ff",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 5
+        },
+        {
+            "h": 3,
+            "i": "ec78c87d-af85-40d9-8dcc-0cc4130eb61c",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 8
+        },
+        {
+            "h": 3,
+            "i": "b8aa7976-e3c0-4c31-8cd9-9048f821df7c",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 8
+        },
+        {
+            "h": 3,
+            "i": "2ef7aec6-797c-4e03-8c73-d272d3d9c69b",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 11
+        },
+        {
+            "h": 3,
+            "i": "ab4bd726-be03-4ea8-a07f-8ac02b0b9177",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 11
+        },
+        {
+            "h": 1,
+            "i": "f1c439b2-3bf7-4dc9-a7f3-96906dbb7703",
+            "maxH": 1,
+            "minH": 1,
+            "minW": 12,
+            "moved": false,
+            "static": false,
+            "w": 12,
+            "x": 0,
+            "y": 14
+        },
+        {
+            "h": 3,
+            "i": "5137214a-a8ab-4845-9c5d-400d0b30d4d1",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 15
+        },
+        {
+            "h": 3,
+            "i": "9f7d2d30-c248-4aa4-bc14-c1bf7e85e8e8",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 15
+        },
+        {
+            "h": 3,
+            "i": "fbc1eebb-315c-4aae-bc0f-a511db120087",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 18
+        },
+        {
+            "h": 3,
+            "i": "780355ef-795f-44d8-94dc-5b2f2a8730de",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 18
+        },
+        {
+            "h": 3,
+            "i": "0c6c769b-07c7-45e4-b8d5-76cd48659cf2",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 21
+        },
+        {
+            "h": 3,
+            "i": "56d86715-47b5-4d2b-962d-214aff69f8df",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 21
+        },
+        {
+            "h": 1,
+            "i": "f4cb6806-8e82-4c4a-874b-3bf2520633ae",
+            "maxH": 1,
+            "minH": 1,
+            "minW": 12,
+            "moved": false,
+            "static": false,
+            "w": 12,
+            "x": 0,
+            "y": 24
+        },
+        {
+            "h": 3,
+            "i": "e30711f5-269f-4d9a-ab82-607d206e140e",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 25
+        },
+        {
+            "h": 3,
+            "i": "eec65ae0-4401-4abe-8655-2f4b5ad8df2f",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 25
+        },
+        {
+            "h": 3,
+            "i": "415fc761-49d5-48ba-8255-230680ccbccc",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 28
+        },
+        {
+            "h": 3,
+            "i": "7f629342-b9b6-45ba-8bb0-596cf7c95b6d",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 28
+        },
+        {
+            "h": 1,
+            "i": "fd16fa67-47e4-4315-85cd-86d28ad248bb",
+            "maxH": 1,
+            "minH": 1,
+            "minW": 12,
+            "moved": false,
+            "static": false,
+            "w": 12,
+            "x": 0,
+            "y": 31
+        },
+        {
+            "h": 3,
+            "i": "22ea8fb0-9e79-442f-a4e0-916ed30ed1f2",
+            "moved": false,
+            "static": false,
+            "w": 3,
+            "x": 0,
+            "y": 32
+        },
+        {
+            "h": 3,
+            "i": "4f2392c3-f3af-44b2-a897-f459d1716897",
+            "moved": false,
+            "static": false,
+            "w": 3,
+            "x": 3,
+            "y": 32
+        },
+        {
+            "h": 3,
+            "i": "cd3996c3-ede0-4556-b935-30eda3f0e940",
+            "moved": false,
+            "static": false,
+            "w": 3,
+            "x": 6,
+            "y": 32
+        },
+        {
+            "h": 3,
+            "i": "33634483-2e18-4e09-ae3a-8040d7e7c979",
+            "moved": false,
+            "static": false,
+            "w": 3,
+            "x": 9,
+            "y": 32
+        },
+        {
+            "h": 1,
+            "i": "29a636cb-8cbd-49ad-a10b-f24a5c3fdc8d",
+            "maxH": 1,
+            "minH": 1,
+            "minW": 12,
+            "moved": false,
+            "static": false,
+            "w": 12,
+            "x": 0,
+            "y": 35
+        },
+        {
+            "h": 3,
+            "i": "26d3345a-c7b1-413a-93a7-77620f14ca0b",
+            "moved": false,
+            "static": false,
+            "w": 3,
+            "x": 0,
+            "y": 36
+        },
+        {
+            "h": 3,
+            "i": "6494aa85-f4b7-4130-8cfa-f879699d73f6",
+            "moved": false,
+            "static": false,
+            "w": 3,
+            "x": 3,
+            "y": 36
+        },
+        {
+            "h": 3,
+            "i": "43d55dba-3482-410d-8ff0-3e6aea776c38",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 36
+        },
+        {
+            "h": 3,
+            "i": "5a8538a0-bff3-4787-a35f-6866b3e55579",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 39
+        },
+        {
+            "h": 1,
+            "i": "5dbc8c46-41d5-4fdc-b765-4f8a93b8f4cc",
+            "maxH": 1,
+            "minH": 1,
+            "minW": 12,
+            "moved": false,
+            "static": false,
+            "w": 12,
+            "x": 0,
+            "y": 42
+        },
+        {
+            "h": 3,
+            "i": "b435d577-ca70-411b-8990-f8be311c8a08",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 43
+        },
+        {
+            "h": 3,
+            "i": "926125fb-b1a9-426a-b187-a1dcddc4c208",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 43
+        },
+        {
+            "h": 3,
+            "i": "1b883d13-9fb2-423a-858b-3f83b6adf6cb",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 46
+        },
+        {
+            "h": 3,
+            "i": "5952bff1-36ab-458e-b001-57b01c301d50",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 46
+        },
+        {
+            "h": 1,
+            "i": "103faad3-570b-4745-9353-66f402671ff3",
+            "maxH": 1,
+            "minH": 1,
+            "minW": 12,
+            "moved": false,
+            "static": false,
+            "w": 12,
+            "x": 0,
+            "y": 49
+        },
+        {
+            "h": 3,
+            "i": "4cdfbf4e-8b7d-4fc1-afc3-a6ef0a8b49bb",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 50
+        },
+        {
+            "h": 3,
+            "i": "58db21ad-272b-472b-a3a4-2c0ee185fddb",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 50
+        },
+        {
+            "h": 3,
+            "i": "96f5a62b-4ea2-4519-a393-ed8a721f99cc",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 53
+        },
+        {
+            "h": 3,
+            "i": "116baa53-05c4-405a-b325-ca3c6fa1154d",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 53
+        },
+        {
+            "h": 1,
+            "i": "468f0445-5d20-4b7b-b0e4-816f55917c8f",
+            "maxH": 1,
+            "minH": 1,
+            "minW": 12,
+            "moved": false,
+            "static": false,
+            "w": 12,
+            "x": 0,
+            "y": 56
+        },
+        {
+            "h": 3,
+            "i": "329ab20b-0e65-41af-8edf-6fe6c0f6cbe4",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 57
+        },
+        {
+            "h": 3,
+            "i": "e08d9c26-ede3-46a7-9e8a-7d062b960148",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 57
+        }
+    ],
+    "name": "",
+    "tags": [
+        "redis",
+        "database",
+        "prometheus",
+        "monitoring"
+    ],
+    "title": "Redis Prometheus Monitoring",
+    "variables": {
+        "9b803dbf-f1e0-450c-ab50-5aa49b14fb29": {
+            "allSelected": true,
+            "customValue": "",
+            "description": "Redis instance to filter by (from redis_exporter target)",
+            "id": "9b803dbf-f1e0-450c-ab50-5aa49b14fb29",
+            "key": "9b803dbf-f1e0-450c-ab50-5aa49b14fb29",
+            "modificationUUID": "74c126d2-aba8-4426-9c12-e34d8640bb35",
+            "multiSelect": true,
+            "name": "redis_instance",
+            "order": 0,
+            "queryValue": "SELECT JSONExtractString(labels, 'instance') AS `instance`\nFROM signoz_metrics.distributed_time_series_v4_1day\nWHERE metric_name = 'redis_up'\nGROUP BY `instance`\nORDER BY `instance` ASC",
+            "selectedValue": [
+                ""
+            ],
+            "showALLOption": true,
+            "sort": "ASC",
+            "textboxValue": "",
+            "type": "QUERY"
+        }
+    },
+    "widgets": [
+        {
+            "description": "",
+            "fillSpans": false,
+            "id": "3a05a54b-e9c0-4817-b6be-2641911867c6",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "row",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "",
+                                "id": "------false",
+                                "isColumn": false,
+                                "isJSON": false,
+                                "key": "",
+                                "type": ""
+                            },
+                            "aggregateOperator": "count",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [],
+                                "op": "AND"
+                            },
+                            "groupBy": [],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "sum",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "avg",
+                            "spaceAggregation": "sum",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "f2ba9020-0562-40db-92a4-1e26d8f7d715",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Overview",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Whether the Redis instance is up (1) or down (0)",
+            "fillSpans": false,
+            "id": "4967d3f8-8d6b-4374-a8fd-3d80726aebc7",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "value",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_up--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_up",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "latest",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "44617118",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "Redis Up",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "latest",
+                            "spaceAggregation": "sum",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "805d4c41-f3c8-447e-bd4c-d1f0d24184a2",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Redis Up Status",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Number of currently connected clients",
+            "fillSpans": false,
+            "id": "f039982e-d1e2-4940-a36b-8a507a7a8b72",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "value",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_connected_clients--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_connected_clients",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "latest",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "6b97744a",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "Connected Clients",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "latest",
+                            "spaceAggregation": "sum",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "7fb97bdb-5d04-4716-b2a9-b80bad953946",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Connected Clients",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Total memory used by Redis in bytes",
+            "fillSpans": false,
+            "id": "4962b07b-6fdc-482d-9893-dafb026ddd4e",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "value",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_memory_used_bytes--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_memory_used_bytes",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "latest",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "68291204",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "Used Memory",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "latest",
+                            "spaceAggregation": "sum",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "55ddf2a4-5ef6-451c-a34c-fb80360633ad",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Used Memory",
+            "yAxisUnit": "bytes",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Time since Redis server started in seconds",
+            "fillSpans": false,
+            "id": "5a579662-2f18-425f-a151-fb6bd428af0d",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "value",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_uptime_in_seconds--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_uptime_in_seconds",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "latest",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "8b0c5622",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "Uptime",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "latest",
+                            "spaceAggregation": "sum",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "a565f59f-6fe7-43cc-8cf3-02cb79664b62",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Uptime",
+            "yAxisUnit": "s",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "",
+            "fillSpans": false,
+            "id": "6ff52a5b-c33d-463d-bc78-0d147b0e649a",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "row",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "",
+                                "id": "------false",
+                                "isColumn": false,
+                                "isJSON": false,
+                                "key": "",
+                                "type": ""
+                            },
+                            "aggregateOperator": "count",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [],
+                                "op": "AND"
+                            },
+                            "groupBy": [],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "sum",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "avg",
+                            "spaceAggregation": "sum",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "c3904048-7789-4bac-8703-84443401d33b",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Memory",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Redis used memory vs max memory over time",
+            "fillSpans": false,
+            "id": "098c8b54-25c3-4d1a-ad50-36b2f4024400",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_memory_used_bytes--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_memory_used_bytes",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "avg",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "7eb4a514",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "Used Memory",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "avg",
+                            "spaceAggregation": "avg",
+                            "ShiftBy": 0
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_memory_max_bytes--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_memory_max_bytes",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "avg",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "a7baf5d7",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "Max Memory",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "avg",
+                            "spaceAggregation": "avg",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "281625b8-bf8b-496d-8f24-9053539b43be",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Memory Usage Over Time",
+            "yAxisUnit": "bytes",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Ratio of memory allocated by the OS to memory requested by Redis. Values > 1.5 indicate fragmentation",
+            "fillSpans": false,
+            "id": "60184ddc-32f8-4897-9473-327ef7d654ff",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_mem_fragmentation_ratio--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_mem_fragmentation_ratio",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "avg",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "badd49df",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "Fragmentation Ratio",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "avg",
+                            "spaceAggregation": "avg",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "7c1720fd-8ecc-4815-ac58-e48cc8ff68dc",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Memory Fragmentation Ratio",
+            "yAxisUnit": "short",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Resident Set Size memory used by Redis as seen by the OS",
+            "fillSpans": false,
+            "id": "ec78c87d-af85-40d9-8dcc-0cc4130eb61c",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_memory_used_rss_bytes--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_memory_used_rss_bytes",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "avg",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "6435f585",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "RSS Memory",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "avg",
+                            "spaceAggregation": "avg",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "d6f7d42c-2c8d-4281-8af7-5c5ac7bce8aa",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "RSS Memory",
+            "yAxisUnit": "bytes",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Memory used by the dataset (key-value data) excluding overhead",
+            "fillSpans": false,
+            "id": "b8aa7976-e3c0-4c31-8cd9-9048f821df7c",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_memory_used_dataset_bytes--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_memory_used_dataset_bytes",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "avg",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "4402306b",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "Dataset Memory",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "avg",
+                            "spaceAggregation": "avg",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "17d09766-3f7b-4ea8-98e7-ab07dabb9573",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Memory by Dataset",
+            "yAxisUnit": "bytes",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Rate of keys evicted due to maxmemory limit",
+            "fillSpans": false,
+            "id": "2ef7aec6-797c-4e03-8c73-d272d3d9c69b",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_evicted_keys_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_evicted_keys_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "sum_rate",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "08a9d0f7",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "Evicted Keys/s",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "rate",
+                            "spaceAggregation": "sum",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "ffd188a3-4cc9-4d78-8ed3-97a1fa576061",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Evicted Keys",
+            "yAxisUnit": "short",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Rate of keys expired due to TTL",
+            "fillSpans": false,
+            "id": "ab4bd726-be03-4ea8-a07f-8ac02b0b9177",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_expired_keys_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_expired_keys_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "sum_rate",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "ece151be",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "Expired Keys/s",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "rate",
+                            "spaceAggregation": "sum",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "8bd74112-800e-4e38-8217-b9865d00ed03",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Expired Keys",
+            "yAxisUnit": "short",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "",
+            "fillSpans": false,
+            "id": "f1c439b2-3bf7-4dc9-a7f3-96906dbb7703",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "row",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "",
+                                "id": "------false",
+                                "isColumn": false,
+                                "isJSON": false,
+                                "key": "",
+                                "type": ""
+                            },
+                            "aggregateOperator": "count",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [],
+                                "op": "AND"
+                            },
+                            "groupBy": [],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "sum",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "avg",
+                            "spaceAggregation": "sum",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "3c8c6ce4-61b7-4d78-a723-1c71e8df86a4",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Performance",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Rate of commands processed by the Redis server",
+            "fillSpans": false,
+            "id": "5137214a-a8ab-4845-9c5d-400d0b30d4d1",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_commands_processed_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_commands_processed_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "962d9fdd",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "Commands/s",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "rate",
+                            "spaceAggregation": "sum",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "82380628-eab1-42f2-a657-89438db0fe0c",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Commands Processed/sec",
+            "yAxisUnit": "ops",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Instantaneous number of operations per second reported by Redis",
+            "fillSpans": false,
+            "id": "9f7d2d30-c248-4aa4-bc14-c1bf7e85e8e8",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_instantaneous_ops_per_sec--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_instantaneous_ops_per_sec",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "avg",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "0db6de9c",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "Ops/s",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "avg",
+                            "spaceAggregation": "avg",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "d3b564bf-6b05-4b91-9a2c-7fc249761959",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Instantaneous Ops/sec",
+            "yAxisUnit": "ops",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Percentage of successful key lookups (hits / (hits + misses))",
+            "fillSpans": false,
+            "id": "fbc1eebb-315c-4aae-bc0f-a511db120087",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_keyspace_hits_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_keyspace_hits_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "22710c06",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "Hits/s",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "rate",
+                            "spaceAggregation": "sum",
+                            "ShiftBy": 0
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_keyspace_misses_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_keyspace_misses_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "b8100f03",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "Misses/s",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "rate",
+                            "spaceAggregation": "sum",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": [
+                        {
+                            "disabled": false,
+                            "expression": "A / (A + B) * 100",
+                            "legend": "Hit Rate %",
+                            "queryName": "F1"
+                        }
+                    ]
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "a4ac2800-9f5d-4e6c-92a7-2370ad754dfb",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Hit Rate",
+            "yAxisUnit": "percent",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Duration of command execution broken down by command type",
+            "fillSpans": false,
+            "id": "780355ef-795f-44d8-94dc-5b2f2a8730de",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_commands_duration_seconds_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_commands_duration_seconds_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "e3517827",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "cmd--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "cmd",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{cmd}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "rate",
+                            "spaceAggregation": "sum",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "f4b4f34c-a5c5-4812-be50-56bed76b2988",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Latency by Command",
+            "yAxisUnit": "s",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Number of entries in the Redis slowlog",
+            "fillSpans": false,
+            "id": "0c6c769b-07c7-45e4-b8d5-76cd48659cf2",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_slowlog_length--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_slowlog_length",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "avg",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "f080c2cb",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "Slowlog Length",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "avg",
+                            "spaceAggregation": "avg",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "7b10ab07-de1d-49bb-a5b0-33f999216f11",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Slowlog Length",
+            "yAxisUnit": "short",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Rate of commands executed broken down by command type",
+            "fillSpans": false,
+            "id": "56d86715-47b5-4d2b-962d-214aff69f8df",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_commands_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_commands_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "302944db",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "cmd--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "cmd",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{cmd}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "rate",
+                            "spaceAggregation": "sum",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "dc60d03c-43df-4592-9a6b-00596807d80e",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Command Calls by Type",
+            "yAxisUnit": "ops",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "",
+            "fillSpans": false,
+            "id": "f4cb6806-8e82-4c4a-874b-3bf2520633ae",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "row",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "",
+                                "id": "------false",
+                                "isColumn": false,
+                                "isJSON": false,
+                                "key": "",
+                                "type": ""
+                            },
+                            "aggregateOperator": "count",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [],
+                                "op": "AND"
+                            },
+                            "groupBy": [],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "sum",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "avg",
+                            "spaceAggregation": "sum",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "168c2c63-ce77-4d08-95c8-874fceff4e45",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Connections",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Number of connected clients over time",
+            "fillSpans": false,
+            "id": "e30711f5-269f-4d9a-ab82-607d206e140e",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_connected_clients--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_connected_clients",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "avg",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "9980e665",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "Connected Clients",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "avg",
+                            "spaceAggregation": "avg",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "0402e4a6-080d-4419-b619-2405f2d7d086",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Connected Clients Over Time",
+            "yAxisUnit": "short",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Number of clients pending on a blocking call (BLPOP, BRPOP, BRPOPLPUSH, etc.)",
+            "fillSpans": false,
+            "id": "eec65ae0-4401-4abe-8655-2f4b5ad8df2f",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_blocked_clients--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_blocked_clients",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "avg",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "4aec4e3d",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "Blocked Clients",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "avg",
+                            "spaceAggregation": "avg",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "8ae58986-0796-4536-ba79-11dbede16b8c",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Blocked Clients",
+            "yAxisUnit": "short",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Rate of new connections received by the Redis server",
+            "fillSpans": false,
+            "id": "415fc761-49d5-48ba-8255-230680ccbccc",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_connections_received_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_connections_received_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "3b9c52ac",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "Connections/s",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "rate",
+                            "spaceAggregation": "sum",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "ce78ebf5-c248-497c-b65f-616136698d0b",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Connections Received",
+            "yAxisUnit": "ops",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Rate of connections rejected due to maxclients limit",
+            "fillSpans": false,
+            "id": "7f629342-b9b6-45ba-8bb0-596cf7c95b6d",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_rejected_connections_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_rejected_connections_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "22253672",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "Rejected/s",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "rate",
+                            "spaceAggregation": "sum",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "87753957-21b5-4413-b8e5-c74a34b04a07",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Rejected Connections",
+            "yAxisUnit": "ops",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "",
+            "fillSpans": false,
+            "id": "fd16fa67-47e4-4315-85cd-86d28ad248bb",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "row",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "",
+                                "id": "------false",
+                                "isColumn": false,
+                                "isJSON": false,
+                                "key": "",
+                                "type": ""
+                            },
+                            "aggregateOperator": "count",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [],
+                                "op": "AND"
+                            },
+                            "groupBy": [],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "sum",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "avg",
+                            "spaceAggregation": "sum",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "50d6d7cd-57be-4260-a3cf-e78fbabe136f",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Persistence",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Status of the last RDB background save operation (1=success, 0=failure)",
+            "fillSpans": false,
+            "id": "22ea8fb0-9e79-442f-a4e0-916ed30ed1f2",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "value",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_rdb_last_bgsave_status--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_rdb_last_bgsave_status",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "latest",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "dbbbefa9",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "RDB Save Status",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "latest",
+                            "spaceAggregation": "sum",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "46aa71fa-1919-4dda-9c8d-a99dee4c5f29",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "RDB Last Save Status",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Number of changes since the last RDB dump",
+            "fillSpans": false,
+            "id": "4f2392c3-f3af-44b2-a897-f459d1716897",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_rdb_changes_since_last_save--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_rdb_changes_since_last_save",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "avg",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "22ae3187",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "Changes",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "avg",
+                            "spaceAggregation": "avg",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "a538bce3-c328-491f-b21d-713f6708d4ad",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "RDB Changes Since Last Save",
+            "yAxisUnit": "short",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Duration of the last AOF rewrite operation in seconds",
+            "fillSpans": false,
+            "id": "cd3996c3-ede0-4556-b935-30eda3f0e940",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "value",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_aof_last_rewrite_duration_sec--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_aof_last_rewrite_duration_sec",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "latest",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "3bb2b6d0",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "AOF Rewrite Duration",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "latest",
+                            "spaceAggregation": "sum",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "fb9048d4-aeae-445d-8cee-c87a3ca5f40c",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "AOF Rewrite Duration",
+            "yAxisUnit": "s",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Current size of the AOF file in bytes",
+            "fillSpans": false,
+            "id": "33634483-2e18-4e09-ae3a-8040d7e7c979",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_aof_current_size_bytes--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_aof_current_size_bytes",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "avg",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "5f5327fc",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "AOF Size",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "avg",
+                            "spaceAggregation": "avg",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "6dbf6f76-feba-4074-9093-cd99137f78a8",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "AOF Current Size",
+            "yAxisUnit": "bytes",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "",
+            "fillSpans": false,
+            "id": "29a636cb-8cbd-49ad-a10b-f24a5c3fdc8d",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "row",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "",
+                                "id": "------false",
+                                "isColumn": false,
+                                "isJSON": false,
+                                "key": "",
+                                "type": ""
+                            },
+                            "aggregateOperator": "count",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [],
+                                "op": "AND"
+                            },
+                            "groupBy": [],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "sum",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "avg",
+                            "spaceAggregation": "sum",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "b2d2366f-27cf-479d-a0d1-fe47c4634d41",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Replication",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Role of the Redis instance (master or slave)",
+            "fillSpans": false,
+            "id": "26d3345a-c7b1-413a-93a7-77620f14ca0b",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "value",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_instance_info--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_instance_info",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "latest",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "16967cc9",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "role--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "role",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{role}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "latest",
+                            "spaceAggregation": "sum",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "7158fb9b-0274-4e2c-b44a-22adc8d86070",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Replication Role",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Number of connected replica instances",
+            "fillSpans": false,
+            "id": "6494aa85-f4b7-4130-8cfa-f879699d73f6",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "value",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_connected_slaves--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_connected_slaves",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "latest",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "0d539164",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "Connected Replicas",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "latest",
+                            "spaceAggregation": "sum",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "040a17f7-714f-495d-9307-729dfe5ac40a",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Connected Replicas",
+            "yAxisUnit": "short",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Master replication offset indicating the amount of data replicated",
+            "fillSpans": false,
+            "id": "43d55dba-3482-410d-8ff0-3e6aea776c38",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_master_repl_offset--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_master_repl_offset",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "avg",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "74bb5711",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "Master Repl Offset",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "avg",
+                            "spaceAggregation": "avg",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "5d8daa8f-3718-4ff5-ba7c-d1283b2c91b9",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Replication Offset",
+            "yAxisUnit": "short",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Replication lag of connected replicas in seconds",
+            "fillSpans": false,
+            "id": "5a8538a0-bff3-4787-a35f-6866b3e55579",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_connected_slave_lag_seconds--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_connected_slave_lag_seconds",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "avg",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "3e53efb2",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "slave_ip--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "slave_ip",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "slave_port--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "slave_port",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{slave_ip}}:{{slave_port}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "avg",
+                            "spaceAggregation": "avg",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "ec3723bd-5186-4744-8080-eebeaf2dec39",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Replica Lag",
+            "yAxisUnit": "s",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "",
+            "fillSpans": false,
+            "id": "5dbc8c46-41d5-4fdc-b765-4f8a93b8f4cc",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "row",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "",
+                                "id": "------false",
+                                "isColumn": false,
+                                "isJSON": false,
+                                "key": "",
+                                "type": ""
+                            },
+                            "aggregateOperator": "count",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [],
+                                "op": "AND"
+                            },
+                            "groupBy": [],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "sum",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "avg",
+                            "spaceAggregation": "sum",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "5ac29919-78af-4565-8600-53f4f060df65",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Keyspace",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Total number of keys per database",
+            "fillSpans": false,
+            "id": "b435d577-ca70-411b-8990-f8be311c8a08",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_db_keys--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_db_keys",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "sum",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "458fbf59",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "db--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "db",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{db}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "avg",
+                            "spaceAggregation": "sum",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "c2799a68-174a-4376-be31-97133a6bf944",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Total Keys",
+            "yAxisUnit": "short",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Number of keys with an expiry set per database",
+            "fillSpans": false,
+            "id": "926125fb-b1a9-426a-b187-a1dcddc4c208",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_db_keys_expiring--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_db_keys_expiring",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "sum",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "42300a00",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "db--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "db",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{db}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "avg",
+                            "spaceAggregation": "sum",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "38c57b23-e0f2-4fcf-98f4-90fe73934096",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Keys with Expiry",
+            "yAxisUnit": "short",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Rate at which keys are expiring due to TTL",
+            "fillSpans": false,
+            "id": "1b883d13-9fb2-423a-858b-3f83b6adf6cb",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_expired_keys_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_expired_keys_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "510a2e69",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "Expiry Rate",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "rate",
+                            "spaceAggregation": "sum",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "c9acc5e4-932e-4149-8cd4-b2d0d33e7929",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Key Expiry Rate",
+            "yAxisUnit": "ops",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Rate at which keys are being evicted due to maxmemory policy",
+            "fillSpans": false,
+            "id": "5952bff1-36ab-458e-b001-57b01c301d50",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_evicted_keys_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_evicted_keys_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "a067c070",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "Eviction Rate",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "rate",
+                            "spaceAggregation": "sum",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "4c0d79a1-741e-44e0-b51f-811d6da62d9e",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Eviction Rate",
+            "yAxisUnit": "ops",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "",
+            "fillSpans": false,
+            "id": "103faad3-570b-4745-9353-66f402671ff3",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "row",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "",
+                                "id": "------false",
+                                "isColumn": false,
+                                "isJSON": false,
+                                "key": "",
+                                "type": ""
+                            },
+                            "aggregateOperator": "count",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [],
+                                "op": "AND"
+                            },
+                            "groupBy": [],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "sum",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "avg",
+                            "spaceAggregation": "sum",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "0c74436c-8820-40c5-ba2e-5e0ac406e540",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Network",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Rate of bytes received by the Redis server from network",
+            "fillSpans": false,
+            "id": "4cdfbf4e-8b7d-4fc1-afc3-a6ef0a8b49bb",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_net_input_bytes_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_net_input_bytes_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "e1ea4344",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "Input Bytes/s",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "rate",
+                            "spaceAggregation": "sum",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "c7817bfd-36bf-40e9-99d0-5530f1afc1ab",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Network Input",
+            "yAxisUnit": "binBps",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Rate of bytes sent by the Redis server to network",
+            "fillSpans": false,
+            "id": "58db21ad-272b-472b-a3a4-2c0ee185fddb",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_net_output_bytes_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_net_output_bytes_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "6e768eaf",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "Output Bytes/s",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "rate",
+                            "spaceAggregation": "sum",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "2cf9d583-21da-4553-a16a-f61cfb5f6699",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Network Output",
+            "yAxisUnit": "binBps",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Number of active pub/sub channels",
+            "fillSpans": false,
+            "id": "96f5a62b-4ea2-4519-a393-ed8a721f99cc",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_pubsub_channels--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_pubsub_channels",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "avg",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "d8882309",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "Pub/Sub Channels",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "avg",
+                            "spaceAggregation": "avg",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "b10afeff-1502-4572-bf6e-563c7fc05861",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Pub/Sub Channels",
+            "yAxisUnit": "short",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Number of active pub/sub pattern subscriptions",
+            "fillSpans": false,
+            "id": "116baa53-05c4-405a-b325-ca3c6fa1154d",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_pubsub_patterns--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_pubsub_patterns",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "avg",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "72702e09",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "Pub/Sub Patterns",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "avg",
+                            "spaceAggregation": "avg",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "48d2f02b-4489-4ef5-9f79-6cc62de56a7d",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Pub/Sub Patterns",
+            "yAxisUnit": "short",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "",
+            "fillSpans": false,
+            "id": "468f0445-5d20-4b7b-b0e4-816f55917c8f",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "row",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "",
+                                "id": "------false",
+                                "isColumn": false,
+                                "isJSON": false,
+                                "key": "",
+                                "type": ""
+                            },
+                            "aggregateOperator": "count",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [],
+                                "op": "AND"
+                            },
+                            "groupBy": [],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "sum",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "avg",
+                            "spaceAggregation": "sum",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "151a5bef-9357-4a86-b2b9-c8d9c617d163",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "CPU",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Rate of system CPU consumed by the Redis server",
+            "fillSpans": false,
+            "id": "329ab20b-0e65-41af-8edf-6fe6c0f6cbe4",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_cpu_sys_seconds_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_cpu_sys_seconds_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "2d137473",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "System CPU",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "rate",
+                            "spaceAggregation": "sum",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "81c1d500-6b73-4756-a7f5-ea9b2ee53939",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "System CPU Usage",
+            "yAxisUnit": "s",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        },
+        {
+            "description": "Rate of user CPU consumed by the Redis server",
+            "fillSpans": false,
+            "id": "e08d9c26-ede3-46a7-9e8a-7d062b960148",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redis_cpu_user_seconds_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redis_cpu_user_seconds_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "0a2a1f72",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redis_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "User CPU",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "last",
+                            "stepInterval": 60,
+                            "functions": [],
+                            "offset": 0,
+                            "pageSize": 0,
+                            "timeAggregation": "rate",
+                            "spaceAggregation": "sum",
+                            "ShiftBy": 0
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "db7bbd9a-d095-45ff-81ba-16ac4ce1dbf2",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "User CPU Usage",
+            "yAxisUnit": "s",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "dataType": "string",
+                    "id": "serviceName--string--tag--true",
+                    "isColumn": true,
+                    "key": "serviceName",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "name--string--tag--true",
+                    "isColumn": true,
+                    "key": "name",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "durationNano--string--tag--true",
+                    "isColumn": true,
+                    "key": "durationNano",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "httpMethod--string--tag--true",
+                    "isColumn": true,
+                    "key": "httpMethod",
+                    "type": "tag"
+                },
+                {
+                    "dataType": "string",
+                    "id": "responseStatusCode--string--tag--true",
+                    "isColumn": true,
+                    "key": "responseStatusCode",
+                    "type": "tag"
+                }
+            ],
+            "stackedBarChart": false,
+            "mergeAllActiveQueries": false
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

Comprehensive Redis Prometheus monitoring dashboard with **47 panels** across 9 sections:

| Section | Panels | Key Metrics |
|---------|--------|-------------|
| Overview | 4 value | Up status, clients, memory, uptime |
| Memory | 6 | Usage, fragmentation, RSS, dataset, evictions |
| Performance | 6 | Commands/sec, hit rate, latency, slowlog |
| Connections | 4 | Connected/blocked clients, received/rejected |
| Persistence | 4 | RDB save, AOF rewrite, changes since save |
| Replication | 4 | Role, replicas, offset, lag |
| Keyspace | 4 | Total keys, expiring, expiry/eviction rate |
| Network | 4 | Input/output bytes, pub/sub channels |
| CPU | 2 | System and user CPU |

**Data source:** Prometheus metrics from [redis_exporter](https://github.com/oliver006/redis_exporter)

**Variables:** `{{redis_instance}}` for filtering by Redis instance

Closes SigNoz/signoz#6024

## Test plan
- [ ] Import JSON into SigNoz dashboard
- [ ] Verify all panels render with redis_exporter metrics
- [ ] Confirm variable filtering works

Closes SigNoz/signoz#6024