### PR TITLE
feat(dashboard): Add Redpanda Prometheus monitoring dashboard

### DIFF
--- a/redpanda/README.md
+++ b/redpanda/README.md
@@ -1,0 +1,70 @@
+# Redpanda Monitoring Dashboard - Prometheus
+
+Comprehensive Redpanda monitoring dashboard for [SigNoz](https://signoz.io/) using native Prometheus metrics exposed by Redpanda.
+
+## Sections
+
+| #   | Section          | Covers                                                          |
+| --- | ---------------- | --------------------------------------------------------------- |
+| 1   | Cluster Overview | Brokers online, partitions, unavailable/under-replicated status |
+| 2   | Throughput       | Produce/consume bytes/sec, messages/sec, latency p99            |
+| 3   | Topics           | Partition counts, log sizes, leaders, replicas                  |
+| 4   | Consumer Groups  | Lag, members, committed offsets, topics per group               |
+| 5   | RPC & Internal   | RPC connections, request errors, Raft leadership changes        |
+| 6   | Resources        | CPU, memory allocated/free, storage used/free, IO queue         |
+| 7   | Schema Registry  | Request rate, errors                                            |
+| 8   | Connections      | Active connections, connection rate                             |
+| 9   | Storage          | Disk utilization, compaction metrics                            |
+
+## Metrics Ingestion
+
+Redpanda exposes Prometheus metrics natively on port 9644.
+
+### Using OpenTelemetry Collector with Prometheus Receiver
+
+```yaml
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: "redpanda"
+          scrape_interval: 15s
+          static_configs:
+            - targets: ["redpanda-broker-1:9644", "redpanda-broker-2:9644"]
+          metric_relabel_configs:
+            - source_labels: [__name__]
+              regex: "redpanda_.*|vectorized_.*"
+              action: keep
+
+processors:
+  batch:
+    timeout: 10s
+  resource:
+    attributes:
+      - key: service.name
+        value: "redpanda"
+        action: insert
+
+exporters:
+  otlp:
+    endpoint: "ingest.<region>.signoz.cloud:443"
+    headers:
+      signoz-ingestion-key: "<your-ingestion-key>"
+
+service:
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      processors: [batch, resource]
+      exporters: [otlp]
+```
+
+## Variables
+
+- `{{redpanda_instance}}`: Redpanda broker instance for filtering metrics
+
+## Dashboard Panels (49 total)
+
+- **4 value panels** — instant cluster status metrics
+- **36 time series panels** — trends for throughput, latency, resources, and more
+- **9 section headers** — organized into logical monitoring categories

--- a/redpanda/redpanda-prometheus-v1.json
+++ b/redpanda/redpanda-prometheus-v1.json
@@ -1,0 +1,10484 @@
+{
+    "id": "redpanda-prometheus-overview",
+    "description": "Comprehensive Redpanda monitoring dashboard using native Prometheus metrics. Covers cluster health, throughput, topics, consumer groups, RPC internals, resources, and schema registry.\n",
+    "layout": [
+        {
+            "h": 1,
+            "i": "a2167d58-f2fc-4f40-87cf-8885957be2b4",
+            "moved": false,
+            "static": false,
+            "w": 12,
+            "x": 0,
+            "y": 0
+        },
+        {
+            "h": 3,
+            "i": "0f073eaf-e2ba-47dc-b738-6e10a9a945e7",
+            "moved": false,
+            "static": false,
+            "w": 3,
+            "x": 0,
+            "y": 1
+        },
+        {
+            "h": 3,
+            "i": "15e8c732-e71f-4154-a840-fdc1109f2e45",
+            "moved": false,
+            "static": false,
+            "w": 3,
+            "x": 3,
+            "y": 1
+        },
+        {
+            "h": 3,
+            "i": "ddb00a92-172e-475e-abd5-3edf2b883ecb",
+            "moved": false,
+            "static": false,
+            "w": 3,
+            "x": 6,
+            "y": 1
+        },
+        {
+            "h": 3,
+            "i": "d019468a-2422-4b17-8b49-5e430846ca14",
+            "moved": false,
+            "static": false,
+            "w": 3,
+            "x": 9,
+            "y": 1
+        },
+        {
+            "h": 1,
+            "i": "1010b279-92a8-467b-8cf1-08fc0bc3862c",
+            "moved": false,
+            "static": false,
+            "w": 12,
+            "x": 0,
+            "y": 4
+        },
+        {
+            "h": 3,
+            "i": "e18fb2b4-81a8-427e-89db-567ba00e5c39",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 5
+        },
+        {
+            "h": 3,
+            "i": "10da0763-7881-43c6-954d-110c4914e9d2",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 5
+        },
+        {
+            "h": 3,
+            "i": "69b7f7d4-47a0-414a-bb14-bcd67d4d80d5",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 8
+        },
+        {
+            "h": 3,
+            "i": "876e4bb8-dc97-4f72-887a-b62ce22554aa",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 8
+        },
+        {
+            "h": 3,
+            "i": "8439e01e-9707-4e00-b489-e21a0a8fd803",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 11
+        },
+        {
+            "h": 3,
+            "i": "33447587-9a2d-44d5-a1b5-721581e1c133",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 11
+        },
+        {
+            "h": 1,
+            "i": "2791b221-58b3-4073-8cbb-655e96f1182d",
+            "moved": false,
+            "static": false,
+            "w": 12,
+            "x": 0,
+            "y": 14
+        },
+        {
+            "h": 3,
+            "i": "296dbbe3-c98a-48a3-80b8-124a015b244a",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 15
+        },
+        {
+            "h": 3,
+            "i": "bb90ea85-0b59-4b17-8837-4c9b176dbbb1",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 15
+        },
+        {
+            "h": 3,
+            "i": "a250ce82-6d08-4b23-b846-756fe2baed78",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 18
+        },
+        {
+            "h": 3,
+            "i": "7982747b-faa4-450a-af35-ec9d939f1192",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 18
+        },
+        {
+            "h": 1,
+            "i": "9e990f31-395e-4c17-ad09-5bfe5593484e",
+            "moved": false,
+            "static": false,
+            "w": 12,
+            "x": 0,
+            "y": 21
+        },
+        {
+            "h": 3,
+            "i": "507556e8-b7dc-44b9-a81d-6faf9a3f65ec",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 22
+        },
+        {
+            "h": 3,
+            "i": "6819b276-ad96-44a5-ba3f-60a537dd926c",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 22
+        },
+        {
+            "h": 3,
+            "i": "cfd9985c-8bea-413d-bf06-184383d221aa",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 25
+        },
+        {
+            "h": 3,
+            "i": "9b18e7de-ff9a-4710-96cf-5e0abc762fb1",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 25
+        },
+        {
+            "h": 1,
+            "i": "8b87ebd9-e759-4d73-9301-924ca17ad825",
+            "moved": false,
+            "static": false,
+            "w": 12,
+            "x": 0,
+            "y": 28
+        },
+        {
+            "h": 3,
+            "i": "663a54e3-de5c-4d98-991e-3d6f3b814897",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 29
+        },
+        {
+            "h": 3,
+            "i": "8eeec767-0c6c-425c-a22f-3c025649bd38",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 29
+        },
+        {
+            "h": 3,
+            "i": "f738958d-725b-476f-9e26-357742af016f",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 32
+        },
+        {
+            "h": 3,
+            "i": "0e110b6f-8215-4310-ac42-5667d1328bee",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 32
+        },
+        {
+            "h": 1,
+            "i": "f935ed58-0d38-4b96-bab8-91f39a06b13d",
+            "moved": false,
+            "static": false,
+            "w": 12,
+            "x": 0,
+            "y": 35
+        },
+        {
+            "h": 3,
+            "i": "e3f0c5dc-e69d-4365-9752-f2b95536a2b8",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 36
+        },
+        {
+            "h": 3,
+            "i": "695a921e-887a-42de-aeca-a8580f032a88",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 36
+        },
+        {
+            "h": 3,
+            "i": "b241861a-6702-4237-b0a5-927abde1f02f",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 39
+        },
+        {
+            "h": 3,
+            "i": "253be663-d11f-447f-b5e7-bafae473f599",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 39
+        },
+        {
+            "h": 3,
+            "i": "c6f1ad97-c121-4b4f-9bde-97bc2351d887",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 42
+        },
+        {
+            "h": 3,
+            "i": "e1bc9004-4c9e-4fcc-9f62-819532cbf908",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 42
+        },
+        {
+            "h": 1,
+            "i": "4fb65215-25b8-4f26-82c7-053fb30451bd",
+            "moved": false,
+            "static": false,
+            "w": 12,
+            "x": 0,
+            "y": 45
+        },
+        {
+            "h": 3,
+            "i": "e0d26349-bf69-4b13-b930-b793a4bee84c",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 46
+        },
+        {
+            "h": 3,
+            "i": "a0a35e0f-9310-4698-a656-1374087a1cc9",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 46
+        },
+        {
+            "h": 1,
+            "i": "e861f4ab-13b4-44d1-b3d7-04a8e8af36a8",
+            "moved": false,
+            "static": false,
+            "w": 12,
+            "x": 0,
+            "y": 49
+        },
+        {
+            "h": 3,
+            "i": "3e3b55e3-a668-4375-976f-fde4403cdfc9",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 50
+        },
+        {
+            "h": 3,
+            "i": "2a797709-c996-47dd-90db-2857e2111d4b",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 50
+        },
+        {
+            "h": 3,
+            "i": "2e06168c-3280-45eb-85a7-71995faef707",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 53
+        },
+        {
+            "h": 3,
+            "i": "53c0ff4a-b4f8-41b1-ab5e-e03ea9ae71cd",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 53
+        },
+        {
+            "h": 3,
+            "i": "d0e138a2-d403-4121-9f4f-713c93d2b18a",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 56
+        },
+        {
+            "h": 3,
+            "i": "6cbc7492-078a-41cb-905b-d3259ac97c77",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 56
+        },
+        {
+            "h": 1,
+            "i": "aafdc469-5c70-4c18-8b18-6db1c4706023",
+            "moved": false,
+            "static": false,
+            "w": 12,
+            "x": 0,
+            "y": 59
+        },
+        {
+            "h": 3,
+            "i": "afdb998f-fbe2-468e-933d-b312eb5bfbd2",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 60
+        },
+        {
+            "h": 3,
+            "i": "dbfe5eee-3cc4-4acf-8f5f-363d47d50986",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 60
+        },
+        {
+            "h": 3,
+            "i": "452d6920-32d3-407d-869f-f5f36e0edc6b",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 63
+        },
+        {
+            "h": 3,
+            "i": "3aee51ec-e47e-4204-a765-9a64a6b761a4",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 63
+        }
+    ],
+    "name": "",
+    "tags": [
+        "redpanda",
+        "kafka",
+        "streaming",
+        "prometheus"
+    ],
+    "title": "Redpanda Prometheus Overview",
+    "variables": {
+        "4ceb7c9a-3a1b-441d-8798-b982ae0c4676": {
+            "allSelected": true,
+            "customValue": "",
+            "description": "Redpanda instance to filter metrics by",
+            "id": "4ceb7c9a-3a1b-441d-8798-b982ae0c4676",
+            "key": "4ceb7c9a-3a1b-441d-8798-b982ae0c4676",
+            "modificationUUID": "fde4b368-ddb8-4677-bf06-d24245a2f0e3",
+            "multiSelect": true,
+            "name": "redpanda_instance",
+            "order": 0,
+            "queryValue": "SELECT JSONExtractString(labels, 'instance') AS `instance`\nFROM signoz_metrics.distributed_time_series_v4_1day\nWHERE metric_name = 'redpanda_cluster_brokers'\nGROUP BY `instance`\nORDER BY `instance` ASC",
+            "selectedValue": [
+                ""
+            ],
+            "showALLOption": true,
+            "sort": "ASC",
+            "textboxValue": "",
+            "type": "QUERY"
+        },
+        "845257c7-a88f-4d35-b05d-968720ac4c4a": {
+            "allSelected": true,
+            "customValue": "",
+            "description": "Redpanda topic to filter metrics by",
+            "id": "845257c7-a88f-4d35-b05d-968720ac4c4a",
+            "key": "845257c7-a88f-4d35-b05d-968720ac4c4a",
+            "modificationUUID": "10152755-da8b-4a42-9496-9fb44a7625e4",
+            "multiSelect": true,
+            "name": "redpanda_topic",
+            "order": 1,
+            "queryValue": "SELECT JSONExtractString(labels, 'redpanda_topic') AS `redpanda_topic`\nFROM signoz_metrics.distributed_time_series_v4_1day\nWHERE metric_name = 'redpanda_kafka_partitions'\nGROUP BY `redpanda_topic`\nORDER BY `redpanda_topic` ASC",
+            "selectedValue": [
+                ""
+            ],
+            "showALLOption": true,
+            "sort": "ASC",
+            "textboxValue": "",
+            "type": "QUERY"
+        },
+        "991fdbe8-de84-42f5-bc23-b25c47d7bfa7": {
+            "allSelected": true,
+            "customValue": "",
+            "description": "Redpanda consumer group to filter metrics by",
+            "id": "991fdbe8-de84-42f5-bc23-b25c47d7bfa7",
+            "key": "991fdbe8-de84-42f5-bc23-b25c47d7bfa7",
+            "modificationUUID": "f00b4b82-0bb8-4a71-9c99-2c58161a1a36",
+            "multiSelect": true,
+            "name": "redpanda_group",
+            "order": 2,
+            "queryValue": "SELECT JSONExtractString(labels, 'redpanda_group') AS `redpanda_group`\nFROM signoz_metrics.distributed_time_series_v4_1day\nWHERE metric_name = 'redpanda_kafka_consumer_group_lag'\nGROUP BY `redpanda_group`\nORDER BY `redpanda_group` ASC",
+            "selectedValue": [
+                ""
+            ],
+            "showALLOption": true,
+            "sort": "ASC",
+            "textboxValue": "",
+            "type": "QUERY"
+        }
+    },
+    "widgets": [
+        {
+            "description": "",
+            "fillSpans": false,
+            "id": "a2167d58-f2fc-4f40-87cf-8885957be2b4",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "row",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "",
+                                "id": "------false",
+                                "isColumn": false,
+                                "isJSON": false,
+                                "key": "",
+                                "type": ""
+                            },
+                            "aggregateOperator": "count",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [],
+                                "op": "AND"
+                            },
+                            "groupBy": [],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "sum",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "b201d01b-79d5-40e9-abd1-7eb34c9014be",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Cluster Overview",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "stackedBarChart": false
+        },
+        {
+            "description": "Cluster health status. 1 = Healthy (no unavailable partitions), 0 = Unhealthy",
+            "fillSpans": false,
+            "id": "0f073eaf-e2ba-47dc-b738-6e10a9a945e7",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "value",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_cluster_unavailable_partitions--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_cluster_unavailable_partitions",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "latest",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "6a06cf8d",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [],
+                            "having": [],
+                            "legend": "Status",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "latest",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "580a1582-bf70-4d6f-8573-3eb84a8f32fa",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [
+                {
+                    "color": "#2ecc71",
+                    "index": 0,
+                    "isEditEnabled": false,
+                    "moveEnabled": false,
+                    "value": 0
+                },
+                {
+                    "color": "#e74c3c",
+                    "index": 1,
+                    "isEditEnabled": true,
+                    "moveEnabled": true,
+                    "value": 1
+                }
+            ],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Cluster Status",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "stackedBarChart": false
+        },
+        {
+            "description": "Number of active brokers in the Redpanda cluster",
+            "fillSpans": false,
+            "id": "15e8c732-e71f-4154-a840-fdc1109f2e45",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "value",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_cluster_brokers--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_cluster_brokers",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "latest",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "2554e58d",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [],
+                            "having": [],
+                            "legend": "Brokers",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "latest",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "7701152c-e88d-49e1-b23e-05df1c85f857",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Brokers Online",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "stackedBarChart": false
+        },
+        {
+            "description": "Total number of partitions across all topics in the cluster",
+            "fillSpans": false,
+            "id": "ddb00a92-172e-475e-abd5-3edf2b883ecb",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "value",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_cluster_partitions--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_cluster_partitions",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "latest",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "bc15b487",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [],
+                            "having": [],
+                            "legend": "Partitions",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "latest",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "12245b4f-84bc-43dc-9f22-e6786c764bea",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Total Partitions",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "stackedBarChart": false
+        },
+        {
+            "description": "Number of partitions that have fewer replicas than the configured replication factor",
+            "fillSpans": false,
+            "id": "d019468a-2422-4b17-8b49-5e430846ca14",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "value",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_cluster_under_replicated_partitions--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_cluster_under_replicated_partitions",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "latest",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "204afd24",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [],
+                            "having": [],
+                            "legend": "Under-replicated",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "latest",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "cbaf352e-fdd5-4be1-848a-a0ef40ff14a1",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [
+                {
+                    "color": "#2ecc71",
+                    "index": 0,
+                    "isEditEnabled": false,
+                    "moveEnabled": false,
+                    "value": 0
+                },
+                {
+                    "color": "#f39c12",
+                    "index": 1,
+                    "isEditEnabled": true,
+                    "moveEnabled": true,
+                    "value": 1
+                },
+                {
+                    "color": "#e74c3c",
+                    "index": 2,
+                    "isEditEnabled": true,
+                    "moveEnabled": true,
+                    "value": 10
+                }
+            ],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Under-replicated Partitions",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "stackedBarChart": false
+        },
+        {
+            "description": "",
+            "fillSpans": false,
+            "id": "1010b279-92a8-467b-8cf1-08fc0bc3862c",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "row",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "",
+                                "id": "------false",
+                                "isColumn": false,
+                                "isJSON": false,
+                                "key": "",
+                                "type": ""
+                            },
+                            "aggregateOperator": "count",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [],
+                                "op": "AND"
+                            },
+                            "groupBy": [],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "sum",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "57fe16da-c2c5-473b-a281-66c60fa12235",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Throughput",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "stackedBarChart": false
+        },
+        {
+            "description": "Rate of bytes produced to the cluster by producers across all topics and partitions",
+            "fillSpans": false,
+            "id": "e18fb2b4-81a8-427e-89db-567ba00e5c39",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_request_bytes_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_request_bytes_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "473c6b16",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    },
+                                    {
+                                        "id": "b4b93f80",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "redpanda_cmd--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "redpanda_cmd",
+                                            "type": "tag"
+                                        },
+                                        "op": "=",
+                                        "value": "produce"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{instance}} - {{redpanda_topic}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_request_bytes_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_request_bytes_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "6723b4d2",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    },
+                                    {
+                                        "id": "0dd7da98",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "redpanda_cmd--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "redpanda_cmd",
+                                            "type": "tag"
+                                        },
+                                        "op": "=",
+                                        "value": "produce"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_request_bytes_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_request_bytes_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "ed4b2288",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    },
+                                    {
+                                        "id": "d17b3559",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "redpanda_cmd--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "redpanda_cmd",
+                                            "type": "tag"
+                                        },
+                                        "op": "=",
+                                        "value": "produce"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "c33b3052-dd61-432e-8b33-22df93c4ad7f",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Bytes Produced per Second",
+            "yAxisUnit": "binBps",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "Rate of bytes consumed from the cluster by consumers across all topics and partitions",
+            "fillSpans": false,
+            "id": "10da0763-7881-43c6-954d-110c4914e9d2",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_request_bytes_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_request_bytes_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "2e814051",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    },
+                                    {
+                                        "id": "def592a3",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "redpanda_cmd--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "redpanda_cmd",
+                                            "type": "tag"
+                                        },
+                                        "op": "=",
+                                        "value": "fetch"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{instance}} - {{redpanda_topic}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_request_bytes_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_request_bytes_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "84a64e5f",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    },
+                                    {
+                                        "id": "9e45c5ec",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "redpanda_cmd--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "redpanda_cmd",
+                                            "type": "tag"
+                                        },
+                                        "op": "=",
+                                        "value": "fetch"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_request_bytes_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_request_bytes_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "1fefef47",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    },
+                                    {
+                                        "id": "eaea0e3f",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "redpanda_cmd--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "redpanda_cmd",
+                                            "type": "tag"
+                                        },
+                                        "op": "=",
+                                        "value": "fetch"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "ab885e66-f9a8-4e08-aafd-9662d9b6a674",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Bytes Consumed per Second",
+            "yAxisUnit": "binBps",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "Rate of messages (records) produced to the cluster per second",
+            "fillSpans": false,
+            "id": "69b7f7d4-47a0-414a-bb14-bcd67d4d80d5",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_records_produced_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_records_produced_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "72bb7f05",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_topic--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_topic",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{instance}} - {{redpanda_topic}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_records_produced_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_records_produced_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "dae2c0a3",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_topic--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_topic",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_records_produced_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_records_produced_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "2d5f5fd0",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_topic--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_topic",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "c5dd76bf-3a62-45d2-a153-447ea38f48a0",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Messages Produced per Second",
+            "yAxisUnit": "ops",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "Rate of messages (records) fetched/consumed from the cluster per second",
+            "fillSpans": false,
+            "id": "876e4bb8-dc97-4f72-887a-b62ce22554aa",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_records_fetched_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_records_fetched_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "80cc5f0f",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_topic--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_topic",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{instance}} - {{redpanda_topic}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_records_fetched_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_records_fetched_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "5409864e",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_topic--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_topic",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_records_fetched_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_records_fetched_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "778f83b0",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_topic--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_topic",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "eceddb01-f427-44d6-98fd-ea68f98b1bd2",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Messages Consumed per Second",
+            "yAxisUnit": "ops",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "99th percentile latency for produce requests in the cluster",
+            "fillSpans": false,
+            "id": "8439e01e-9707-4e00-b489-e21a0a8fd803",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_request_latency_seconds_bucket--float64--Histogram--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_request_latency_seconds_bucket",
+                                "type": "Histogram"
+                            },
+                            "aggregateOperator": "p99",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "1676bcf0",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    },
+                                    {
+                                        "id": "983be531",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "redpanda_cmd--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "redpanda_cmd",
+                                            "type": "tag"
+                                        },
+                                        "op": "=",
+                                        "value": "produce"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "p99 {{instance}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_request_latency_seconds_bucket--float64--Histogram--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_request_latency_seconds_bucket",
+                                "type": "Histogram"
+                            },
+                            "aggregateOperator": "p99",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "fc4dc3b1",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    },
+                                    {
+                                        "id": "abfeffaa",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "redpanda_cmd--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "redpanda_cmd",
+                                            "type": "tag"
+                                        },
+                                        "op": "=",
+                                        "value": "produce"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_request_latency_seconds_bucket--float64--Histogram--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_request_latency_seconds_bucket",
+                                "type": "Histogram"
+                            },
+                            "aggregateOperator": "p99",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "105dd4a1",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    },
+                                    {
+                                        "id": "a9391ec0",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "redpanda_cmd--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "redpanda_cmd",
+                                            "type": "tag"
+                                        },
+                                        "op": "=",
+                                        "value": "produce"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "eca31159-3da7-4fca-9021-0a49c367dbc6",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Produce Latency p99",
+            "yAxisUnit": "s",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "99th percentile latency for fetch/consume requests in the cluster",
+            "fillSpans": false,
+            "id": "33447587-9a2d-44d5-a1b5-721581e1c133",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_request_latency_seconds_bucket--float64--Histogram--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_request_latency_seconds_bucket",
+                                "type": "Histogram"
+                            },
+                            "aggregateOperator": "p99",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "ca2beaa0",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    },
+                                    {
+                                        "id": "a4aefedb",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "redpanda_cmd--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "redpanda_cmd",
+                                            "type": "tag"
+                                        },
+                                        "op": "=",
+                                        "value": "fetch"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "p99 {{instance}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_request_latency_seconds_bucket--float64--Histogram--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_request_latency_seconds_bucket",
+                                "type": "Histogram"
+                            },
+                            "aggregateOperator": "p99",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "51ee6522",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    },
+                                    {
+                                        "id": "9eb1c1ae",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "redpanda_cmd--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "redpanda_cmd",
+                                            "type": "tag"
+                                        },
+                                        "op": "=",
+                                        "value": "fetch"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_request_latency_seconds_bucket--float64--Histogram--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_request_latency_seconds_bucket",
+                                "type": "Histogram"
+                            },
+                            "aggregateOperator": "p99",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "de7f55a2",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    },
+                                    {
+                                        "id": "d653ddb1",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "redpanda_cmd--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "redpanda_cmd",
+                                            "type": "tag"
+                                        },
+                                        "op": "=",
+                                        "value": "fetch"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "a0bb3a2b-3244-48cb-8000-22d6357d1a2d",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Fetch Latency p99",
+            "yAxisUnit": "s",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "",
+            "fillSpans": false,
+            "id": "2791b221-58b3-4073-8cbb-655e96f1182d",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "row",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "",
+                                "id": "------false",
+                                "isColumn": false,
+                                "isJSON": false,
+                                "key": "",
+                                "type": ""
+                            },
+                            "aggregateOperator": "count",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [],
+                                "op": "AND"
+                            },
+                            "groupBy": [],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "sum",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "7b3eac03-5a51-429f-949a-7a19fb85fe81",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Topics & Partitions",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "stackedBarChart": false
+        },
+        {
+            "description": "Number of partitions per topic showing distribution of data partitioning across the cluster",
+            "fillSpans": false,
+            "id": "296dbbe3-c98a-48a3-80b8-124a015b244a",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_partitions--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_partitions",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "sum",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "12888e2b",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_topic--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_topic",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{redpanda_topic}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_partitions--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_partitions",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "sum",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "bfd7e13d",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_topic--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_topic",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_partitions--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_partitions",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "sum",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "70d27bab",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_topic--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_topic",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "cdde8d9e-3d72-4071-bc75-1814014a420a",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Topic Partition Count",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "Total log size in bytes per topic showing disk space consumption",
+            "fillSpans": false,
+            "id": "bb90ea85-0b59-4b17-8837-4c9b176dbbb1",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_log_size_bytes--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_log_size_bytes",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "sum",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "287bbff3",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_topic--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_topic",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{redpanda_topic}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_log_size_bytes--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_log_size_bytes",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "sum",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "3c478922",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_topic--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_topic",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_log_size_bytes--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_log_size_bytes",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "sum",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "36c255ae",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_topic--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_topic",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "9f5472e2-9e61-47f0-adae-49fa6b8d4341",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Log Size by Topic",
+            "yAxisUnit": "bytes",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "Number of partition leaders per broker showing leadership distribution across the cluster",
+            "fillSpans": false,
+            "id": "a250ce82-6d08-4b23-b846-756fe2baed78",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_partition_leader_count--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_partition_leader_count",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "sum",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "792b2bd6",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{instance}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_partition_leader_count--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_partition_leader_count",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "sum",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "1ac78003",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_partition_leader_count--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_partition_leader_count",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "sum",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "70b6d018",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "eec72cec-4156-486a-90f7-33a429a61333",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Partition Leader Count per Broker",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "Total number of partition replicas across the cluster including both leaders and followers",
+            "fillSpans": false,
+            "id": "7982747b-faa4-450a-af35-ec9d939f1192",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_replicas--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_replicas",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "sum",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "2b623520",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_topic--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_topic",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{instance}} - {{redpanda_topic}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_replicas--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_replicas",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "sum",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "7dd7f7de",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_topic--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_topic",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_replicas--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_replicas",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "sum",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "85472380",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_topic--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_topic",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "ddfff24a-f1d5-450b-9168-751a42759a48",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Partition Replicas",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "",
+            "fillSpans": false,
+            "id": "9e990f31-395e-4c17-ad09-5bfe5593484e",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "row",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "",
+                                "id": "------false",
+                                "isColumn": false,
+                                "isJSON": false,
+                                "key": "",
+                                "type": ""
+                            },
+                            "aggregateOperator": "count",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [],
+                                "op": "AND"
+                            },
+                            "groupBy": [],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "sum",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "60fea5ec-6d47-4c9a-94ad-9b2462244a0b",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Consumer Groups",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "stackedBarChart": false
+        },
+        {
+            "description": "Number of messages a consumer group is behind the latest offset for each topic partition. High lag indicates consumers cannot keep up with producers.",
+            "fillSpans": false,
+            "id": "507556e8-b7dc-44b9-a81d-6faf9a3f65ec",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_consumer_group_lag--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_consumer_group_lag",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "max",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "e39b923e",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_group--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_group",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_topic--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_topic",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{redpanda_group}} - {{redpanda_topic}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_consumer_group_lag--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_consumer_group_lag",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "max",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "9af60447",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_group--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_group",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_topic--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_topic",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_consumer_group_lag--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_consumer_group_lag",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "max",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "0fcfd645",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_group--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_group",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_topic--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_topic",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "b368ace6-0d12-48ec-8fe6-b81950bb55bf",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Consumer Group Lag",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "Number of active members (consumers) in each consumer group",
+            "fillSpans": false,
+            "id": "6819b276-ad96-44a5-ba3f-60a537dd926c",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_consumer_group_members--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_consumer_group_members",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "sum",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "6a424cae",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_group--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_group",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{redpanda_group}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_consumer_group_members--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_consumer_group_members",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "sum",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "81362c9f",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_group--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_group",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_consumer_group_members--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_consumer_group_members",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "sum",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "e1371ffc",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_group--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_group",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "fa08d6f6-1bda-4692-ba5d-dd510da463bf",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Consumer Group Members",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "Latest committed offset for each consumer group and topic partition showing consumption progress",
+            "fillSpans": false,
+            "id": "cfd9985c-8bea-413d-bf06-184383d221aa",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_consumer_group_committed_offset--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_consumer_group_committed_offset",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "max",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "2ef176d8",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_group--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_group",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_topic--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_topic",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{redpanda_group}} - {{redpanda_topic}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_consumer_group_committed_offset--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_consumer_group_committed_offset",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "max",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "d1093077",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_group--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_group",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_topic--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_topic",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_consumer_group_committed_offset--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_consumer_group_committed_offset",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "max",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "429e26a2",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_group--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_group",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_topic--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_topic",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "646c5bbf-644b-4468-8e98-1507fb7493c4",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Consumer Group Committed Offset",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "Number of topics each consumer group is subscribed to",
+            "fillSpans": false,
+            "id": "9b18e7de-ff9a-4710-96cf-5e0abc762fb1",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_consumer_group_topics--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_consumer_group_topics",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "sum",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "43d88c60",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_group--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_group",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{redpanda_group}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_consumer_group_topics--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_consumer_group_topics",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "sum",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "daa59350",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_group--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_group",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_consumer_group_topics--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_consumer_group_topics",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "sum",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "ed848624",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_group--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_group",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "abe7b90a-a730-4659-897b-010a305d60f2",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Consumer Group Topics",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "",
+            "fillSpans": false,
+            "id": "8b87ebd9-e759-4d73-9301-924ca17ad825",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "row",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "",
+                                "id": "------false",
+                                "isColumn": false,
+                                "isJSON": false,
+                                "key": "",
+                                "type": ""
+                            },
+                            "aggregateOperator": "count",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [],
+                                "op": "AND"
+                            },
+                            "groupBy": [],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "sum",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "9152d2c9-281f-4216-8060-d9f809c19794",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "RPC & Internal",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "stackedBarChart": false
+        },
+        {
+            "description": "Number of currently active RPC connections between brokers in the cluster for inter-broker communication",
+            "fillSpans": false,
+            "id": "663a54e3-de5c-4d98-991e-3d6f3b814897",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_rpc_active_connections--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_rpc_active_connections",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "sum",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "41bd3eb8",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_server--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_server",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{instance}} - {{redpanda_server}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_rpc_active_connections--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_rpc_active_connections",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "sum",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "88559894",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_server--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_server",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_rpc_active_connections--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_rpc_active_connections",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "sum",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "f98c8781",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_server--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_server",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "c26e6b51-7205-4dcd-a741-f293a0dbf506",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "RPC Active Connections",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "Rate of RPC request errors between brokers. Non-zero values may indicate network issues or broker failures.",
+            "fillSpans": false,
+            "id": "8eeec767-0c6c-425c-a22f-3c025649bd38",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_rpc_request_errors_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_rpc_request_errors_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "17c0afcb",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_server--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_server",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{instance}} - {{redpanda_server}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_rpc_request_errors_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_rpc_request_errors_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "4eb6e2cb",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_server--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_server",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_rpc_request_errors_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_rpc_request_errors_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "8385c885",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "redpanda_server--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "redpanda_server",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "31fb89ed-89b2-424e-81ae-5f5c45a9b46f",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "RPC Request Errors Rate",
+            "yAxisUnit": "ops",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "Rate of Raft leadership changes across partitions. Frequent changes may indicate instability in the cluster.",
+            "fillSpans": false,
+            "id": "f738958d-725b-476f-9e26-357742af016f",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_raft_leadership_changes_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_raft_leadership_changes_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "a55ecc3f",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{instance}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_raft_leadership_changes_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_raft_leadership_changes_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "2fb755ba",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_raft_leadership_changes_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_raft_leadership_changes_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "cd409e22",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "f728317d-de40-4e79-be2d-f695aebc6d3a",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Raft Leadership Changes Rate",
+            "yAxisUnit": "ops",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "Number of partition movement operations during Raft recovery processes",
+            "fillSpans": false,
+            "id": "0e110b6f-8215-4310-ac42-5667d1328bee",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_raft_recovery_partition_movement_operations--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_raft_recovery_partition_movement_operations",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "sum",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "eaf4473e",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{instance}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_raft_recovery_partition_movement_operations--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_raft_recovery_partition_movement_operations",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "sum",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "e50c4605",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_raft_recovery_partition_movement_operations--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_raft_recovery_partition_movement_operations",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "sum",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "f1dd0758",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "db7e40b3-b642-4182-93c7-1e3d738db835",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Raft Recovery Partition Movements",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "",
+            "fillSpans": false,
+            "id": "f935ed58-0d38-4b96-bab8-91f39a06b13d",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "row",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "",
+                                "id": "------false",
+                                "isColumn": false,
+                                "isJSON": false,
+                                "key": "",
+                                "type": ""
+                            },
+                            "aggregateOperator": "count",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [],
+                                "op": "AND"
+                            },
+                            "groupBy": [],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "sum",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "59490c39-1895-4ac6-a8c3-cc6f73b30666",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Resources",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "stackedBarChart": false
+        },
+        {
+            "description": "Total CPU busy time in seconds per broker. Rate shows CPU cores used.",
+            "fillSpans": false,
+            "id": "e3f0c5dc-e69d-4365-9752-f2b95536a2b8",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_cpu_busy_seconds_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_cpu_busy_seconds_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "a8f73239",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "shard--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "shard",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{instance}} - shard {{shard}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_cpu_busy_seconds_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_cpu_busy_seconds_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "b5906d8d",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "shard--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "shard",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_cpu_busy_seconds_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_cpu_busy_seconds_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "97dede77",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "shard--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "shard",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "57abfcf4-3533-4772-8fe2-b8fa09237499",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "CPU Utilization",
+            "yAxisUnit": "percentunit",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "Amount of memory allocated by Redpanda processes per broker in bytes",
+            "fillSpans": false,
+            "id": "695a921e-887a-42de-aeca-a8580f032a88",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_memory_allocated_memory--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_memory_allocated_memory",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "avg",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "97a39b32",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "shard--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "shard",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{instance}} - shard {{shard}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_memory_allocated_memory--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_memory_allocated_memory",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "avg",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "733bc24b",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "shard--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "shard",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_memory_allocated_memory--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_memory_allocated_memory",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "avg",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "37b96dcc",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "shard--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "shard",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "77e2bcd7-ffc6-467f-ae28-f06b37c973a9",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Memory Allocated",
+            "yAxisUnit": "bytes",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "Amount of free memory available to Redpanda processes per broker",
+            "fillSpans": false,
+            "id": "b241861a-6702-4237-b0a5-927abde1f02f",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_memory_free_memory--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_memory_free_memory",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "avg",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "08e628a4",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "shard--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "shard",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{instance}} - shard {{shard}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_memory_free_memory--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_memory_free_memory",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "avg",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "0469d96b",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "shard--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "shard",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_memory_free_memory--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_memory_free_memory",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "avg",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "97b44799",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "shard--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "shard",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "44b2477b-88b5-4e74-ab00-0d2fd728f6ef",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Free Memory",
+            "yAxisUnit": "bytes",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "Total disk space used by Redpanda data directories per broker",
+            "fillSpans": false,
+            "id": "253be663-d11f-447f-b5e7-bafae473f599",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_storage_disk_used_bytes--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_storage_disk_used_bytes",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "avg",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "5c6094e1",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{instance}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_storage_disk_used_bytes--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_storage_disk_used_bytes",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "avg",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "c97134c1",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_storage_disk_used_bytes--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_storage_disk_used_bytes",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "avg",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "76ab1bdd",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "bc0a3c4a-4e9f-4d63-b60b-5dd267ebaa92",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Storage Used",
+            "yAxisUnit": "bytes",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "Available disk space remaining on Redpanda data directories per broker",
+            "fillSpans": false,
+            "id": "c6f1ad97-c121-4b4f-9bde-97bc2351d887",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_storage_disk_free_bytes--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_storage_disk_free_bytes",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "avg",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "44201941",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{instance}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_storage_disk_free_bytes--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_storage_disk_free_bytes",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "avg",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "eeeea746",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_storage_disk_free_bytes--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_storage_disk_free_bytes",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "avg",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "197925b3",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "7a68bbea-1ce7-4a47-9b3c-f59529027ce9",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Storage Free",
+            "yAxisUnit": "bytes",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "Total I/O operations queued across all shards per broker showing storage subsystem load",
+            "fillSpans": false,
+            "id": "e1bc9004-4c9e-4fcc-9f62-819532cbf908",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_io_queue_total_operations--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_io_queue_total_operations",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "78111975",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "class--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "class",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "shard--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "shard",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{instance}} - {{class}} - {{shard}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_io_queue_total_operations--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_io_queue_total_operations",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "50b07e0c",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "class--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "class",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "shard--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "shard",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_io_queue_total_operations--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_io_queue_total_operations",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "2558b70c",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "class--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "class",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "shard--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "shard",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "c2c20caa-e6ef-4b0a-b88b-2a5e46072c26",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "IO Queue Total Operations",
+            "yAxisUnit": "ops",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "",
+            "fillSpans": false,
+            "id": "4fb65215-25b8-4f26-82c7-053fb30451bd",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "row",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "",
+                                "id": "------false",
+                                "isColumn": false,
+                                "isJSON": false,
+                                "key": "",
+                                "type": ""
+                            },
+                            "aggregateOperator": "count",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [],
+                                "op": "AND"
+                            },
+                            "groupBy": [],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "sum",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "99bb4b65-810c-4ace-9a3d-b785c445dc40",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Schema Registry",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "stackedBarChart": false
+        },
+        {
+            "description": "Rate of requests handled by the Schema Registry showing registry utilization",
+            "fillSpans": false,
+            "id": "e0d26349-bf69-4b13-b930-b793a4bee84c",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_schema_registry_request_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_schema_registry_request_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "34ed90a8",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "handler--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "handler",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{instance}} - {{handler}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_schema_registry_request_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_schema_registry_request_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "265b6be5",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "handler--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "handler",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_schema_registry_request_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_schema_registry_request_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "79864231",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "handler--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "handler",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "19affe3e-4070-47d3-a1b2-3e4a999a69bd",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Schema Registry Request Rate",
+            "yAxisUnit": "reqps",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "Rate of errors returned by the Schema Registry endpoint",
+            "fillSpans": false,
+            "id": "a0a35e0f-9310-4698-a656-1374087a1cc9",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_schema_registry_request_errors_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_schema_registry_request_errors_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "b125f29a",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "handler--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "handler",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{instance}} - {{handler}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_schema_registry_request_errors_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_schema_registry_request_errors_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "fa1149e1",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "handler--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "handler",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_schema_registry_request_errors_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_schema_registry_request_errors_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "3f7bc0cb",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "handler--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "handler",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "21dcd2a5-cc62-4b5f-a27c-d8de32d39e15",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Schema Registry Errors",
+            "yAxisUnit": "ops",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "",
+            "fillSpans": false,
+            "id": "e861f4ab-13b4-44d1-b3d7-04a8e8af36a8",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "row",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "",
+                                "id": "------false",
+                                "isColumn": false,
+                                "isJSON": false,
+                                "key": "",
+                                "type": ""
+                            },
+                            "aggregateOperator": "count",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [],
+                                "op": "AND"
+                            },
+                            "groupBy": [],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "sum",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "ca0054de-bb93-46f2-ae0d-212b96f82f63",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Kafka API Details",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "stackedBarChart": false
+        },
+        {
+            "description": "Rate of Kafka produce API requests handled per second by each broker",
+            "fillSpans": false,
+            "id": "3e3b55e3-a668-4375-976f-fde4403cdfc9",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_request_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_request_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "da12128a",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    },
+                                    {
+                                        "id": "c8e03f01",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "redpanda_cmd--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "redpanda_cmd",
+                                            "type": "tag"
+                                        },
+                                        "op": "=",
+                                        "value": "produce"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{instance}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_request_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_request_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "f7ddbdb3",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    },
+                                    {
+                                        "id": "7f986f7b",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "redpanda_cmd--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "redpanda_cmd",
+                                            "type": "tag"
+                                        },
+                                        "op": "=",
+                                        "value": "produce"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_request_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_request_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "c4d7c0f5",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    },
+                                    {
+                                        "id": "35e9be5e",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "redpanda_cmd--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "redpanda_cmd",
+                                            "type": "tag"
+                                        },
+                                        "op": "=",
+                                        "value": "produce"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "f5620a9b-e9ed-4c57-b8c0-aa5635dd2c2b",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Kafka API Request Rate - Produce",
+            "yAxisUnit": "reqps",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "Rate of Kafka fetch/consume API requests handled per second by each broker",
+            "fillSpans": false,
+            "id": "2a797709-c996-47dd-90db-2857e2111d4b",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_request_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_request_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "fcca100d",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    },
+                                    {
+                                        "id": "25957a3d",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "redpanda_cmd--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "redpanda_cmd",
+                                            "type": "tag"
+                                        },
+                                        "op": "=",
+                                        "value": "fetch"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{instance}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_request_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_request_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "be5540ff",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    },
+                                    {
+                                        "id": "dd2c9b51",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "redpanda_cmd--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "redpanda_cmd",
+                                            "type": "tag"
+                                        },
+                                        "op": "=",
+                                        "value": "fetch"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_request_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_request_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "03755655",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    },
+                                    {
+                                        "id": "e0323e8b",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "redpanda_cmd--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "redpanda_cmd",
+                                            "type": "tag"
+                                        },
+                                        "op": "=",
+                                        "value": "fetch"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "d7841f70-9525-4d10-b8df-2c8e5b2de5b8",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Kafka API Request Rate - Fetch",
+            "yAxisUnit": "reqps",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "Rate of Kafka metadata API requests which can indicate excessive client refreshes",
+            "fillSpans": false,
+            "id": "2e06168c-3280-45eb-85a7-71995faef707",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_request_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_request_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "3f13877e",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    },
+                                    {
+                                        "id": "40af37ca",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "redpanda_cmd--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "redpanda_cmd",
+                                            "type": "tag"
+                                        },
+                                        "op": "=",
+                                        "value": "metadata"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{instance}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_request_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_request_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "1fb59635",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    },
+                                    {
+                                        "id": "dafcba87",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "redpanda_cmd--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "redpanda_cmd",
+                                            "type": "tag"
+                                        },
+                                        "op": "=",
+                                        "value": "metadata"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_request_total--float64--Sum--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_request_total",
+                                "type": "Sum"
+                            },
+                            "aggregateOperator": "rate",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "f2095cda",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    },
+                                    {
+                                        "id": "d5943845",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "redpanda_cmd--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "redpanda_cmd",
+                                            "type": "tag"
+                                        },
+                                        "op": "=",
+                                        "value": "metadata"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "c47651a7-f1f2-4706-bb3c-c971b632ac06",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Kafka API Request Rate - Metadata",
+            "yAxisUnit": "reqps",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "Number of active Kafka client connections per broker showing client load distribution",
+            "fillSpans": false,
+            "id": "53c0ff4a-b4f8-41b1-ab5e-e03ea9ae71cd",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_connections_active--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_connections_active",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "sum",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "5be463e5",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{instance}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_connections_active--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_connections_active",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "sum",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "2461eff4",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_connections_active--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_connections_active",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "sum",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "793fdf23",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "3a503fd7-daab-4aaa-9f67-4422b07de49e",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Kafka Active Connections",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "Median (50th percentile) latency for produce requests showing typical request performance",
+            "fillSpans": false,
+            "id": "d0e138a2-d403-4121-9f4f-713c93d2b18a",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_request_latency_seconds_bucket--float64--Histogram--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_request_latency_seconds_bucket",
+                                "type": "Histogram"
+                            },
+                            "aggregateOperator": "p50",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "3f3aee78",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    },
+                                    {
+                                        "id": "83fa7f08",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "redpanda_cmd--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "redpanda_cmd",
+                                            "type": "tag"
+                                        },
+                                        "op": "=",
+                                        "value": "produce"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "p50 {{instance}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_request_latency_seconds_bucket--float64--Histogram--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_request_latency_seconds_bucket",
+                                "type": "Histogram"
+                            },
+                            "aggregateOperator": "p50",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "93542776",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    },
+                                    {
+                                        "id": "280b1760",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "redpanda_cmd--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "redpanda_cmd",
+                                            "type": "tag"
+                                        },
+                                        "op": "=",
+                                        "value": "produce"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_request_latency_seconds_bucket--float64--Histogram--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_request_latency_seconds_bucket",
+                                "type": "Histogram"
+                            },
+                            "aggregateOperator": "p50",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "59e6fad8",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    },
+                                    {
+                                        "id": "538dfaa6",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "redpanda_cmd--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "redpanda_cmd",
+                                            "type": "tag"
+                                        },
+                                        "op": "=",
+                                        "value": "produce"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "6004be29-33d9-49e9-a98c-71fabf45f7e6",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Produce Latency p50",
+            "yAxisUnit": "s",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "Median (50th percentile) latency for fetch/consume requests showing typical consumer performance",
+            "fillSpans": false,
+            "id": "6cbc7492-078a-41cb-905b-d3259ac97c77",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_request_latency_seconds_bucket--float64--Histogram--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_request_latency_seconds_bucket",
+                                "type": "Histogram"
+                            },
+                            "aggregateOperator": "p50",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "ee331fcb",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    },
+                                    {
+                                        "id": "bb9b6dec",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "redpanda_cmd--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "redpanda_cmd",
+                                            "type": "tag"
+                                        },
+                                        "op": "=",
+                                        "value": "fetch"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "p50 {{instance}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_request_latency_seconds_bucket--float64--Histogram--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_request_latency_seconds_bucket",
+                                "type": "Histogram"
+                            },
+                            "aggregateOperator": "p50",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "eaff496e",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    },
+                                    {
+                                        "id": "3a346568",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "redpanda_cmd--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "redpanda_cmd",
+                                            "type": "tag"
+                                        },
+                                        "op": "=",
+                                        "value": "fetch"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_kafka_request_latency_seconds_bucket--float64--Histogram--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_kafka_request_latency_seconds_bucket",
+                                "type": "Histogram"
+                            },
+                            "aggregateOperator": "p50",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "599fdc99",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    },
+                                    {
+                                        "id": "878deba3",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "redpanda_cmd--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "redpanda_cmd",
+                                            "type": "tag"
+                                        },
+                                        "op": "=",
+                                        "value": "fetch"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "e81c02b8-5040-4b5d-9bbf-30a206805692",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Fetch Latency p50",
+            "yAxisUnit": "s",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "",
+            "fillSpans": false,
+            "id": "aafdc469-5c70-4c18-8b18-6db1c4706023",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "row",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "",
+                                "id": "------false",
+                                "isColumn": false,
+                                "isJSON": false,
+                                "key": "",
+                                "type": ""
+                            },
+                            "aggregateOperator": "count",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [],
+                                "op": "AND"
+                            },
+                            "groupBy": [],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "sum",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "c40091ca-ed72-4d3b-a627-38f51ed4e0b6",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Cluster Health Details",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "stackedBarChart": false
+        },
+        {
+            "description": "Time series of unavailable partitions. Any non-zero value indicates data availability issues.",
+            "fillSpans": false,
+            "id": "afdb998f-fbe2-468e-933d-b312eb5bfbd2",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_cluster_unavailable_partitions--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_cluster_unavailable_partitions",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "max",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "e9a9fafe",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [],
+                            "having": [],
+                            "legend": "Unavailable Partitions",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_cluster_unavailable_partitions--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_cluster_unavailable_partitions",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "max",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "718e3f6c",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_cluster_unavailable_partitions--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_cluster_unavailable_partitions",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "max",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "f1191964",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "c57fdbbc-58d2-45be-97bd-88114f05e3a4",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Unavailable Partitions Over Time",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "Time series of under-replicated partitions tracking replication health trends",
+            "fillSpans": false,
+            "id": "dbfe5eee-3cc4-4acf-8f5f-363d47d50986",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_cluster_under_replicated_partitions--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_cluster_under_replicated_partitions",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "max",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "641f8f5f",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [],
+                            "having": [],
+                            "legend": "Under-replicated Partitions",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_cluster_under_replicated_partitions--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_cluster_under_replicated_partitions",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "max",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "b04f3f0b",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_cluster_under_replicated_partitions--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_cluster_under_replicated_partitions",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "max",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "e5c291dd",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "be81d3b9-8bc7-445b-89f5-75053665513c",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Under-replicated Partitions Over Time",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "Number of partitions without an elected leader. Non-zero indicates service disruption for those partitions.",
+            "fillSpans": false,
+            "id": "452d6920-32d3-407d-869f-f5f36e0edc6b",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_cluster_leaderless_partitions--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_cluster_leaderless_partitions",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "max",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "b0e9f1a1",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [],
+                            "having": [],
+                            "legend": "Leaderless Partitions",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_cluster_leaderless_partitions--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_cluster_leaderless_partitions",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "max",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "887a23f3",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_cluster_leaderless_partitions--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_cluster_leaderless_partitions",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "max",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "9fd81860",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "cb1fd3cf-e4b9-49b5-8dd9-9a61ca294827",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Leaderless Partitions",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        },
+        {
+            "description": "Number of partitions hosted by each broker showing partition distribution and balance",
+            "fillSpans": false,
+            "id": "3aee51ec-e47e-4204-a765-9a64a6b761a4",
+            "isStacked": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_cluster_partition_count--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_cluster_partition_count",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "sum",
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "1f21ee42",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "{{instance}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_cluster_partition_count--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_cluster_partition_count",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "sum",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "B",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "bf116b06",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        },
+                        {
+                            "aggregateAttribute": {
+                                "dataType": "float64",
+                                "id": "redpanda_cluster_partition_count--float64--Gauge--true",
+                                "isColumn": true,
+                                "isJSON": false,
+                                "key": "redpanda_cluster_partition_count",
+                                "type": "Gauge"
+                            },
+                            "aggregateOperator": "sum",
+                            "dataSource": "metrics",
+                            "disabled": true,
+                            "expression": "C",
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "cd191d08",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "instance--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "instance",
+                                            "type": "tag"
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "{{.redpanda_instance}}"
+                                        ]
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "instance--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "instance",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": [],
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "C",
+                            "reduceTo": "avg",
+                            "stepInterval": 60
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "id": "e758f056-9287-48e2-921f-63a4a86988a8",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "B",
+                        "query": ""
+                    },
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "C",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "softMax": null,
+            "softMin": null,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Broker Partition Count",
+            "yAxisUnit": "none",
+            "columnUnits": {},
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "mergeAllActiveQueries": false,
+            "selectedLogFields": [],
+            "selectedTracesFields": [],
+            "stackedBarChart": false
+        }
+    ],
+    "version": "v1"
+}


### PR DESCRIPTION
## Summary

Comprehensive Redpanda Prometheus monitoring dashboard with **49 panels** across 9 sections:

| Section | Panels | Key Metrics |
|---------|--------|-------------|
| Cluster Overview | 4 value | Brokers, partitions, unavailable/under-replicated |
| Throughput | 6 | Produce/consume bytes/sec, messages/sec, latency p99 |
| Topics & Partitions | 4 | Partition counts, log sizes, leaders, replicas |
| Consumer Groups | 4 | Lag, members, committed offsets, topics |
| RPC & Internal | 4 | RPC connections, errors, Raft leadership changes |
| Resources | 6 | CPU, memory, storage, IO queue |
| Schema Registry | 2 | Request rate, errors |
| Connections | 2 | Active connections, connection rate |
| Storage | 2 | Disk utilization, compaction |

**Data source:** Native Redpanda Prometheus metrics (port 9644)

**Variables:** `{{redpanda_instance}}` for filtering by broker

Closes SigNoz/signoz#6027

## Test plan
- [ ] Import JSON into SigNoz dashboard
- [ ] Verify all panels render with Redpanda Prometheus metrics
- [ ] Confirm variable filtering works

Closes SigNoz/signoz#6027