### PR TITLE
feat(dashboard): Add GCP App Engine monitoring dashboard

### DIFF
--- a/gcp/README-app-engine.md
+++ b/gcp/README-app-engine.md
@@ -1,0 +1,62 @@
+# GCP App Engine Monitoring Dashboard - Prometheus
+
+Comprehensive GCP App Engine monitoring dashboard for [SigNoz](https://signoz.io/) using Google Cloud Monitoring metrics via the OpenTelemetry Google Cloud exporter.
+
+## Sections
+
+| #   | Section             | Covers                                                    |
+| --- | ------------------- | --------------------------------------------------------- |
+| 1   | Overview            | Active instances, request count, error rate, response time |
+| 2   | HTTP Performance    | Request rate, latency percentiles, error rates by code    |
+| 3   | Instance Management | Instance count, memory/CPU per instance, startup latency  |
+| 4   | Network             | Bytes sent/received, bandwidth per version                |
+| 5   | Memcache            | Hit ratio, operations/sec, size, item count               |
+| 6   | Task Queue          | Queue depth, execution rate, retry count, task age        |
+| 7   | Costs & Quotas      | Billable instance hours, API calls by service             |
+
+## Metrics Ingestion
+
+### Using OpenTelemetry Collector with Google Cloud Monitoring Receiver
+
+```yaml
+receivers:
+  googlecloudmonitoring:
+    project_id: "your-gcp-project"
+    collection_interval: 60s
+    metrics_list:
+      - metric_name: "appengine.googleapis.com/http/server/response_count"
+      - metric_name: "appengine.googleapis.com/http/server/response_latencies"
+      - metric_name: "appengine.googleapis.com/system/instance_count"
+      - metric_name: "appengine.googleapis.com/system/cpu/usage"
+      - metric_name: "appengine.googleapis.com/system/memory/usage"
+      - metric_name: "appengine.googleapis.com/system/network/sent_bytes_count"
+      - metric_name: "appengine.googleapis.com/system/network/received_bytes_count"
+      - metric_name: "appengine.googleapis.com/memcache/hit_ratio"
+      - metric_name: "appengine.googleapis.com/task_queue/queue_depth"
+
+processors:
+  batch:
+    timeout: 10s
+  resource:
+    attributes:
+      - key: service.name
+        value: "gcp-app-engine"
+        action: insert
+
+exporters:
+  otlp:
+    endpoint: "ingest.<region>.signoz.cloud:443"
+    headers:
+      signoz-ingestion-key: "<your-ingestion-key>"
+
+service:
+  pipelines:
+    metrics:
+      receivers: [googlecloudmonitoring]
+      processors: [batch, resource]
+      exporters: [otlp]
+```
+
+## Variables
+
+- `{{gcp_project}}`: GCP project ID for filtering metrics

--- a/gcp/gcp-app-engine-prometheus-v1.json
+++ b/gcp/gcp-app-engine-prometheus-v1.json
@@ -1,0 +1,8788 @@
+{
+  "description": "Comprehensive monitoring dashboard for Google Cloud Platform App Engine. Tracks HTTP performance, instance management, network I/O, memcache, task queues, and cost-related metrics collected via the GCP Cloud Monitoring (Stackdriver) or OpenTelemetry receiver.",
+  "image": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNMTIgMkw0IDdWMTdMIDEyIDIyTDIwIDE3VjdMMTIgMloiIHN0cm9rZT0iIzQyODVGNCIgc3Ryb2tlLXdpZHRoPSIyIiBmaWxsPSIjNDI4NUY0IiBmaWxsLW9wYWNpdHk9IjAuMiIvPjxwYXRoIGQ9Ik0xMiA2TDggOFYxNkwxMiAxOEwxNiAxNlY4TDEyIDZaIiBmaWxsPSIjNDI4NUY0Ii8+PC9zdmc+",
+  "layout": [
+    {
+      "h": 1,
+      "i": "040d7d49-9cd9-407c-aaed-878de24426c0",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 0,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 7,
+      "i": "494c62c0-38e0-4493-8b1d-097682577987",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 0,
+      "y": 1
+    },
+    {
+      "h": 7,
+      "i": "05e0410b-f35c-4dd7-abc2-5e762430da66",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 3,
+      "y": 1
+    },
+    {
+      "h": 7,
+      "i": "8b3231ee-a343-4b26-a3bd-ed55056751cc",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 6,
+      "y": 1
+    },
+    {
+      "h": 7,
+      "i": "9b45d5f5-f31f-40d8-926a-395ca6a5b3fa",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 9,
+      "y": 1
+    },
+    {
+      "h": 1,
+      "i": "dd178a20-c24d-4c7c-a0dc-6b4d7a63cec3",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 8,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 6,
+      "i": "01b06c42-e7c8-4505-8868-969f54d31ed7",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 9
+    },
+    {
+      "h": 6,
+      "i": "26db619b-844a-4ea3-b142-f758e86567e1",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 9
+    },
+    {
+      "h": 6,
+      "i": "42d293b0-a477-4317-a418-b342461a06cd",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 15
+    },
+    {
+      "h": 6,
+      "i": "83f0d6b1-31db-4467-ad73-4f4eb424b42b",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 15
+    },
+    {
+      "h": 6,
+      "i": "80886def-1127-41c6-83ef-727fda07e909",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 21
+    },
+    {
+      "h": 6,
+      "i": "64e883f4-de47-46e4-918a-934a80e3adf8",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 21
+    },
+    {
+      "h": 1,
+      "i": "f0ca6480-9f6a-4694-8e8b-8b699584f927",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 27,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 6,
+      "i": "8b74eb06-a1f7-4b05-a1d8-2ecc336de850",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 28
+    },
+    {
+      "h": 6,
+      "i": "18522927-0e49-4c69-82bf-49630f9c175a",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 28
+    },
+    {
+      "h": 6,
+      "i": "999eb615-0dde-4c42-b25d-30152e0f9344",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 34
+    },
+    {
+      "h": 6,
+      "i": "20258a3c-d881-4908-a3ad-bb1d4d2f779c",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 34
+    },
+    {
+      "h": 1,
+      "i": "fced28eb-c280-498e-8c6d-1b0c062a1aa1",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 40,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 6,
+      "i": "d0098d4a-83f7-4587-9525-8dfc0cd33987",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 41
+    },
+    {
+      "h": 6,
+      "i": "2826af20-ba63-4bfd-b099-4f92bf2c4fd8",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 41
+    },
+    {
+      "h": 6,
+      "i": "5588ca70-245d-447a-99d0-16117496bd25",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 47
+    },
+    {
+      "h": 6,
+      "i": "3305ec31-d8eb-43fd-a655-fde95abe2262",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 47
+    },
+    {
+      "h": 1,
+      "i": "9f980910-131c-4fec-98e7-1b84cca351ce",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 53,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 6,
+      "i": "fb54fef4-1658-4638-ae8f-5ae3485e48fc",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 54
+    },
+    {
+      "h": 6,
+      "i": "1a1df61b-c100-44f0-8391-18d21c684fad",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 54
+    },
+    {
+      "h": 6,
+      "i": "d651efd4-0b0a-46fa-bb3a-f05e6113e6fe",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 60
+    },
+    {
+      "h": 6,
+      "i": "aeeed71c-5285-45b0-b586-a183f6ec3bfc",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 60
+    },
+    {
+      "h": 1,
+      "i": "a2e65b37-6ac7-4ad3-8170-ad24fe59d591",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 66,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 6,
+      "i": "285ec157-e47e-4503-be54-4b801651926d",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 67
+    },
+    {
+      "h": 6,
+      "i": "a8fcb771-d75a-4d69-a1d2-6ef368aa8349",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 67
+    },
+    {
+      "h": 6,
+      "i": "9bb11bcc-2c17-4e6d-a7c3-5fcbd25826c8",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 73
+    },
+    {
+      "h": 6,
+      "i": "613b06d3-7b62-4fae-9b05-20de7f40bf63",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 73
+    },
+    {
+      "h": 1,
+      "i": "a3fbfa80-b564-4ccb-b3cd-28ea37acfcf0",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 79,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 6,
+      "i": "90b90f9e-5ec9-44bb-91cb-ff27651a0269",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 80
+    },
+    {
+      "h": 6,
+      "i": "e9a8b3b3-c161-4dfe-8efb-aba930d1a038",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 80
+    },
+    {
+      "h": 1,
+      "i": "a00ff1ad-f2ea-4820-a0bc-d0f7b86381ee",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 86,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 6,
+      "i": "68aa4903-402d-406a-8eaa-1f1efef55526",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 87
+    },
+    {
+      "h": 6,
+      "i": "e73a2396-23f0-495e-bfcf-a9a4879667b7",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 87
+    },
+    {
+      "h": 6,
+      "i": "b29ad895-33f9-41d0-932d-4b2795b4be4b",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 93
+    },
+    {
+      "h": 6,
+      "i": "02d90e22-867d-479a-9ea2-d22d4a3fa569",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 93
+    },
+    {
+      "h": 1,
+      "i": "204c0c96-c9ea-4746-8ef7-460b69f7af5c",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 99,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 7,
+      "i": "20c2c9e5-1681-4ee7-b6f0-70e95bc9bcf2",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 0,
+      "y": 100
+    },
+    {
+      "h": 7,
+      "i": "60030aa2-562d-4778-93a3-f4f0ea79b81a",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 3,
+      "y": 100
+    },
+    {
+      "h": 7,
+      "i": "060eda62-c70e-4f57-ab78-49176280dd54",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 6,
+      "y": 100
+    },
+    {
+      "h": 7,
+      "i": "0ee248bc-c844-4c53-807f-90a24385f519",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 9,
+      "y": 100
+    },
+    {
+      "h": 6,
+      "i": "ce2d1d2e-9bf0-4fd7-a9b6-e869b69ca57a",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 107
+    },
+    {
+      "h": 6,
+      "i": "80df5c3e-5018-4aca-b5ef-25278cae699d",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 107
+    },
+    {
+      "h": 6,
+      "i": "8a47ebb9-1a49-49ab-91a7-370d0aab2eb4",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 113
+    },
+    {
+      "h": 6,
+      "i": "a29133b2-94b9-48ac-9531-ed0c60c876dc",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 113
+    },
+    {
+      "h": 1,
+      "i": "c03f020c-074f-40ed-aad0-cdad2383a724",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 119,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 6,
+      "i": "3f80e4e8-d521-4ab4-85fd-2ae0631be866",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 120
+    },
+    {
+      "h": 6,
+      "i": "2015d7e2-a2fb-4bd1-9a9a-58388d1202a2",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 120
+    },
+    {
+      "h": 1,
+      "i": "584fa8f0-f705-419a-8809-e87213e5263b",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 126,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 6,
+      "i": "685d99ec-41d7-4f46-a18a-fb3dc15bbfb5",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 127
+    },
+    {
+      "h": 6,
+      "i": "9a1300d0-9503-4c0c-8750-6475fa001d1c",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 127
+    },
+    {
+      "h": 6,
+      "i": "a62154d6-ce48-4f14-a59d-3ed2a851e212",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 133
+    },
+    {
+      "h": 6,
+      "i": "d100ea92-445f-4d0e-a985-2f5a5aad3f84",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 133
+    }
+  ],
+  "panelMap": {
+    "040d7d49-9cd9-407c-aaed-878de24426c0": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 7,
+          "i": "494c62c0-38e0-4493-8b1d-097682577987",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 0,
+          "y": 1
+        },
+        {
+          "h": 7,
+          "i": "05e0410b-f35c-4dd7-abc2-5e762430da66",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 3,
+          "y": 1
+        },
+        {
+          "h": 7,
+          "i": "8b3231ee-a343-4b26-a3bd-ed55056751cc",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 6,
+          "y": 1
+        },
+        {
+          "h": 7,
+          "i": "9b45d5f5-f31f-40d8-926a-395ca6a5b3fa",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 9,
+          "y": 1
+        }
+      ]
+    },
+    "dd178a20-c24d-4c7c-a0dc-6b4d7a63cec3": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "01b06c42-e7c8-4505-8868-969f54d31ed7",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 9
+        },
+        {
+          "h": 6,
+          "i": "26db619b-844a-4ea3-b142-f758e86567e1",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 9
+        },
+        {
+          "h": 6,
+          "i": "42d293b0-a477-4317-a418-b342461a06cd",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 15
+        },
+        {
+          "h": 6,
+          "i": "83f0d6b1-31db-4467-ad73-4f4eb424b42b",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 15
+        },
+        {
+          "h": 6,
+          "i": "80886def-1127-41c6-83ef-727fda07e909",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 21
+        },
+        {
+          "h": 6,
+          "i": "64e883f4-de47-46e4-918a-934a80e3adf8",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 21
+        }
+      ]
+    },
+    "f0ca6480-9f6a-4694-8e8b-8b699584f927": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "8b74eb06-a1f7-4b05-a1d8-2ecc336de850",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 28
+        },
+        {
+          "h": 6,
+          "i": "18522927-0e49-4c69-82bf-49630f9c175a",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 28
+        },
+        {
+          "h": 6,
+          "i": "999eb615-0dde-4c42-b25d-30152e0f9344",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 34
+        },
+        {
+          "h": 6,
+          "i": "20258a3c-d881-4908-a3ad-bb1d4d2f779c",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 34
+        }
+      ]
+    },
+    "fced28eb-c280-498e-8c6d-1b0c062a1aa1": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "d0098d4a-83f7-4587-9525-8dfc0cd33987",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 41
+        },
+        {
+          "h": 6,
+          "i": "2826af20-ba63-4bfd-b099-4f92bf2c4fd8",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 41
+        },
+        {
+          "h": 6,
+          "i": "5588ca70-245d-447a-99d0-16117496bd25",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 47
+        },
+        {
+          "h": 6,
+          "i": "3305ec31-d8eb-43fd-a655-fde95abe2262",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 47
+        }
+      ]
+    },
+    "9f980910-131c-4fec-98e7-1b84cca351ce": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "fb54fef4-1658-4638-ae8f-5ae3485e48fc",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 54
+        },
+        {
+          "h": 6,
+          "i": "1a1df61b-c100-44f0-8391-18d21c684fad",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 54
+        },
+        {
+          "h": 6,
+          "i": "d651efd4-0b0a-46fa-bb3a-f05e6113e6fe",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 60
+        },
+        {
+          "h": 6,
+          "i": "aeeed71c-5285-45b0-b586-a183f6ec3bfc",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 60
+        }
+      ]
+    },
+    "a2e65b37-6ac7-4ad3-8170-ad24fe59d591": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "285ec157-e47e-4503-be54-4b801651926d",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 67
+        },
+        {
+          "h": 6,
+          "i": "a8fcb771-d75a-4d69-a1d2-6ef368aa8349",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 67
+        },
+        {
+          "h": 6,
+          "i": "9bb11bcc-2c17-4e6d-a7c3-5fcbd25826c8",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 73
+        },
+        {
+          "h": 6,
+          "i": "613b06d3-7b62-4fae-9b05-20de7f40bf63",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 73
+        }
+      ]
+    },
+    "a3fbfa80-b564-4ccb-b3cd-28ea37acfcf0": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "90b90f9e-5ec9-44bb-91cb-ff27651a0269",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 80
+        },
+        {
+          "h": 6,
+          "i": "e9a8b3b3-c161-4dfe-8efb-aba930d1a038",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 80
+        }
+      ]
+    },
+    "a00ff1ad-f2ea-4820-a0bc-d0f7b86381ee": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "68aa4903-402d-406a-8eaa-1f1efef55526",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 87
+        },
+        {
+          "h": 6,
+          "i": "e73a2396-23f0-495e-bfcf-a9a4879667b7",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 87
+        },
+        {
+          "h": 6,
+          "i": "b29ad895-33f9-41d0-932d-4b2795b4be4b",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 93
+        },
+        {
+          "h": 6,
+          "i": "02d90e22-867d-479a-9ea2-d22d4a3fa569",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 93
+        }
+      ]
+    },
+    "204c0c96-c9ea-4746-8ef7-460b69f7af5c": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 7,
+          "i": "20c2c9e5-1681-4ee7-b6f0-70e95bc9bcf2",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 0,
+          "y": 100
+        },
+        {
+          "h": 7,
+          "i": "60030aa2-562d-4778-93a3-f4f0ea79b81a",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 3,
+          "y": 100
+        },
+        {
+          "h": 7,
+          "i": "060eda62-c70e-4f57-ab78-49176280dd54",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 6,
+          "y": 100
+        },
+        {
+          "h": 7,
+          "i": "0ee248bc-c844-4c53-807f-90a24385f519",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 9,
+          "y": 100
+        },
+        {
+          "h": 6,
+          "i": "ce2d1d2e-9bf0-4fd7-a9b6-e869b69ca57a",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 107
+        },
+        {
+          "h": 6,
+          "i": "80df5c3e-5018-4aca-b5ef-25278cae699d",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 107
+        },
+        {
+          "h": 6,
+          "i": "8a47ebb9-1a49-49ab-91a7-370d0aab2eb4",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 113
+        },
+        {
+          "h": 6,
+          "i": "a29133b2-94b9-48ac-9531-ed0c60c876dc",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 113
+        }
+      ]
+    },
+    "c03f020c-074f-40ed-aad0-cdad2383a724": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "3f80e4e8-d521-4ab4-85fd-2ae0631be866",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 120
+        },
+        {
+          "h": 6,
+          "i": "2015d7e2-a2fb-4bd1-9a9a-58388d1202a2",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 120
+        }
+      ]
+    },
+    "584fa8f0-f705-419a-8809-e87213e5263b": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "685d99ec-41d7-4f46-a18a-fb3dc15bbfb5",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 127
+        },
+        {
+          "h": 6,
+          "i": "9a1300d0-9503-4c0c-8750-6475fa001d1c",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 127
+        },
+        {
+          "h": 6,
+          "i": "a62154d6-ce48-4f14-a59d-3ed2a851e212",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 133
+        },
+        {
+          "h": 6,
+          "i": "d100ea92-445f-4d0e-a985-2f5a5aad3f84",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 133
+        }
+      ]
+    }
+  },
+  "tags": [
+    "gcp",
+    "app-engine",
+    "serverless"
+  ],
+  "title": "GCP App Engine Overview",
+  "uploadedGrafana": false,
+  "variables": {
+    "864bf76f-2c89-4f1c-9ccb-c5998dc4e9e0": {
+      "customValue": "",
+      "description": "GCP Project ID for filtering App Engine metrics",
+      "id": "864bf76f-2c89-4f1c-9ccb-c5998dc4e9e0",
+      "modificationUUID": "3a73bc21-62af-4d0e-928b-8c729dfd076a",
+      "multiSelect": false,
+      "name": "gcp_project",
+      "order": 0,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'gcp_project'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name like '%appengine%'",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "1a66a5bb-3c09-4cc1-80c4-df1d2b622d02": {
+      "customValue": "",
+      "description": "Deployment environment for filtering App Engine metrics",
+      "id": "1a66a5bb-3c09-4cc1-80c4-df1d2b622d02",
+      "modificationUUID": "92c802d4-da90-415c-b0b7-18fbfc7b7c40",
+      "multiSelect": false,
+      "name": "deployment.environment",
+      "order": 1,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'deployment.environment'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name like '%appengine%'",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "5c8b0488-a98d-428c-b608-d30d1262d6a3": {
+      "customValue": "",
+      "description": "App Engine version ID for filtering metrics",
+      "id": "5c8b0488-a98d-428c-b608-d30d1262d6a3",
+      "modificationUUID": "ab0bd1a7-c870-4c6c-a70e-d52378ca5e0c",
+      "multiSelect": true,
+      "name": "version_id",
+      "order": 2,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'version_id'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name like '%appengine%'",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "version": "v4",
+  "widgets": [
+    {
+      "description": "",
+      "id": "040d7d49-9cd9-407c-aaed-878de24426c0",
+      "panelTypes": "row",
+      "title": "Overview"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Current number of active App Engine instances serving traffic.",
+      "fillSpans": false,
+      "id": "494c62c0-38e0-4493-8b1d-097682577987",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_system_instance_count--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/system/instance_count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "2f14c8a9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Active Instances",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8568855b-2894-4bab-9bc0-5e5758f34cda",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Instances",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total number of HTTP requests received by the App Engine application.",
+      "fillSpans": false,
+      "id": "05e0410b-f35c-4dd7-abc2-5e762430da66",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_http_server_response_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/http/server/response_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "2b1a83d1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Total Requests",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "77f7c75f-fb25-4925-81a6-502a029d0e15",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Percentage of HTTP responses with 5xx status codes indicating server errors.",
+      "fillSpans": false,
+      "id": "8b3231ee-a343-4b26-a3bd-ed55056751cc",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_http_server_response_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/http/server/response_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "0564acdd",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  },
+                  {
+                    "id": "7ab18297",
+                    "key": {
+                      "dataType": "string",
+                      "id": "response_code--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "response_code",
+                      "type": "tag"
+                    },
+                    "op": ">=",
+                    "value": "500"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "sum"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_http_server_response_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/http/server/response_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "51c8743e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "A / B * 100",
+              "legend": "Error Rate %",
+              "queryName": "F1"
+            }
+          ]
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0049e08f-340b-47fc-b73e-0a434fa1cc1a",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Error Rate (%)",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Average HTTP response latency across all App Engine requests.",
+      "fillSpans": false,
+      "id": "9b45d5f5-f31f-40d8-926a-395ca6a5b3fa",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_http_server_response_latencies--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/http/server/response_latencies",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "49915484",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Avg Response Time",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "76f6658d-f8fe-4d22-8ddc-30e773e86b7a",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Avg Response Time",
+      "yAxisUnit": "ms"
+    },
+    {
+      "description": "",
+      "id": "dd178a20-c24d-4c7c-a0dc-6b4d7a63cec3",
+      "panelTypes": "row",
+      "title": "HTTP Performance"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of HTTP requests per second broken down by App Engine version.",
+      "fillSpans": false,
+      "id": "01b06c42-e7c8-4505-8868-969f54d31ed7",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_http_server_response_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/http/server/response_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "c3de596f",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "version_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "version_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Version: {{version_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "69e0e5c4-f535-4d1b-ac1f-f205d9301d68",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Rate by Version",
+      "yAxisUnit": "ops"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "HTTP response latency percentiles (p50, p95, p99) for App Engine requests.",
+      "fillSpans": false,
+      "id": "26db619b-844a-4ea3-b142-f758e86567e1",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_http_server_response_latencies--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/http/server/response_latencies",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p50",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "46e6a8c3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p50",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "p50",
+              "stepInterval": 60,
+              "timeAggregation": "p50"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_http_server_response_latencies--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/http/server/response_latencies",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p95",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "aafe6e31",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p95",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "p95",
+              "stepInterval": 60,
+              "timeAggregation": "p95"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_http_server_response_latencies--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/http/server/response_latencies",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p99",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "C",
+              "filters": {
+                "items": [
+                  {
+                    "id": "a79a5a22",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p99",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "C",
+              "reduceTo": "avg",
+              "spaceAggregation": "p99",
+              "stepInterval": 60,
+              "timeAggregation": "p99"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          },
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "B",
+            "query": ""
+          },
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "C",
+            "query": ""
+          }
+        ],
+        "id": "837622b2-26f8-458d-8ad6-ba65b2017613",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          },
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "B",
+            "query": ""
+          },
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "C",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Response Latency (p50/p95/p99)",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of HTTP responses broken down by response status code.",
+      "fillSpans": false,
+      "id": "42d293b0-a477-4317-a418-b342461a06cd",
+      "isStacked": true,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_http_server_response_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/http/server/response_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "bf8c5a2d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "response_code--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "response_code",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "HTTP {{response_code}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "77ead360-362e-4cb3-b1c0-5fa27efbadad",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Error Rate by Response Code",
+      "yAxisUnit": "ops"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of HTTP requests broken down by App Engine request handler.",
+      "fillSpans": false,
+      "id": "83f0d6b1-31db-4467-ad73-4f4eb424b42b",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_http_server_response_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/http/server/response_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "6b8f13d0",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "handler--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "handler",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Handler: {{handler}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "1ded0550-0237-4ca9-ac97-49423641a8ea",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Requests by Handler",
+      "yAxisUnit": "ops"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Percentage of HTTP responses with 4xx client error status codes over time.",
+      "fillSpans": false,
+      "id": "80886def-1127-41c6-83ef-727fda07e909",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_http_server_response_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/http/server/response_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "ca408f49",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  },
+                  {
+                    "id": "b55461ac",
+                    "key": {
+                      "dataType": "string",
+                      "id": "response_code_class--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "response_code_class",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "4xx"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_http_server_response_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/http/server/response_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "21c58b67",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "A / B * 100",
+              "legend": "4xx Error Rate %",
+              "queryName": "F1"
+            }
+          ]
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "fb7ecf70-36d3-4775-8523-08c9659f01ec",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "4xx Error Rate",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Percentage of HTTP responses with 5xx server error status codes over time.",
+      "fillSpans": false,
+      "id": "64e883f4-de47-46e4-918a-934a80e3adf8",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_http_server_response_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/http/server/response_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b04b4000",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  },
+                  {
+                    "id": "34930a73",
+                    "key": {
+                      "dataType": "string",
+                      "id": "response_code_class--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "response_code_class",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "5xx"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_http_server_response_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/http/server/response_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f6c8c9c7",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "A / B * 100",
+              "legend": "5xx Error Rate %",
+              "queryName": "F1"
+            }
+          ]
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "fa95d91e-6bd8-4162-9330-4c5453364a22",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "5xx Error Rate",
+      "yAxisUnit": "percent"
+    },
+    {
+      "description": "",
+      "id": "f0ca6480-9f6a-4694-8e8b-8b699584f927",
+      "panelTypes": "row",
+      "title": "Instance Management"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of App Engine instances over time, grouped by version and state (active, idle).",
+      "fillSpans": false,
+      "id": "8b74eb06-a1f7-4b05-a1d8-2ecc336de850",
+      "isStacked": true,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_system_instance_count--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/system/instance_count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "402a765a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "version_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "version_id",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "state--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "state",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{version_id}} ({{state}})",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "82c68fd4-c3db-411f-a729-8140a4c750c9",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Instance Count Over Time",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Memory usage in bytes per App Engine instance over time.",
+      "fillSpans": false,
+      "id": "18522927-0e49-4c69-82bf-49630f9c175a",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_system_memory_usage--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/system/memory/usage",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "1ad6f412",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "instance_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "instance_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Instance: {{instance_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b5d5d1ee-0552-4d4c-b009-65d259118ccf",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memory Usage per Instance",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "CPU usage rate per App Engine instance, measured in CPU seconds per second.",
+      "fillSpans": false,
+      "id": "999eb615-0dde-4c42-b25d-30152e0f9344",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_system_cpu_usage--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/system/cpu/usage",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "3fcd36e6",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "instance_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "instance_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Instance: {{instance_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a72658ce-033e-4a17-bc2f-004820d61150",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "CPU Utilization per Instance",
+      "yAxisUnit": "percentunit"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "App Engine instance loading request latency, indicating cold start performance.",
+      "fillSpans": false,
+      "id": "20258a3c-d881-4908-a3ad-bb1d4d2f779c",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_system_instance_count--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/system/instance_count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "9ae685de",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "state--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "state",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "State: {{state}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "2d4ef959-7f1d-4b6c-9533-e6f27e4043fa",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Instance Startup Latency",
+      "yAxisUnit": "ms"
+    },
+    {
+      "description": "",
+      "id": "fced28eb-c280-498e-8c6d-1b0c062a1aa1",
+      "panelTypes": "row",
+      "title": "Network"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of outbound network bytes sent from App Engine instances.",
+      "fillSpans": false,
+      "id": "d0098d4a-83f7-4587-9525-8dfc0cd33987",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_system_network_sent_bytes_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/system/network/sent_bytes_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "25d7328b",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "version_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "version_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Version: {{version_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f5a77eca-d7bf-46df-9909-769513de6d3e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Network Bytes Sent",
+      "yAxisUnit": "binBps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of inbound network bytes received by App Engine instances.",
+      "fillSpans": false,
+      "id": "2826af20-ba63-4bfd-b099-4f92bf2c4fd8",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_system_network_received_bytes_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/system/network/received_bytes_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "2af7d72c",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "version_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "version_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Version: {{version_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b6c5fca6-4625-4477-b3b9-92b95359c713",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Network Bytes Received",
+      "yAxisUnit": "binBps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Combined send and receive network bandwidth per App Engine version.",
+      "fillSpans": false,
+      "id": "5588ca70-245d-447a-99d0-16117496bd25",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_system_network_sent_bytes_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/system/network/sent_bytes_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "17725712",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "version_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "version_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Sent: {{version_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_system_network_received_bytes_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/system/network/received_bytes_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "3650b8d9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "version_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "version_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Received: {{version_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          },
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "B",
+            "query": ""
+          }
+        ],
+        "id": "61957687-d5ec-43d9-94f5-748a94e80059",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          },
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "B",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Bandwidth per Version",
+      "yAxisUnit": "binBps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of HTTP connections to App Engine, split by whether the request triggered instance loading.",
+      "fillSpans": false,
+      "id": "3305ec31-d8eb-43fd-a655-fde95abe2262",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_http_server_response_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/http/server/response_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "3b4498ea",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "loading--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "loading",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Loading: {{loading}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9356453c-b60e-48d7-9196-052e7add23d0",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Connection Count",
+      "yAxisUnit": "ops"
+    },
+    {
+      "description": "",
+      "id": "9f980910-131c-4fec-98e7-1b84cca351ce",
+      "panelTypes": "row",
+      "title": "Memcache"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Percentage of memcache lookups that resulted in a cache hit. Higher is better.",
+      "fillSpans": false,
+      "id": "fb54fef4-1658-4638-ae8f-5ae3485e48fc",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_memcache_hit_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/memcache/hit_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "a987f6b3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_memcache_miss_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/memcache/miss_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "3b2d8e0e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "A / (A + B) * 100",
+              "legend": "Hit Ratio %",
+              "queryName": "F1"
+            }
+          ]
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "021f8ad4-34e5-48a4-bc61-716aa4575e4d",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memcache Hit Ratio",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of memcache operations split by hits and misses per second.",
+      "fillSpans": false,
+      "id": "1a1df61b-c100-44f0-8391-18d21c684fad",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_memcache_hit_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/memcache/hit_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d42a85c0",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Hits/s",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_memcache_miss_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/memcache/miss_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "edc70722",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Misses/s",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          },
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "B",
+            "query": ""
+          }
+        ],
+        "id": "1e6236db-3274-43d1-be84-0e53710fbf76",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          },
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "B",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memcache Operations/sec",
+      "yAxisUnit": "ops"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Current memory used by memcache service in bytes.",
+      "fillSpans": false,
+      "id": "d651efd4-0b0a-46fa-bb3a-f05e6113e6fe",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_memcache_used_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/memcache/used_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "5f681e6f",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Used Bytes",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "16880ec0-a141-483f-86c4-2a386e8f334d",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memcache Used Size",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Current number of items stored in the App Engine memcache.",
+      "fillSpans": false,
+      "id": "aeeed71c-5285-45b0-b586-a183f6ec3bfc",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_memcache_item_count--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/memcache/item_count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "890ae0c1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Item Count",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b7de7f58-9e64-498d-8971-3dbd0ab0d754",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memcache Item Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "id": "a2e65b37-6ac7-4ad3-8170-ad24fe59d591",
+      "panelTypes": "row",
+      "title": "Task Queue"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of tasks waiting in each App Engine task queue.",
+      "fillSpans": false,
+      "id": "285ec157-e47e-4503-be54-4b801651926d",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_task_queue_queue_depth--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/task_queue/queue/depth",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b7f93106",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "queue_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "queue_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Queue: {{queue_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "92ed00e5-1fee-401e-942c-f08a526499d1",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Task Queue Depth",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of task executions per second from App Engine task queues.",
+      "fillSpans": false,
+      "id": "a8fcb771-d75a-4d69-a1d2-6ef368aa8349",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_task_queue_task_execution_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/task_queue/task/execution_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "7bab22af",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "queue_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "queue_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Queue: {{queue_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ea7e7b1d-7cdb-4cc5-8841-3265bf2cc4a3",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Task Execution Rate",
+      "yAxisUnit": "ops"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of task retries per second indicating tasks that failed and were rescheduled.",
+      "fillSpans": false,
+      "id": "9bb11bcc-2c17-4e6d-a7c3-5fcbd25826c8",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_task_queue_task_retry_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/task_queue/task/retry_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b28605c7",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "queue_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "queue_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Queue: {{queue_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8bfc72eb-23e4-43b3-8b11-42508eb8097f",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Task Retry Count",
+      "yAxisUnit": "ops"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Average age of oldest tasks in App Engine task queues, indicating processing lag.",
+      "fillSpans": false,
+      "id": "613b06d3-7b62-4fae-9b05-20de7f40bf63",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_task_queue_task_age--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/task_queue/task/age",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "786cdead",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "queue_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "queue_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Queue: {{queue_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "cf27e984-9549-4e91-9a04-cc4ccde38ce6",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Task Age",
+      "yAxisUnit": "s"
+    },
+    {
+      "description": "",
+      "id": "a3fbfa80-b564-4ccb-b3cd-28ea37acfcf0",
+      "panelTypes": "row",
+      "title": "Costs & Quotas"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of active instances over time, directly proportional to billed instance hours.",
+      "fillSpans": false,
+      "id": "90b90f9e-5ec9-44bb-91cb-ff27651a0269",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_system_instance_count--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/system/instance_count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "ace52056",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "version_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "version_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Version: {{version_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "721e5a34-9d65-482d-87c0-ed8305b38300",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Billable Instance Hours",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of API calls broken down by version and handler, useful for quota monitoring.",
+      "fillSpans": false,
+      "id": "e9a8b3b3-c161-4dfe-8efb-aba930d1a038",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_http_server_response_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/http/server/response_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "6276c01d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "version_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "version_id",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "handler--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "handler",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{version_id}} / {{handler}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "cba52c88-607d-4df9-9ff6-d05c6ef7ca04",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "API Calls by Service",
+      "yAxisUnit": "ops"
+    },
+    {
+      "description": "",
+      "id": "a00ff1ad-f2ea-4820-a0bc-d0f7b86381ee",
+      "panelTypes": "row",
+      "title": "HTTP Request Details"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Distribution of App Engine HTTP responses by type (dynamic vs static content).",
+      "fillSpans": false,
+      "id": "68aa4903-402d-406a-8eaa-1f1efef55526",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_http_server_response_style_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/http/server/response_style_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "90bb2997",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "dynamic--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "dynamic",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Dynamic: {{dynamic}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "aab13603-d27b-4585-a4ce-23a115cc4e24",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Response Type Distribution",
+      "yAxisUnit": "ops"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Average HTTP response latency broken down by App Engine handler to identify slow endpoints.",
+      "fillSpans": false,
+      "id": "e73a2396-23f0-495e-bfcf-a9a4879667b7",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_http_server_response_latencies--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/http/server/response_latencies",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "70487a4b",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "handler--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "handler",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Handler: {{handler}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "97c3b752-8c51-4303-9e4c-f76412af6335",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Latency by Handler",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of HTTP requests broken down by HTTP method (GET, POST, PUT, DELETE, etc.).",
+      "fillSpans": false,
+      "id": "b29ad895-33f9-41d0-932d-4b2795b4be4b",
+      "isStacked": true,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_http_server_response_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/http/server/response_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "0e3d1fc4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "method--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "method",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Method: {{method}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6eb31c94-48d7-464e-b224-3f35cd1288c3",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Count by HTTP Method",
+      "yAxisUnit": "ops"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Response latency percentiles per App Engine version to compare performance across deployments.",
+      "fillSpans": false,
+      "id": "02d90e22-867d-479a-9ea2-d22d4a3fa569",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_http_server_response_latencies--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/http/server/response_latencies",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p50",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "677845d7",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "version_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "version_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "p50 {{version_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "p50",
+              "stepInterval": 60,
+              "timeAggregation": "p50"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_http_server_response_latencies--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/http/server/response_latencies",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p90",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "23ec0c94",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "version_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "version_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "p90 {{version_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "p90",
+              "stepInterval": 60,
+              "timeAggregation": "p90"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          },
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "B",
+            "query": ""
+          }
+        ],
+        "id": "d2f2c6b3-38fc-49d8-922d-415405e782ae",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          },
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "B",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Latency by Version (p50/p90)",
+      "yAxisUnit": "ms"
+    },
+    {
+      "description": "",
+      "id": "204c0c96-c9ea-4746-8ef7-460b69f7af5c",
+      "panelTypes": "row",
+      "title": "Instance Details"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Current total memory usage across all active App Engine instances.",
+      "fillSpans": false,
+      "id": "20c2c9e5-1681-4ee7-b6f0-70e95bc9bcf2",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_system_memory_usage--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/system/memory/usage",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "ca59055a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Total Memory",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ed210dd6-b147-45c4-b0e8-4975208b3a40",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Memory Usage",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Maximum CPU usage across all App Engine instances during the selected time window.",
+      "fillSpans": false,
+      "id": "60030aa2-562d-4778-93a3-f4f0ea79b81a",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_system_cpu_usage--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/system/cpu/usage",
+                "type": "Sum"
+              },
+              "aggregateOperator": "max",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "a42199e6",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Peak CPU",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "max",
+              "spaceAggregation": "max",
+              "stepInterval": 60,
+              "timeAggregation": "max"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9016a718-248f-4aac-9fc0-b1fba2c37eb0",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Peak CPU Usage",
+      "yAxisUnit": "percentunit"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of distinct App Engine versions with active instances.",
+      "fillSpans": false,
+      "id": "060eda62-c70e-4f57-ab78-49176280dd54",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_system_instance_count--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/system/instance_count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "count_distinct",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "97bd41df",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "version_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "version_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9c5203cb-b06f-4427-8dbf-76d6f904410f",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Versions",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Combined rate of inbound and outbound network traffic across all App Engine instances.",
+      "fillSpans": false,
+      "id": "0ee248bc-c844-4c53-807f-90a24385f519",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_system_network_sent_bytes_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/system/network/sent_bytes_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d22129cb",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_system_network_received_bytes_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/system/network/received_bytes_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b86ba3b9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "A + B",
+              "legend": "Total I/O",
+              "queryName": "F1"
+            }
+          ]
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          },
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "B",
+            "query": ""
+          }
+        ],
+        "id": "d495f6ef-b7e7-4ea3-b5ec-14fb71e73888",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          },
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "B",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Network I/O Rate",
+      "yAxisUnit": "binBps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Average memory usage per App Engine version over time.",
+      "fillSpans": false,
+      "id": "ce2d1d2e-9bf0-4fd7-a9b6-e869b69ca57a",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_system_memory_usage--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/system/memory/usage",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "95c8e1e4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "version_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "version_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Version: {{version_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "5e5caedc-558d-4033-9a3c-0ef48f504de3",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memory Usage by Version",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "CPU usage rate per App Engine version over time.",
+      "fillSpans": false,
+      "id": "80df5c3e-5018-4aca-b5ef-25278cae699d",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_system_cpu_usage--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/system/cpu/usage",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "657f885f",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "version_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "version_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Version: {{version_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b426a70f-ee90-4692-83f1-6ee909c2cf41",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "CPU Usage by Version",
+      "yAxisUnit": "percentunit"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "App Engine instance distribution by state (active, idle, starting) over time.",
+      "fillSpans": false,
+      "id": "8a47ebb9-1a49-49ab-91a7-370d0aab2eb4",
+      "isStacked": true,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_system_instance_count--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/system/instance_count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "afedb64a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "state--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "state",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "State: {{state}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9a2d9318-8b0d-4731-ac30-8637ab6972ee",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Instances by State",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Average CPU usage per active instance, indicating how efficiently instances are being utilized.",
+      "fillSpans": false,
+      "id": "a29133b2-94b9-48ac-9531-ed0c60c876dc",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_system_cpu_usage--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/system/cpu/usage",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "7fcea035",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_system_instance_count--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/system/instance_count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "6a383727",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "A / B",
+              "legend": "CPU per Instance",
+              "queryName": "F1"
+            }
+          ]
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          },
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "B",
+            "query": ""
+          }
+        ],
+        "id": "c975b201-007b-41e8-b747-6b38bb227339",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          },
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "B",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "CPU per Instance (Efficiency)",
+      "yAxisUnit": "percentunit"
+    },
+    {
+      "description": "",
+      "id": "c03f020c-074f-40ed-aad0-cdad2383a724",
+      "panelTypes": "row",
+      "title": "Memcache Details"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Percentage of available memcache capacity currently in use.",
+      "fillSpans": false,
+      "id": "3f80e4e8-d521-4ab4-85fd-2ae0631be866",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_memcache_used_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/memcache/used_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "dfd944fe",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_memcache_total_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/memcache/total_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "42edcb95",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "A / B * 100",
+              "legend": "Utilization %",
+              "queryName": "F1"
+            }
+          ]
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          },
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "B",
+            "query": ""
+          }
+        ],
+        "id": "8fc95e05-aca9-47c7-b937-70bac60ac722",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          },
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "B",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memcache Utilization (%)",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of memcache evictions per second. High eviction rates indicate insufficient cache capacity.",
+      "fillSpans": false,
+      "id": "2015d7e2-a2fb-4bd1-9a9a-58388d1202a2",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_memcache_eviction_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/memcache/eviction_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "ddc14586",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Evictions/s",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "69b5ad24-7bf9-4097-b2f4-320c1fd41526",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memcache Evictions",
+      "yAxisUnit": "ops"
+    },
+    {
+      "description": "",
+      "id": "584fa8f0-f705-419a-8809-e87213e5263b",
+      "panelTypes": "row",
+      "title": "Quota & Limits"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Overall HTTP request rate trend for capacity planning and quota monitoring.",
+      "fillSpans": false,
+      "id": "685d99ec-41d7-4f46-a18a-fb3dc15bbfb5",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_http_server_response_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/http/server/response_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "cfe9c1cb",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Request Rate",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ca0ef4c0-49a9-47f8-a2d0-715160556eda",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Rate Trend",
+      "yAxisUnit": "ops"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Detailed breakdown of instance hours by version and state for cost attribution.",
+      "fillSpans": false,
+      "id": "9a1300d0-9503-4c0c-8750-6475fa001d1c",
+      "isStacked": true,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_system_instance_count--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/system/instance_count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "be120428",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "version_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "version_id",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "state--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "state",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{version_id}} ({{state}})",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "97e74680-20f3-4af2-ba91-a55503f45aca",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Instance Hours by Version & State",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Calculated service availability percentage based on the ratio of non-5xx to total responses. Target is typically 99.9% or higher.",
+      "fillSpans": false,
+      "id": "a62154d6-ce48-4f14-a59d-3ed2a851e212",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_http_server_response_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/http/server/response_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b8e7735c",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  },
+                  {
+                    "id": "2439d146",
+                    "key": {
+                      "dataType": "string",
+                      "id": "response_code_class--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "response_code_class",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "5xx"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_http_server_response_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/http/server/response_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "9d6aa307",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "(1 - (A / B)) * 100",
+              "legend": "Availability %",
+              "queryName": "F1"
+            }
+          ]
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          },
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "B",
+            "query": ""
+          }
+        ],
+        "id": "58f219bc-c153-45f5-a231-67127e74d7c4",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          },
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "B",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Service Availability (%)",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Average number of requests handled per instance, useful for understanding scaling efficiency.",
+      "fillSpans": false,
+      "id": "d100ea92-445f-4d0e-a985-2f5a5aad3f84",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_http_server_response_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/http/server/response_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f33e3b64",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "appengine_googleapis_com_system_instance_count--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "appengine.googleapis.com/system/instance_count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "0654c86e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "gcp_project--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "gcp_project",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.gcp_project}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "A / B",
+              "legend": "Requests per Instance",
+              "queryName": "F1"
+            }
+          ]
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          },
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "B",
+            "query": ""
+          }
+        ],
+        "id": "5c0c8535-8e14-4dcc-98a1-cb04afd8cbe0",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          },
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "B",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Throughput per Instance",
+      "yAxisUnit": "ops"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Comprehensive GCP App Engine monitoring dashboard covering HTTP performance, instance management, network, memcache, task queues, and cost tracking.

| Section | Panels | Key Metrics |
|---------|--------|-------------|
| Overview | 4 value | Instances, requests, error rate, response time |
| HTTP Performance | 6 | Request rate, latency p50/p95/p99, 4xx/5xx errors |
| Instance Management | 4 | Instance count, memory, CPU, startup latency |
| Network | 4 | Bytes sent/received, bandwidth per version |
| Memcache | 4 | Hit ratio, operations/sec, size, item count |
| Task Queue | 4 | Queue depth, execution rate, retries, task age |
| Costs & Quotas | 2 | Billable hours, API calls |

**Data source:** Google Cloud Monitoring metrics via OpenTelemetry

**Variables:** `{{gcp_project}}` for filtering by GCP project

Closes SigNoz/signoz#6382

## Test plan
- [ ] Import JSON into SigNoz dashboard
- [ ] Verify panels render with GCP App Engine metrics
- [ ] Confirm variable filtering works

Closes SigNoz/signoz#6382