### PR TITLE
feat: Add GCP VPC Metrics monitoring dashboard (Prometheus v1)

### DIFF
--- a/gcp/README-vpc-metrics.md
+++ b/gcp/README-vpc-metrics.md
@@ -1,0 +1,56 @@
+# GCP VPC Metrics Dashboard
+
+Comprehensive monitoring for Google Cloud VPC networking infrastructure via Google Cloud Monitoring (Stackdriver) exporter.
+
+## Sections & Panels (36 panels)
+
+### Overview (4 panels)
+- Firewall Dropped Packets / Bytes
+- Firewall Allowed Connections
+- Firewall Hit Count
+
+### VPC Flow Logs & Traffic (6 panels)
+- Sent / Received Bytes by Subnet
+- Sent / Received Packets by Subnet
+- RTT Latencies
+- Inbound vs Outbound Traffic Rate
+
+### Cloud NAT (8 panels)
+- NAT Sent / Received Bytes
+- NAT Sent / Received Packets
+- NAT Dropped Sent / Received Packets
+- NAT Port Allocation
+- NAT Open Connections
+
+### VPC Peering (4 panels)
+- Peering Sent / Received Bytes
+- Peering Sent / Received Packets
+
+### Cloud Interconnect (4 panels)
+- Interconnect Sent / Received Bytes
+- Interconnect Link Capacity
+- Interconnect Receive Power (dBm)
+
+### Load Balancer (6 panels)
+- LB Request Count
+- LB Total Latency
+- LB Backend Request / Response Bytes
+- LB 4xx/5xx Error Rate
+- LB Backend Latency
+
+### DNS (2 panels)
+- DNS Query Count
+- DNS Query Latency
+
+### Subnet Utilization (2 panels)
+- Subnet IP Utilization
+- Subnet Instances Count
+
+## Variables
+| Variable | Description |
+|----------|-------------|
+| `project_id` | GCP Project ID |
+| `network_name` | VPC Network Name (multi-select) |
+
+## Data Source
+Google Cloud Monitoring metrics via Prometheus exporter (`networking.googleapis.com/*`).

--- a/gcp/gcp-vpc-metrics-prometheus-v1.json
+++ b/gcp/gcp-vpc-metrics-prometheus-v1.json
@@ -1,0 +1,5912 @@
+{
+  "description": "Comprehensive monitoring dashboard for GCP VPC networking. Tracks firewall rules, VPC flow logs, Cloud NAT, VPC peering, Cloud Interconnect, load balancer metrics, DNS queries, and subnet utilization via Google Cloud Monitoring exporter.",
+  "image": "",
+  "layout": [
+    {
+      "h": 1,
+      "i": "b1c2d3e4-0001-4000-8000-000000000001",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0001-4000-8000-000000000002",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 1
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0001-4000-8000-000000000003",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 1
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0001-4000-8000-000000000004",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 7
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0001-4000-8000-000000000005",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 7
+    },
+    {
+      "h": 1,
+      "i": "b1c2d3e4-0002-4000-8000-000000000001",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 13
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0002-4000-8000-000000000002",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 14
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0002-4000-8000-000000000003",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 14
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0002-4000-8000-000000000004",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 20
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0002-4000-8000-000000000005",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 20
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0002-4000-8000-000000000006",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 26
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0002-4000-8000-000000000007",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 26
+    },
+    {
+      "h": 1,
+      "i": "b1c2d3e4-0003-4000-8000-000000000001",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 32
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0003-4000-8000-000000000002",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 33
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0003-4000-8000-000000000003",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 33
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0003-4000-8000-000000000004",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 39
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0003-4000-8000-000000000005",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 39
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0003-4000-8000-000000000006",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 45
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0003-4000-8000-000000000007",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 45
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0003-4000-8000-000000000008",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 51
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0003-4000-8000-000000000009",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 51
+    },
+    {
+      "h": 1,
+      "i": "b1c2d3e4-0004-4000-8000-000000000001",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 57
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0004-4000-8000-000000000002",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 58
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0004-4000-8000-000000000003",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 58
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0004-4000-8000-000000000004",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 64
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0004-4000-8000-000000000005",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 64
+    },
+    {
+      "h": 1,
+      "i": "b1c2d3e4-0005-4000-8000-000000000001",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 70
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0005-4000-8000-000000000002",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 71
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0005-4000-8000-000000000003",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 71
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0005-4000-8000-000000000004",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 77
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0005-4000-8000-000000000005",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 77
+    },
+    {
+      "h": 1,
+      "i": "b1c2d3e4-0006-4000-8000-000000000001",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 83
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0006-4000-8000-000000000002",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 84
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0006-4000-8000-000000000003",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 84
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0006-4000-8000-000000000004",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 84
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0006-4000-8000-000000000005",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 90
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0006-4000-8000-000000000006",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 90
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0006-4000-8000-000000000007",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 90
+    },
+    {
+      "h": 1,
+      "i": "b1c2d3e4-0007-4000-8000-000000000001",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 96
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0007-4000-8000-000000000002",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 97
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0007-4000-8000-000000000003",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 97
+    },
+    {
+      "h": 1,
+      "i": "b1c2d3e4-0008-4000-8000-000000000001",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 103
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0008-4000-8000-000000000002",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 104
+    },
+    {
+      "h": 6,
+      "i": "b1c2d3e4-0008-4000-8000-000000000003",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 104
+    }
+  ],
+  "panelMap": {
+    "b1c2d3e4-0001-4000-8000-000000000001": {
+      "collapsed": false,
+      "widgets": [
+        "b1c2d3e4-0001-4000-8000-000000000002",
+        "b1c2d3e4-0001-4000-8000-000000000003",
+        "b1c2d3e4-0001-4000-8000-000000000004",
+        "b1c2d3e4-0001-4000-8000-000000000005"
+      ]
+    },
+    "b1c2d3e4-0002-4000-8000-000000000001": {
+      "collapsed": false,
+      "widgets": [
+        "b1c2d3e4-0002-4000-8000-000000000002",
+        "b1c2d3e4-0002-4000-8000-000000000003",
+        "b1c2d3e4-0002-4000-8000-000000000004",
+        "b1c2d3e4-0002-4000-8000-000000000005",
+        "b1c2d3e4-0002-4000-8000-000000000006",
+        "b1c2d3e4-0002-4000-8000-000000000007"
+      ]
+    },
+    "b1c2d3e4-0003-4000-8000-000000000001": {
+      "collapsed": false,
+      "widgets": [
+        "b1c2d3e4-0003-4000-8000-000000000002",
+        "b1c2d3e4-0003-4000-8000-000000000003",
+        "b1c2d3e4-0003-4000-8000-000000000004",
+        "b1c2d3e4-0003-4000-8000-000000000005",
+        "b1c2d3e4-0003-4000-8000-000000000006",
+        "b1c2d3e4-0003-4000-8000-000000000007",
+        "b1c2d3e4-0003-4000-8000-000000000008",
+        "b1c2d3e4-0003-4000-8000-000000000009"
+      ]
+    },
+    "b1c2d3e4-0004-4000-8000-000000000001": {
+      "collapsed": false,
+      "widgets": [
+        "b1c2d3e4-0004-4000-8000-000000000002",
+        "b1c2d3e4-0004-4000-8000-000000000003",
+        "b1c2d3e4-0004-4000-8000-000000000004",
+        "b1c2d3e4-0004-4000-8000-000000000005"
+      ]
+    },
+    "b1c2d3e4-0005-4000-8000-000000000001": {
+      "collapsed": false,
+      "widgets": [
+        "b1c2d3e4-0005-4000-8000-000000000002",
+        "b1c2d3e4-0005-4000-8000-000000000003",
+        "b1c2d3e4-0005-4000-8000-000000000004",
+        "b1c2d3e4-0005-4000-8000-000000000005"
+      ]
+    },
+    "b1c2d3e4-0006-4000-8000-000000000001": {
+      "collapsed": false,
+      "widgets": [
+        "b1c2d3e4-0006-4000-8000-000000000002",
+        "b1c2d3e4-0006-4000-8000-000000000003",
+        "b1c2d3e4-0006-4000-8000-000000000004",
+        "b1c2d3e4-0006-4000-8000-000000000005",
+        "b1c2d3e4-0006-4000-8000-000000000006",
+        "b1c2d3e4-0006-4000-8000-000000000007"
+      ]
+    },
+    "b1c2d3e4-0007-4000-8000-000000000001": {
+      "collapsed": false,
+      "widgets": [
+        "b1c2d3e4-0007-4000-8000-000000000002",
+        "b1c2d3e4-0007-4000-8000-000000000003"
+      ]
+    },
+    "b1c2d3e4-0008-4000-8000-000000000001": {
+      "collapsed": false,
+      "widgets": [
+        "b1c2d3e4-0008-4000-8000-000000000002",
+        "b1c2d3e4-0008-4000-8000-000000000003"
+      ]
+    }
+  },
+  "tags": [
+    "gcp",
+    "vpc",
+    "networking"
+  ],
+  "title": "GCP VPC Metrics",
+  "uploadedGrafana": false,
+  "variables": {
+    "8b11b51d-fde6-4e81-b84b-1b91eca71dae": {
+      "customValue": "",
+      "description": "GCP Project ID",
+      "id": "8b11b51d-fde6-4e81-b84b-1b91eca71dae",
+      "modificationUUID": "0c04d1ce-7a96-4b3b-afc4-c7e260e2f4bf",
+      "multiSelect": false,
+      "name": "project_id",
+      "order": 0,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'project_id'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name LIKE '%networking%'",
+      "showALLOption": false,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "742f742a-f5df-4fa6-9d49-4f2e5ed8df9b": {
+      "customValue": "",
+      "description": "VPC Network Name",
+      "id": "742f742a-f5df-4fa6-9d49-4f2e5ed8df9b",
+      "modificationUUID": "d8214565-0b09-4d62-a1b8-6497a2e012ad",
+      "multiSelect": true,
+      "name": "network_name",
+      "order": 1,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'network_name'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name LIKE '%networking%'\nAND JSONExtractString(labels, 'project_id') = '{{.project_id}}'",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "version": "v4",
+  "widgets": [
+    {
+      "description": "",
+      "id": "b1c2d3e4-0001-4000-8000-000000000001",
+      "panelTypes": "row",
+      "title": "Overview"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total firewall-dropped packets by rule and direction",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0001-4000-8000-000000000002",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/firewall/dropped_packets_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/firewall/dropped_packets_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "e1dbb4fd",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "firewall_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "firewall_name",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "direction--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "direction",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{firewall_name}} / {{direction}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "620cd1d1-5e33-4269-bc4d-d5fd63b08856",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Firewall Dropped Packets",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total firewall-dropped bytes by rule and direction",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0001-4000-8000-000000000003",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/firewall/dropped_bytes_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/firewall/dropped_bytes_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "600519c5",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "firewall_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "firewall_name",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "direction--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "direction",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{firewall_name}} / {{direction}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "5a24549e-4c43-4ccc-93a7-52caa2bb1c67",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Firewall Dropped Bytes",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total firewall-allowed connections by rule",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0001-4000-8000-000000000004",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/firewall/allowed_connections--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/firewall/allowed_connections",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "85209dbb",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "firewall_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "firewall_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{firewall_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "82345465-5eee-4389-a2b4-03da8fbc2df8",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Firewall Allowed Packets",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of times each firewall rule was hit",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0001-4000-8000-000000000005",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/firewall/hit_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/firewall/hit_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "039abb5e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "firewall_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "firewall_name",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "direction--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "direction",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{firewall_name}} / {{direction}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "02b6fbeb-2383-440a-87a9-2c59fee0b1d6",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Firewall Hit Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "id": "b1c2d3e4-0002-4000-8000-000000000001",
+      "panelTypes": "row",
+      "title": "VPC Flow Logs & Traffic"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Bytes sent through VPC flow, grouped by subnet",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0002-4000-8000-000000000002",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/vpc_flow/sent_bytes_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/vpc_flow/sent_bytes_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "8f8ec2a0",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "subnetwork_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "subnetwork_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{subnetwork_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f0248168-6936-46dd-8190-bb0d566a8f24",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Sent Bytes by Subnet",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Bytes received through VPC flow, grouped by subnet",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0002-4000-8000-000000000003",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/vpc_flow/received_bytes_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/vpc_flow/received_bytes_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "6fe55558",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "subnetwork_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "subnetwork_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{subnetwork_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "7a6a729b-7aa3-4ee8-80c6-ebe2a41be063",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Received Bytes by Subnet",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Packets sent through VPC flow, grouped by subnet",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0002-4000-8000-000000000004",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/vpc_flow/sent_packets_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/vpc_flow/sent_packets_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "9f5fb947",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "subnetwork_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "subnetwork_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{subnetwork_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c64af10c-30c5-40f0-a647-c8de87e4cfd3",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Sent Packets by Subnet",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Packets received through VPC flow, grouped by subnet",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0002-4000-8000-000000000005",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/vpc_flow/received_packets_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/vpc_flow/received_packets_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b7436b45",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "subnetwork_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "subnetwork_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{subnetwork_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b101eeaf-3b25-49de-b9ed-29afcbb45b6e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Received Packets by Subnet",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Round-trip time latency for sent packets",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0002-4000-8000-000000000006",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/vpc_flow/rtt--float64--Summary--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/vpc_flow/rtt",
+                "type": "Summary"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "af7531ad",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "subnetwork_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "subnetwork_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{subnetwork_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0f9f1ac2-42a1-4d0a-b9b7-5fdf1202c4f3",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "RTT Latencies (Sent)",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of bytes sent through VPC",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0002-4000-8000-000000000007",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/vpc_flow/sent_bytes_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/vpc_flow/sent_bytes_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "c463d297",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "subnetwork_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "subnetwork_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{subnetwork_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "33ad6b63-b710-4d01-a55f-2ec9990d189a",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Inbound vs Outbound Traffic Rate",
+      "yAxisUnit": "binBps"
+    },
+    {
+      "description": "",
+      "id": "b1c2d3e4-0003-4000-8000-000000000001",
+      "panelTypes": "row",
+      "title": "Cloud NAT"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Bytes sent via Cloud NAT by gateway",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0003-4000-8000-000000000002",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/nat/sent_bytes_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/nat/sent_bytes_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "8ec61e74",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "gateway_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "gateway_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{gateway_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "2ec3cee2-8cfa-4028-ab54-5dc7aaf373f5",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "NAT Sent Bytes",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Bytes received via Cloud NAT by gateway",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0003-4000-8000-000000000003",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/nat/received_bytes_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/nat/received_bytes_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "7bcfb2ac",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "gateway_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "gateway_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{gateway_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9122294b-19bd-4ed7-ad25-3ab67cabc686",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "NAT Received Bytes",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Packets sent via Cloud NAT",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0003-4000-8000-000000000004",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/nat/sent_packets_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/nat/sent_packets_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "44090386",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "gateway_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "gateway_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{gateway_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "998e751e-da24-457c-9e71-46eba19343a3",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "NAT Sent Packets",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Packets received via Cloud NAT",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0003-4000-8000-000000000005",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/nat/received_packets_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/nat/received_packets_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "665182a9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "gateway_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "gateway_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{gateway_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9b69259e-db74-42a2-a8f8-8c2b2a33ce22",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "NAT Received Packets",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "NAT packets dropped (sent direction) \u2014 indicates exhaustion",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0003-4000-8000-000000000006",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/nat/dropped_sent_packets_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/nat/dropped_sent_packets_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "ea851fd9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "gateway_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "gateway_name",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "reason--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "reason",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{gateway_name}} / {{reason}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "121a3977-59e9-49dc-95da-d4dfdc7e2bfe",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "NAT Dropped Sent Packets",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "NAT packets dropped (received direction)",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0003-4000-8000-000000000007",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/nat/dropped_received_packets_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/nat/dropped_received_packets_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "47060811",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "gateway_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "gateway_name",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "reason--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "reason",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{gateway_name}} / {{reason}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "49e6201a-2d3a-4b47-9880-dbbca02792d2",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "NAT Dropped Received Packets",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of ports allocated to VM by NAT gateway",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0003-4000-8000-000000000008",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/nat/allocated_ports--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/nat/allocated_ports",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "cc49d696",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "gateway_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "gateway_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{gateway_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0cedf185-41df-4e93-8c58-c284dd05244c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "NAT Port Allocation",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Current open NAT connections by protocol",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0003-4000-8000-000000000009",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/nat/open_connections--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/nat/open_connections",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "04b49de7",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "gateway_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "gateway_name",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "ip_protocol--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "ip_protocol",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{gateway_name}} / {{ip_protocol}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8d7212ad-78a3-476a-b5b3-43a6dba50b3a",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "NAT Open Connections",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "id": "b1c2d3e4-0004-4000-8000-000000000001",
+      "panelTypes": "row",
+      "title": "VPC Peering"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Bytes sent over VPC peering connections",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0004-4000-8000-000000000002",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/vpc_peering/sent_bytes_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/vpc_peering/sent_bytes_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "2f42bddf",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "peering_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "peering_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{peering_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "86b730bc-ca03-4c25-affa-da37d8c1e295",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Peering Sent Bytes",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Bytes received over VPC peering connections",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0004-4000-8000-000000000003",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/vpc_peering/received_bytes_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/vpc_peering/received_bytes_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "cfc023ce",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "peering_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "peering_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{peering_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "db4d7ccd-92ed-40a0-beaa-bc0293e35415",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Peering Received Bytes",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Packets sent over VPC peering",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0004-4000-8000-000000000004",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/vpc_peering/sent_packets_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/vpc_peering/sent_packets_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "68163418",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "peering_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "peering_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{peering_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "90e0948f-21d6-4ed4-b0b4-ca9477226398",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Peering Sent Packets",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Packets received over VPC peering",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0004-4000-8000-000000000005",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/vpc_peering/received_packets_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/vpc_peering/received_packets_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "4da38f8d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "peering_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "peering_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{peering_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "bc3aac0d-d986-4b00-a00a-98fc2a4778bd",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Peering Received Packets",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "id": "b1c2d3e4-0005-4000-8000-000000000001",
+      "panelTypes": "row",
+      "title": "Cloud Interconnect"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Bytes sent through Cloud Interconnect attachments",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0005-4000-8000-000000000002",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/interconnect/sent_bytes_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/interconnect/sent_bytes_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "c8dd5500",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "interconnect_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "interconnect_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{interconnect_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c48c14e4-ac22-49cd-8286-deb5efd321e4",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Interconnect Sent Bytes",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Bytes received through Cloud Interconnect attachments",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0005-4000-8000-000000000003",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/interconnect/received_bytes_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/interconnect/received_bytes_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "0ee149ef",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "interconnect_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "interconnect_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{interconnect_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "3a8859d2-48ac-426c-857f-bc81eb141aa3",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Interconnect Received Bytes",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Capacity of each interconnect link",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0005-4000-8000-000000000004",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/interconnect/link/capacity--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/interconnect/link/capacity",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d766e635",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "interconnect_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "interconnect_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{interconnect_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "fbdab68d-14dc-4a63-b9e0-753792d836ff",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Interconnect Link Capacity",
+      "yAxisUnit": "binBps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Optical receive power level on interconnect links",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0005-4000-8000-000000000005",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/interconnect/link/receive_power--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/interconnect/link/receive_power",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "801176c5",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "interconnect_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "interconnect_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{interconnect_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ac5f99cc-f47a-4b71-ac46-b17975700ef4",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Interconnect Receive Power (dBm)",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "id": "b1c2d3e4-0006-4000-8000-000000000001",
+      "panelTypes": "row",
+      "title": "Load Balancer"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "HTTP(S) load balancer request count by backend",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0006-4000-8000-000000000002",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/https/request_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/https/request_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d0d6fa05",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "backend_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "backend_name",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "response_code--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "response_code",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{backend_name}} / {{response_code}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d0a4fe45-326a-49a8-8795-92edbed52977",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "LB Request Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "End-to-end latency of load-balanced requests",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0006-4000-8000-000000000003",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/https/total_latencies--float64--Summary--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/https/total_latencies",
+                "type": "Summary"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "3099519b",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "backend_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "backend_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{backend_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b35eb97c-9f00-4e07-932f-b1262b32f1f9",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "LB Total Latency",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Bytes sent to backends from load balancer",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0006-4000-8000-000000000004",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/https/backend_request_bytes_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/https/backend_request_bytes_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b24a8aad",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "backend_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "backend_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{backend_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "933fa844-a978-447a-874f-495b4794d2ca",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "LB Backend Request Bytes",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Bytes received from backends",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0006-4000-8000-000000000005",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/https/backend_response_bytes_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/https/backend_response_bytes_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "bf06dec7",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "backend_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "backend_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{backend_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "748fc3ef-7a8c-4168-8494-0ab75d213a2f",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "LB Backend Response Bytes",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Error requests (4xx/5xx) from load balancer",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0006-4000-8000-000000000006",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/https/request_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/https/request_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "7395949f",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "response_code_class--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "response_code_class",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{response_code_class}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "00d42408-7bcc-4cd4-8e6e-3684d05dcac0",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "LB 4xx/5xx Error Rate",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Latency from load balancer to backend",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0006-4000-8000-000000000007",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/https/backend_latencies--float64--Summary--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/https/backend_latencies",
+                "type": "Summary"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "5fff40c1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "backend_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "backend_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{backend_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8d30f21c-ce0b-4cf6-9af5-8108b4bc5da6",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "LB Backend Latency",
+      "yAxisUnit": "ms"
+    },
+    {
+      "description": "",
+      "id": "b1c2d3e4-0007-4000-8000-000000000001",
+      "panelTypes": "row",
+      "title": "DNS"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "DNS queries by zone and response code",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0007-4000-8000-000000000002",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/dns/query/count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/dns/query/count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "343536c1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "dns_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "dns_name",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "response_code--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "response_code",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{dns_name}} / {{response_code}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "157a3f63-8c63-4bc5-9814-c1173fdc638c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "DNS Query Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "DNS query latency distribution",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0007-4000-8000-000000000003",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/dns/query/latencies--float64--Summary--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/dns/query/latencies",
+                "type": "Summary"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "c691f851",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "dns_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "dns_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{dns_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "2395749d-7854-414d-bf83-4e8a6b325738",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "DNS Query Latency",
+      "yAxisUnit": "ms"
+    },
+    {
+      "description": "",
+      "id": "b1c2d3e4-0008-4000-8000-000000000001",
+      "panelTypes": "row",
+      "title": "Subnet Utilization"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Percentage of IP addresses used per subnet",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0008-4000-8000-000000000002",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/subnet/ip_utilization--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/subnet/ip_utilization",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "6bebfdb7",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "subnetwork_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "subnetwork_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{subnetwork_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "685d2e0e-2d83-4cb3-8065-d8ae5dc7daff",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Subnet IP Utilization",
+      "yAxisUnit": "percentunit"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of VM instances per subnet",
+      "fillSpans": false,
+      "id": "b1c2d3e4-0008-4000-8000-000000000003",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "networking.googleapis.com/subnet/instances--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "networking.googleapis.com/subnet/instances",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "9780cfe6",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "subnetwork_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "subnetwork_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{subnetwork_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6f317502-fff7-4737-b030-58e2d2348e8f",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Subnet Instances Count",
+      "yAxisUnit": "none"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Comprehensive GCP VPC networking monitoring dashboard with **36 panels** across **8 sections**, covering firewall rules, VPC flow logs, Cloud NAT, VPC peering, Cloud Interconnect, load balancer, DNS, and subnet utilization.

Closes SigNoz/signoz#6384

## Dashboard Sections

| Section | Panels | Key Metrics |
|---------|--------|-------------|
| Overview | 4 | Firewall dropped/allowed packets, hit counts |
| VPC Flow Logs & Traffic | 6 | Bytes/packets by subnet, RTT latency, traffic rate |
| Cloud NAT | 8 | NAT traffic, drops, port allocation, open connections |
| VPC Peering | 4 | Peering bytes/packets across connections |
| Cloud Interconnect | 4 | Traffic, link capacity, optical receive power |
| Load Balancer | 6 | Request count, latency, errors, backend metrics |
| DNS | 2 | Query count and latency |
| Subnet Utilization | 2 | IP utilization, instance counts |

## Variables
- `project_id` — GCP Project ID (query-based)
- `network_name` — VPC Network Name (multi-select, query-based)

## Data Source
Google Cloud Monitoring metrics via Prometheus exporter (`networking.googleapis.com/*`)

## Files
- `gcp/gcp-vpc-metrics-prometheus-v1.json` — Dashboard definition (5.9K lines)
- `gcp/README-vpc-metrics.md` — Documentation

Closes SigNoz/signoz#6384