### PR TITLE
feat(dashboard): Add GCP Cloud Functions monitoring dashboard

### DIFF
--- a/gcp/README-cloud-function.md
+++ b/gcp/README-cloud-function.md
@@ -1,0 +1,59 @@
+# GCP Cloud Functions Monitoring Dashboard
+
+Comprehensive GCP Cloud Functions monitoring dashboard for [SigNoz](https://signoz.io/) using Google Cloud Monitoring metrics.
+
+## Sections
+
+| #   | Section      | Covers                                                     |
+| --- | ------------ | ---------------------------------------------------------- |
+| 1   | Overview     | Active functions, total invocations, errors, execution time |
+| 2   | Invocations  | Rate by function, by status, errors, timeouts, triggers    |
+| 3   | Latency      | Execution time p50/p95/p99, by function                    |
+| 4   | Resources    | Memory, instances, network egress, CPU                     |
+| 5   | Connections  | Outgoing and database connections                          |
+| 6   | Billing      | Billable execution time, network egress                    |
+
+## Metrics Ingestion
+
+### Using OpenTelemetry Collector with Google Cloud Monitoring Receiver
+
+```yaml
+receivers:
+  googlecloudmonitoring:
+    project_id: "your-gcp-project"
+    collection_interval: 60s
+    metrics_list:
+      - metric_name: "cloudfunctions.googleapis.com/function/execution_count"
+      - metric_name: "cloudfunctions.googleapis.com/function/execution_times"
+      - metric_name: "cloudfunctions.googleapis.com/function/active_instances"
+      - metric_name: "cloudfunctions.googleapis.com/function/user_memory_bytes"
+      - metric_name: "cloudfunctions.googleapis.com/function/network_egress_bytes_count"
+      - metric_name: "cloudfunctions.googleapis.com/function/cpu_utilizations"
+
+processors:
+  batch:
+    timeout: 10s
+  resource:
+    attributes:
+      - key: service.name
+        value: "gcp-cloud-functions"
+        action: insert
+
+exporters:
+  otlp:
+    endpoint: "ingest.<region>.signoz.cloud:443"
+    headers:
+      signoz-ingestion-key: "<your-ingestion-key>"
+
+service:
+  pipelines:
+    metrics:
+      receivers: [googlecloudmonitoring]
+      processors: [batch, resource]
+      exporters: [otlp]
+```
+
+## Variables
+
+- `{{gcp_project}}`: GCP project ID for filtering metrics
+- `{{function_name}}`: Cloud Function name for filtering

--- a/gcp/gcp-cloud-function-prometheus-v1.json
+++ b/gcp/gcp-cloud-function-prometheus-v1.json
@@ -1,0 +1,2684 @@
+{
+  "description": "Comprehensive GCP Cloud Functions monitoring dashboard using Google Cloud Monitoring metrics. Covers invocations, latency, resources, connections, and billing.",
+  "image": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8cmVjdCB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHJ4PSIzIiBmaWxsPSIjNDI4NUY0Ii8+CiAgPHBhdGggZD0iTTkgNEw0IDlMOSAxNEwxNCA5TDkgNFoiIGZpbGw9IndoaXRlIiBmaWxsLW9wYWNpdHk9IjAuOCIvPgo8L3N2Zz4=",
+  "layout": [
+    {
+      "h": 1,
+      "i": "926d3992-fe8d-4814-b0f6-aaabdfc4b4ac",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 0,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 3,
+      "i": "9d5a99e9-4b00-4199-b7c3-376f2048388a",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 0,
+      "y": 1
+    },
+    {
+      "h": 3,
+      "i": "f6a57eb5-1c2f-486c-9d78-454e3e6ef786",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 3,
+      "y": 1
+    },
+    {
+      "h": 3,
+      "i": "1023f975-e779-481e-8403-58880da06653",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 6,
+      "y": 1
+    },
+    {
+      "h": 3,
+      "i": "3649fc10-5276-4e78-91a2-738209f4c614",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 9,
+      "y": 1
+    },
+    {
+      "h": 1,
+      "i": "e2fa7bd9-2fc1-4bfc-bc97-01c39795d575",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 4,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 6,
+      "i": "448caf85-bf76-45a7-870c-cfe878e640bd",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 5
+    },
+    {
+      "h": 6,
+      "i": "644ee7d7-77c8-490f-90d4-ef4d5f6d7fd1",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 5
+    },
+    {
+      "h": 6,
+      "i": "e9bdbfc2-f51b-4b32-a75d-210cfb04b8a3",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 11
+    },
+    {
+      "h": 6,
+      "i": "dd06ab39-4e04-4207-9884-bba733595928",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 11
+    },
+    {
+      "h": 6,
+      "i": "5c3b974a-8bd1-4162-9a68-30347a91ff9c",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 17
+    },
+    {
+      "h": 6,
+      "i": "ecc11103-f992-4bf6-8343-94d4e860180b",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 17
+    },
+    {
+      "h": 1,
+      "i": "6a351cb1-f9fb-4584-92b8-14f461806d25",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 23,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 6,
+      "i": "d373a6c8-dd13-4bfc-b78f-9afdbe1546fe",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 24
+    },
+    {
+      "h": 6,
+      "i": "665c6d4a-8822-4f41-82a1-625a90dadafb",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 24
+    },
+    {
+      "h": 6,
+      "i": "d27584de-bc6d-42b2-92df-0c3d7d1f57d4",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 30
+    },
+    {
+      "h": 6,
+      "i": "97d86308-f614-433a-8bbc-a32c8986209a",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 30
+    },
+    {
+      "h": 1,
+      "i": "e9d86608-2638-4e11-9686-66189958c60c",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 36,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 6,
+      "i": "0b1be6d6-d933-4b12-b067-cd1765cef412",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 37
+    },
+    {
+      "h": 6,
+      "i": "efbc668a-1ca3-468e-ae1d-4fdc3f8d72ad",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 37
+    },
+    {
+      "h": 6,
+      "i": "6464c8b7-c77f-4d25-9edf-8a61afa5e54e",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 43
+    },
+    {
+      "h": 6,
+      "i": "48d68a85-55b9-4826-890a-a0a1e7726d19",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 43
+    },
+    {
+      "h": 6,
+      "i": "cafcd28e-d25c-4ed0-a461-d3b8845f71ec",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 49
+    },
+    {
+      "h": 6,
+      "i": "b53f116b-086c-4aff-ae47-06bc092c77b4",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 49
+    },
+    {
+      "h": 1,
+      "i": "24707689-1227-4f46-bf72-5dcfe35e6ebd",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 55,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 6,
+      "i": "a4f2b1f6-2be7-4994-9ad5-ff33f846525e",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 56
+    },
+    {
+      "h": 6,
+      "i": "9525daac-8e31-4205-99c6-e5eb1da93c07",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 56
+    },
+    {
+      "h": 1,
+      "i": "9f68dd6a-c3ab-46a2-8840-decdd1cb3fe0",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 62,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 6,
+      "i": "2b958fef-d4aa-4af4-9b0a-5fdb8ab36023",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 63
+    },
+    {
+      "h": 6,
+      "i": "ac051f22-6ce4-427e-be3e-c17bec58f1c7",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 63
+    }
+  ],
+  "tags": [
+    "gcp",
+    "cloud-functions",
+    "serverless"
+  ],
+  "title": "GCP Cloud Functions Monitoring",
+  "variables": {
+    "gcp_project": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "GCP Project ID",
+      "modificationUUID": "1d2e10f4-4224-42e6-aaef-ca451e68181c",
+      "multiSelect": false,
+      "name": "gcp_project",
+      "queryValue": "SELECT DISTINCT JSONExtractString(labels, 'project_id') FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'cloudfunctions_googleapis_com_function_execution_count'",
+      "selectedValue": "",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "function_name": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "Cloud Function Name",
+      "modificationUUID": "643eb961-4c82-45ec-b2cd-14cc52464631",
+      "multiSelect": true,
+      "name": "function_name",
+      "queryValue": "SELECT DISTINCT JSONExtractString(labels, 'function_name') FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'cloudfunctions_googleapis_com_function_execution_count'",
+      "selectedValue": "",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "widgets": [
+    {
+      "id": "926d3992-fe8d-4814-b0f6-aaabdfc4b4ac",
+      "title": "Overview",
+      "description": "",
+      "panelTypes": "row",
+      "widgets": [
+        {
+          "id": "1804dbc8-f16f-4c89-b342-ed28a5b866ea",
+          "title": "Overview"
+        }
+      ],
+      "layout": {
+        "h": 1,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      }
+    },
+    {
+      "id": "9d5a99e9-4b00-4199-b7c3-376f2048388a",
+      "title": "Active Functions",
+      "description": "",
+      "panelTypes": "value",
+      "queryData": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "latest",
+              "aggregateAttribute": {
+                "key": "cloudfunctions_googleapis_com_function_active_instances",
+                "dataType": "float64",
+                "type": "Gauge",
+                "isColumn": false
+              },
+              "timeAggregation": "latest",
+              "spaceAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [],
+              "legend": "",
+              "limit": 0,
+              "orderBy": [],
+              "reduceTo": "last"
+            }
+          ],
+          "queryFormulas": []
+        }
+      },
+      "fillSpans": false,
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "none",
+      "layout": {
+        "h": 3,
+        "w": 3,
+        "x": 0,
+        "y": 1
+      }
+    },
+    {
+      "id": "f6a57eb5-1c2f-486c-9d78-454e3e6ef786",
+      "title": "Total Invocations",
+      "description": "",
+      "panelTypes": "value",
+      "queryData": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "sum",
+              "aggregateAttribute": {
+                "key": "cloudfunctions_googleapis_com_function_execution_count",
+                "dataType": "float64",
+                "type": "Gauge",
+                "isColumn": false
+              },
+              "timeAggregation": "latest",
+              "spaceAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [],
+              "legend": "",
+              "limit": 0,
+              "orderBy": [],
+              "reduceTo": "last"
+            }
+          ],
+          "queryFormulas": []
+        }
+      },
+      "fillSpans": false,
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "none",
+      "layout": {
+        "h": 3,
+        "w": 3,
+        "x": 3,
+        "y": 1
+      }
+    },
+    {
+      "id": "1023f975-e779-481e-8403-58880da06653",
+      "title": "Error Count",
+      "description": "",
+      "panelTypes": "value",
+      "queryData": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "sum",
+              "aggregateAttribute": {
+                "key": "cloudfunctions_googleapis_com_function_execution_count",
+                "dataType": "float64",
+                "type": "Gauge",
+                "isColumn": false
+              },
+              "timeAggregation": "latest",
+              "spaceAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [],
+              "legend": "",
+              "limit": 0,
+              "orderBy": [],
+              "reduceTo": "last"
+            }
+          ],
+          "queryFormulas": []
+        }
+      },
+      "fillSpans": false,
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "none",
+      "layout": {
+        "h": 3,
+        "w": 3,
+        "x": 6,
+        "y": 1
+      }
+    },
+    {
+      "id": "3649fc10-5276-4e78-91a2-738209f4c614",
+      "title": "Avg Execution Time",
+      "description": "",
+      "panelTypes": "value",
+      "queryData": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "avg",
+              "aggregateAttribute": {
+                "key": "cloudfunctions_googleapis_com_function_execution_times",
+                "dataType": "float64",
+                "type": "Gauge",
+                "isColumn": false
+              },
+              "timeAggregation": "latest",
+              "spaceAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [],
+              "legend": "",
+              "limit": 0,
+              "orderBy": [],
+              "reduceTo": "last"
+            }
+          ],
+          "queryFormulas": []
+        }
+      },
+      "fillSpans": false,
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "ms",
+      "layout": {
+        "h": 3,
+        "w": 3,
+        "x": 9,
+        "y": 1
+      }
+    },
+    {
+      "id": "e2fa7bd9-2fc1-4bfc-bc97-01c39795d575",
+      "title": "Invocations",
+      "description": "",
+      "panelTypes": "row",
+      "widgets": [
+        {
+          "id": "fd8f9bfa-3b94-4994-b220-b0f342a8f7d6",
+          "title": "Invocations"
+        }
+      ],
+      "layout": {
+        "h": 1,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      }
+    },
+    {
+      "id": "448caf85-bf76-45a7-870c-cfe878e640bd",
+      "title": "Invocation Rate by Function",
+      "description": "",
+      "panelTypes": "graph",
+      "queryData": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "rate",
+              "aggregateAttribute": {
+                "key": "cloudfunctions_googleapis_com_function_execution_count",
+                "dataType": "float64",
+                "type": "Sum",
+                "isColumn": false
+              },
+              "timeAggregation": "rate",
+              "spaceAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "function_name",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{function_name}}",
+              "limit": 0,
+              "orderBy": [],
+              "reduceTo": "last"
+            }
+          ],
+          "queryFormulas": []
+        }
+      },
+      "fillSpans": false,
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "ops",
+      "layout": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 5
+      }
+    },
+    {
+      "id": "644ee7d7-77c8-490f-90d4-ef4d5f6d7fd1",
+      "title": "Invocations by Status",
+      "description": "",
+      "panelTypes": "graph",
+      "queryData": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "rate",
+              "aggregateAttribute": {
+                "key": "cloudfunctions_googleapis_com_function_execution_count",
+                "dataType": "float64",
+                "type": "Sum",
+                "isColumn": false
+              },
+              "timeAggregation": "rate",
+              "spaceAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "status",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{status}}",
+              "limit": 0,
+              "orderBy": [],
+              "reduceTo": "last"
+            }
+          ],
+          "queryFormulas": []
+        }
+      },
+      "fillSpans": false,
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "ops",
+      "layout": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 5
+      }
+    },
+    {
+      "id": "e9bdbfc2-f51b-4b32-a75d-210cfb04b8a3",
+      "title": "Error Rate",
+      "description": "",
+      "panelTypes": "graph",
+      "queryData": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "rate",
+              "aggregateAttribute": {
+                "key": "cloudfunctions_googleapis_com_function_execution_count",
+                "dataType": "float64",
+                "type": "Sum",
+                "isColumn": false
+              },
+              "timeAggregation": "rate",
+              "spaceAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "status",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{status}}",
+              "limit": 0,
+              "orderBy": [],
+              "reduceTo": "last"
+            }
+          ],
+          "queryFormulas": []
+        }
+      },
+      "fillSpans": false,
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "ops",
+      "layout": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 11
+      }
+    },
+    {
+      "id": "dd06ab39-4e04-4207-9884-bba733595928",
+      "title": "Timeout Rate",
+      "description": "",
+      "panelTypes": "graph",
+      "queryData": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "rate",
+              "aggregateAttribute": {
+                "key": "cloudfunctions_googleapis_com_function_execution_count",
+                "dataType": "float64",
+                "type": "Sum",
+                "isColumn": false
+              },
+              "timeAggregation": "rate",
+              "spaceAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "status",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{status}}",
+              "limit": 0,
+              "orderBy": [],
+              "reduceTo": "last"
+            }
+          ],
+          "queryFormulas": []
+        }
+      },
+      "fillSpans": false,
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "ops",
+      "layout": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 11
+      }
+    },
+    {
+      "id": "5c3b974a-8bd1-4162-9a68-30347a91ff9c",
+      "title": "Invocations by Trigger",
+      "description": "",
+      "panelTypes": "graph",
+      "queryData": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "rate",
+              "aggregateAttribute": {
+                "key": "cloudfunctions_googleapis_com_function_execution_count",
+                "dataType": "float64",
+                "type": "Sum",
+                "isColumn": false
+              },
+              "timeAggregation": "rate",
+              "spaceAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "trigger_type",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{trigger_type}}",
+              "limit": 0,
+              "orderBy": [],
+              "reduceTo": "last"
+            }
+          ],
+          "queryFormulas": []
+        }
+      },
+      "fillSpans": false,
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "ops",
+      "layout": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 17
+      }
+    },
+    {
+      "id": "ecc11103-f992-4bf6-8343-94d4e860180b",
+      "title": "Invocations by Region",
+      "description": "",
+      "panelTypes": "graph",
+      "queryData": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "rate",
+              "aggregateAttribute": {
+                "key": "cloudfunctions_googleapis_com_function_execution_count",
+                "dataType": "float64",
+                "type": "Sum",
+                "isColumn": false
+              },
+              "timeAggregation": "rate",
+              "spaceAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "region",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{region}}",
+              "limit": 0,
+              "orderBy": [],
+              "reduceTo": "last"
+            }
+          ],
+          "queryFormulas": []
+        }
+      },
+      "fillSpans": false,
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "ops",
+      "layout": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 17
+      }
+    },
+    {
+      "id": "6a351cb1-f9fb-4584-92b8-14f461806d25",
+      "title": "Latency",
+      "description": "",
+      "panelTypes": "row",
+      "widgets": [
+        {
+          "id": "ffa1e804-3bee-43ff-b556-f632d8f581b7",
+          "title": "Latency"
+        }
+      ],
+      "layout": {
+        "h": 1,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      }
+    },
+    {
+      "id": "d373a6c8-dd13-4bfc-b78f-9afdbe1546fe",
+      "title": "Execution Time p50",
+      "description": "",
+      "panelTypes": "graph",
+      "queryData": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "p50",
+              "aggregateAttribute": {
+                "key": "cloudfunctions_googleapis_com_function_execution_times",
+                "dataType": "float64",
+                "type": "Histogram",
+                "isColumn": false
+              },
+              "timeAggregation": "avg",
+              "spaceAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "function_name",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{function_name}}",
+              "limit": 0,
+              "orderBy": [],
+              "reduceTo": "last"
+            }
+          ],
+          "queryFormulas": []
+        }
+      },
+      "fillSpans": false,
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "ms",
+      "layout": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 24
+      }
+    },
+    {
+      "id": "665c6d4a-8822-4f41-82a1-625a90dadafb",
+      "title": "Execution Time p95",
+      "description": "",
+      "panelTypes": "graph",
+      "queryData": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "p95",
+              "aggregateAttribute": {
+                "key": "cloudfunctions_googleapis_com_function_execution_times",
+                "dataType": "float64",
+                "type": "Histogram",
+                "isColumn": false
+              },
+              "timeAggregation": "avg",
+              "spaceAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "function_name",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{function_name}}",
+              "limit": 0,
+              "orderBy": [],
+              "reduceTo": "last"
+            }
+          ],
+          "queryFormulas": []
+        }
+      },
+      "fillSpans": false,
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "ms",
+      "layout": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 24
+      }
+    },
+    {
+      "id": "d27584de-bc6d-42b2-92df-0c3d7d1f57d4",
+      "title": "Execution Time p99",
+      "description": "",
+      "panelTypes": "graph",
+      "queryData": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "p99",
+              "aggregateAttribute": {
+                "key": "cloudfunctions_googleapis_com_function_execution_times",
+                "dataType": "float64",
+                "type": "Histogram",
+                "isColumn": false
+              },
+              "timeAggregation": "avg",
+              "spaceAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "function_name",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{function_name}}",
+              "limit": 0,
+              "orderBy": [],
+              "reduceTo": "last"
+            }
+          ],
+          "queryFormulas": []
+        }
+      },
+      "fillSpans": false,
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "ms",
+      "layout": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 30
+      }
+    },
+    {
+      "id": "97d86308-f614-433a-8bbc-a32c8986209a",
+      "title": "Execution Time by Function",
+      "description": "",
+      "panelTypes": "graph",
+      "queryData": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "avg",
+              "aggregateAttribute": {
+                "key": "cloudfunctions_googleapis_com_function_execution_times",
+                "dataType": "float64",
+                "type": "Histogram",
+                "isColumn": false
+              },
+              "timeAggregation": "avg",
+              "spaceAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "function_name",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{function_name}}",
+              "limit": 0,
+              "orderBy": [],
+              "reduceTo": "last"
+            }
+          ],
+          "queryFormulas": []
+        }
+      },
+      "fillSpans": false,
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "ms",
+      "layout": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 30
+      }
+    },
+    {
+      "id": "e9d86608-2638-4e11-9686-66189958c60c",
+      "title": "Resources",
+      "description": "",
+      "panelTypes": "row",
+      "widgets": [
+        {
+          "id": "59725595-ba00-4e5d-93bd-982e60bfc591",
+          "title": "Resources"
+        }
+      ],
+      "layout": {
+        "h": 1,
+        "w": 12,
+        "x": 0,
+        "y": 36
+      }
+    },
+    {
+      "id": "0b1be6d6-d933-4b12-b067-cd1765cef412",
+      "title": "Memory Utilization",
+      "description": "",
+      "panelTypes": "graph",
+      "queryData": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "avg",
+              "aggregateAttribute": {
+                "key": "cloudfunctions_googleapis_com_function_user_memory_bytes",
+                "dataType": "float64",
+                "type": "Gauge",
+                "isColumn": false
+              },
+              "timeAggregation": "avg",
+              "spaceAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "function_name",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{function_name}}",
+              "limit": 0,
+              "orderBy": [],
+              "reduceTo": "last"
+            }
+          ],
+          "queryFormulas": []
+        }
+      },
+      "fillSpans": false,
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "bytes",
+      "layout": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 37
+      }
+    },
+    {
+      "id": "efbc668a-1ca3-468e-ae1d-4fdc3f8d72ad",
+      "title": "Memory Limit vs Used",
+      "description": "",
+      "panelTypes": "graph",
+      "queryData": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "max",
+              "aggregateAttribute": {
+                "key": "cloudfunctions_googleapis_com_function_user_memory_bytes",
+                "dataType": "float64",
+                "type": "Gauge",
+                "isColumn": false
+              },
+              "timeAggregation": "avg",
+              "spaceAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "function_name",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{function_name}}",
+              "limit": 0,
+              "orderBy": [],
+              "reduceTo": "last"
+            }
+          ],
+          "queryFormulas": []
+        }
+      },
+      "fillSpans": false,
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "bytes",
+      "layout": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 37
+      }
+    },
+    {
+      "id": "6464c8b7-c77f-4d25-9edf-8a61afa5e54e",
+      "title": "Active Instances",
+      "description": "",
+      "panelTypes": "graph",
+      "queryData": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "avg",
+              "aggregateAttribute": {
+                "key": "cloudfunctions_googleapis_com_function_active_instances",
+                "dataType": "float64",
+                "type": "Gauge",
+                "isColumn": false
+              },
+              "timeAggregation": "avg",
+              "spaceAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "function_name",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{function_name}}",
+              "limit": 0,
+              "orderBy": [],
+              "reduceTo": "last"
+            }
+          ],
+          "queryFormulas": []
+        }
+      },
+      "fillSpans": false,
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "none",
+      "layout": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 43
+      }
+    },
+    {
+      "id": "48d68a85-55b9-4826-890a-a0a1e7726d19",
+      "title": "Instance Count by Function",
+      "description": "",
+      "panelTypes": "graph",
+      "queryData": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "max",
+              "aggregateAttribute": {
+                "key": "cloudfunctions_googleapis_com_function_active_instances",
+                "dataType": "float64",
+                "type": "Gauge",
+                "isColumn": false
+              },
+              "timeAggregation": "avg",
+              "spaceAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "function_name",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{function_name}}",
+              "limit": 0,
+              "orderBy": [],
+              "reduceTo": "last"
+            }
+          ],
+          "queryFormulas": []
+        }
+      },
+      "fillSpans": false,
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "none",
+      "layout": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 43
+      }
+    },
+    {
+      "id": "cafcd28e-d25c-4ed0-a461-d3b8845f71ec",
+      "title": "Network Egress",
+      "description": "",
+      "panelTypes": "graph",
+      "queryData": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "rate",
+              "aggregateAttribute": {
+                "key": "cloudfunctions_googleapis_com_function_network_egress_bytes_count",
+                "dataType": "float64",
+                "type": "Sum",
+                "isColumn": false
+              },
+              "timeAggregation": "rate",
+              "spaceAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "function_name",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{function_name}}",
+              "limit": 0,
+              "orderBy": [],
+              "reduceTo": "last"
+            }
+          ],
+          "queryFormulas": []
+        }
+      },
+      "fillSpans": false,
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "binBps",
+      "layout": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 49
+      }
+    },
+    {
+      "id": "b53f116b-086c-4aff-ae47-06bc092c77b4",
+      "title": "CPU Utilization",
+      "description": "",
+      "panelTypes": "graph",
+      "queryData": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "avg",
+              "aggregateAttribute": {
+                "key": "cloudfunctions_googleapis_com_function_cpu_utilizations",
+                "dataType": "float64",
+                "type": "Gauge",
+                "isColumn": false
+              },
+              "timeAggregation": "avg",
+              "spaceAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "function_name",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{function_name}}",
+              "limit": 0,
+              "orderBy": [],
+              "reduceTo": "last"
+            }
+          ],
+          "queryFormulas": []
+        }
+      },
+      "fillSpans": false,
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "percent",
+      "layout": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 49
+      }
+    },
+    {
+      "id": "24707689-1227-4f46-bf72-5dcfe35e6ebd",
+      "title": "Connections",
+      "description": "",
+      "panelTypes": "row",
+      "widgets": [
+        {
+          "id": "6fb1ef4c-d39c-47ac-b29d-f0c40a705dc8",
+          "title": "Connections"
+        }
+      ],
+      "layout": {
+        "h": 1,
+        "w": 12,
+        "x": 0,
+        "y": 55
+      }
+    },
+    {
+      "id": "a4f2b1f6-2be7-4994-9ad5-ff33f846525e",
+      "title": "Outgoing Connections",
+      "description": "",
+      "panelTypes": "graph",
+      "queryData": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "avg",
+              "aggregateAttribute": {
+                "key": "cloudfunctions_googleapis_com_function_network_connections",
+                "dataType": "float64",
+                "type": "Gauge",
+                "isColumn": false
+              },
+              "timeAggregation": "avg",
+              "spaceAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "function_name",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{function_name}}",
+              "limit": 0,
+              "orderBy": [],
+              "reduceTo": "last"
+            }
+          ],
+          "queryFormulas": []
+        }
+      },
+      "fillSpans": false,
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "none",
+      "layout": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 56
+      }
+    },
+    {
+      "id": "9525daac-8e31-4205-99c6-e5eb1da93c07",
+      "title": "Database Connections",
+      "description": "",
+      "panelTypes": "graph",
+      "queryData": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "sum",
+              "aggregateAttribute": {
+                "key": "cloudfunctions_googleapis_com_function_network_connections",
+                "dataType": "float64",
+                "type": "Gauge",
+                "isColumn": false
+              },
+              "timeAggregation": "avg",
+              "spaceAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "connection_type",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{connection_type}}",
+              "limit": 0,
+              "orderBy": [],
+              "reduceTo": "last"
+            }
+          ],
+          "queryFormulas": []
+        }
+      },
+      "fillSpans": false,
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "none",
+      "layout": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 56
+      }
+    },
+    {
+      "id": "9f68dd6a-c3ab-46a2-8840-decdd1cb3fe0",
+      "title": "Billing",
+      "description": "",
+      "panelTypes": "row",
+      "widgets": [
+        {
+          "id": "150e8ba8-9166-4c74-b9cb-f59e64903377",
+          "title": "Billing"
+        }
+      ],
+      "layout": {
+        "h": 1,
+        "w": 12,
+        "x": 0,
+        "y": 62
+      }
+    },
+    {
+      "id": "2b958fef-d4aa-4af4-9b0a-5fdb8ab36023",
+      "title": "Billable Execution Time",
+      "description": "",
+      "panelTypes": "graph",
+      "queryData": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "sum",
+              "aggregateAttribute": {
+                "key": "cloudfunctions_googleapis_com_function_execution_times",
+                "dataType": "float64",
+                "type": "Histogram",
+                "isColumn": false
+              },
+              "timeAggregation": "avg",
+              "spaceAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "function_name",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{function_name}}",
+              "limit": 0,
+              "orderBy": [],
+              "reduceTo": "last"
+            }
+          ],
+          "queryFormulas": []
+        }
+      },
+      "fillSpans": false,
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "ms",
+      "layout": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 63
+      }
+    },
+    {
+      "id": "ac051f22-6ce4-427e-be3e-c17bec58f1c7",
+      "title": "Network Egress (Billable)",
+      "description": "",
+      "panelTypes": "graph",
+      "queryData": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "sum",
+              "aggregateAttribute": {
+                "key": "cloudfunctions_googleapis_com_function_network_egress_bytes_count",
+                "dataType": "float64",
+                "type": "Sum",
+                "isColumn": false
+              },
+              "timeAggregation": "avg",
+              "spaceAggregation": "sum",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "groupBy": [
+                {
+                  "key": "function_name",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{function_name}}",
+              "limit": 0,
+              "orderBy": [],
+              "reduceTo": "last"
+            }
+          ],
+          "queryFormulas": []
+        }
+      },
+      "fillSpans": false,
+      "softMax": null,
+      "softMin": null,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "yAxisUnit": "bytes",
+      "layout": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 63
+      }
+    }
+  ]
+}    {
+      "description": "",
+      "id": "a1b2c3d4-0003-4000-8000-000000000001",
+      "panelTypes": "row",
+      "title": "Latency"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Distribution of function execution times at the 50th (median), 95th, and 99th percentiles. The p50 represents typical latency, p95 captures the experience of most users, and p99 highlights worst-case tail latency. Track these to set SLO targets and detect latency regressions.",
+      "fillSpans": false,
+      "id": "a1b2c3d4-0003-4000-8000-000000000002",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cloudfunctions_googleapis_com_function_execution_times--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cloudfunctions_googleapis_com_function_execution_times",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p50",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f3a00001",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.gcp_project}}"
+                    ]
+                  },
+                  {
+                    "id": "f3a00002",
+                    "key": {
+                      "dataType": "string",
+                      "id": "function_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "function_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.function_name}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p50",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "p50",
+              "stepInterval": 60,
+              "timeAggregation": "p50"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cloudfunctions_googleapis_com_function_execution_times--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cloudfunctions_googleapis_com_function_execution_times",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p95",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f3a00003",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.gcp_project}}"
+                    ]
+                  },
+                  {
+                    "id": "f3a00004",
+                    "key": {
+                      "dataType": "string",
+                      "id": "function_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "function_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.function_name}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p95",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "p95",
+              "stepInterval": 60,
+              "timeAggregation": "p95"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cloudfunctions_googleapis_com_function_execution_times--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cloudfunctions_googleapis_com_function_execution_times",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p99",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "C",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f3a00005",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.gcp_project}}"
+                    ]
+                  },
+                  {
+                    "id": "f3a00006",
+                    "key": {
+                      "dataType": "string",
+                      "id": "function_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "function_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.function_name}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "p99",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "C",
+              "reduceTo": "avg",
+              "spaceAggregation": "p99",
+              "stepInterval": 60,
+              "timeAggregation": "p99"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "q1b2c3d4-0003-4000-8000-000000000002",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Execution Time p50 / p95 / p99",
+      "yAxisUnit": "ns"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Average execution time for each Cloud Function. Compare functions side-by-side to identify which are the slowest and may benefit from optimization or resource allocation changes.",
+      "fillSpans": false,
+      "id": "a1b2c3d4-0003-4000-8000-000000000003",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cloudfunctions_googleapis_com_function_execution_times--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cloudfunctions_googleapis_com_function_execution_times",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f3b00001",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.gcp_project}}"
+                    ]
+                  },
+                  {
+                    "id": "f3b00002",
+                    "key": {
+                      "dataType": "string",
+                      "id": "function_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "function_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.function_name}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "function_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "function_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{function_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "q1b2c3d4-0003-4000-8000-000000000003",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Execution Time by Function",
+      "yAxisUnit": "ns"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Cold start latency measures the additional time required when a new function instance must be initialized before handling a request. Cold starts occur when there are no warm instances available and GCP must provision new infrastructure. High cold start latency impacts user experience for latency-sensitive workloads.",
+      "fillSpans": false,
+      "id": "a1b2c3d4-0003-4000-8000-000000000004",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cloudfunctions_googleapis_com_function_execution_times--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cloudfunctions_googleapis_com_function_execution_times",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p99",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f3c00001",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.gcp_project}}"
+                    ]
+                  },
+                  {
+                    "id": "f3c00002",
+                    "key": {
+                      "dataType": "string",
+                      "id": "function_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "function_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.function_name}}"
+                    ]
+                  },
+                  {
+                    "id": "f3c00003",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cold_start--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cold_start",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "true"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "function_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "function_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Cold Start p99: {{function_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "p99",
+              "stepInterval": 60,
+              "timeAggregation": "p99"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cloudfunctions_googleapis_com_function_execution_times--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cloudfunctions_googleapis_com_function_execution_times",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p50",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f3c00004",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.gcp_project}}"
+                    ]
+                  },
+                  {
+                    "id": "f3c00005",
+                    "key": {
+                      "dataType": "string",
+                      "id": "function_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "function_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.function_name}}"
+                    ]
+                  },
+                  {
+                    "id": "f3c00006",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cold_start--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cold_start",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "true"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "function_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "function_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Cold Start p50: {{function_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "p50",
+              "stepInterval": 60,
+              "timeAggregation": "p50"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "q1b2c3d4-0003-4000-8000-000000000004",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Cold Start Latency",
+      "yAxisUnit": "ns"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Function instance startup time broken down by function name. This measures the time taken to initialize the function runtime environment including loading dependencies, establishing connections, and running global initialization code. Optimize startup time by minimizing dependency size and deferring initialization.",
+      "fillSpans": false,
+      "id": "a1b2c3d4-0003-4000-8000-000000000005",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "cloudfunctions_googleapis_com_function_execution_times--float64--Histogram--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "cloudfunctions_googleapis_com_function_execution_times",
+                "type": "Histogram"
+              },
+              "aggregateOperator": "p95",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f3d00001",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.gcp_project}}"
+                    ]
+                  },
+                  {
+                    "id": "f3d00002",
+                    "key": {
+                      "dataType": "string",
+                      "id": "function_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "function_name",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.function_name}}"
+                    ]
+                  },
+                  {
+                    "id": "f3d00003",
+                    "key": {
+                      "dataType": "string",
+                      "id": "cold_start--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "cold_start",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "true"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "function_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "function_name",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "region--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "region",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{function_name}} ({{region}})",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "p95",
+              "stepInterval": 60,
+              "timeAggregation": "p95"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "q1b2c3d4-0003-4000-8000-000000000005",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Startup Time by Function",
+      "yAxisUnit": "ns"
+    },


### PR DESCRIPTION
## Summary

Comprehensive GCP Cloud Functions monitoring dashboard with **30 panels** across 6 sections:

| Section | Panels | Key Metrics |
|---------|--------|-------------|
| Overview | 4 value | Active functions, invocations, errors, execution time |
| Invocations | 6 | Rate by function/status/trigger/region, errors, timeouts |
| Latency | 4 | Execution time p50/p95/p99, by function |
| Resources | 6 | Memory, instances, network egress, CPU |
| Connections | 2 | Outgoing and database connections |
| Billing | 2 | Billable execution time, network egress |

**Data source:** Google Cloud Monitoring metrics via OpenTelemetry

**Variables:** `{{gcp_project}}`, `{{function_name}}`

Closes SigNoz/signoz#6383

## Test plan
- [ ] Import JSON into SigNoz dashboard
- [ ] Verify panels render with GCP Cloud Functions metrics
- [ ] Confirm variable filtering works

Closes SigNoz/signoz#6383