### PR TITLE
feat: Add GCP Cloud Monitoring meta-monitoring dashboard (Prometheus v1)

### DIFF
--- a/gcp/README-cloud-monitoring.md
+++ b/gcp/README-cloud-monitoring.md
@@ -1,0 +1,58 @@
+# GCP Cloud Monitoring Dashboard
+
+Meta-monitoring dashboard for Google Cloud Monitoring — monitor the monitoring platform itself. Tracks uptime checks, alerting, metric ingestion, API usage, notifications, SLOs, and log-based metrics.
+
+## Sections & Panels (28 panels)
+
+### Uptime Checks (4 panels)
+- Uptime Check Passed
+- Uptime Check Latency
+- Content Mismatch Events
+- Time Until SSL Cert Expiry
+
+### Alerting Policies (5 panels)
+- Active Alerts per Policy
+- Alert Notification Rate
+- Incident Count
+- Condition Evaluation Duration
+- Notification Errors
+
+### Metric Ingestion (4 panels)
+- Metric Descriptor Count
+- Metric Bytes Ingested
+- Time Series Count (cost driver)
+- Ingested Samples Rate
+
+### Monitoring API Usage (3 panels)
+- API Request Count
+- API Request Latency
+- API Error Rate
+
+### Notification Channels (4 panels)
+- Delivery Success Rate
+- Delivery Latency
+- Channel Errors
+- Notifications per Channel
+
+### Service Level Objectives (4 panels)
+- SLO Compliance
+- Error Budget Remaining
+- Good Events Ratio
+- SLO Burn Rate
+
+### Logging Integration (2 panels)
+- Log-Based Metric Entries
+- Log Metric Extraction Errors
+
+### Custom & Agent Metrics (2 panels)
+- Custom Metric Descriptor Count
+- Agent Metric Bytes Ingested
+
+## Variables
+| Variable | Description |
+|----------|-------------|
+| `project_id` | GCP Project ID |
+| `service_name` | GCP Service Name (multi-select) |
+
+## Data Source
+Google Cloud Monitoring metrics via Prometheus exporter (`monitoring.googleapis.com/*`).

--- a/gcp/gcp-cloud-monitoring-prometheus-v1.json
+++ b/gcp/gcp-cloud-monitoring-prometheus-v1.json
@@ -1,0 +1,4695 @@
+{
+  "description": "Comprehensive meta-monitoring dashboard for GCP Cloud Monitoring. Tracks uptime checks, alerting policies, metric ingestion costs, API usage, notification channels, SLO compliance, log-based metrics, and custom/agent metric health via Google Cloud Monitoring exporter.",
+  "image": "",
+  "layout": [
+    {
+      "h": 1,
+      "i": "c2d3e4f5-0001-4000-8000-000000000001",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 6,
+      "i": "c2d3e4f5-0001-4000-8000-000000000002",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 1
+    },
+    {
+      "h": 6,
+      "i": "c2d3e4f5-0001-4000-8000-000000000003",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 1
+    },
+    {
+      "h": 6,
+      "i": "c2d3e4f5-0001-4000-8000-000000000004",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 7
+    },
+    {
+      "h": 6,
+      "i": "c2d3e4f5-0001-4000-8000-000000000005",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 7
+    },
+    {
+      "h": 1,
+      "i": "c2d3e4f5-0002-4000-8000-000000000001",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 13
+    },
+    {
+      "h": 6,
+      "i": "c2d3e4f5-0002-4000-8000-000000000002",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 14
+    },
+    {
+      "h": 6,
+      "i": "c2d3e4f5-0002-4000-8000-000000000003",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 14
+    },
+    {
+      "h": 6,
+      "i": "c2d3e4f5-0002-4000-8000-000000000004",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 14
+    },
+    {
+      "h": 6,
+      "i": "c2d3e4f5-0002-4000-8000-000000000005",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 20
+    },
+    {
+      "h": 6,
+      "i": "c2d3e4f5-0002-4000-8000-000000000006",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 20
+    },
+    {
+      "h": 1,
+      "i": "c2d3e4f5-0003-4000-8000-000000000001",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 26
+    },
+    {
+      "h": 6,
+      "i": "c2d3e4f5-0003-4000-8000-000000000002",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 27
+    },
+    {
+      "h": 6,
+      "i": "c2d3e4f5-0003-4000-8000-000000000003",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 27
+    },
+    {
+      "h": 6,
+      "i": "c2d3e4f5-0003-4000-8000-000000000004",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 33
+    },
+    {
+      "h": 6,
+      "i": "c2d3e4f5-0003-4000-8000-000000000005",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 33
+    },
+    {
+      "h": 1,
+      "i": "c2d3e4f5-0004-4000-8000-000000000001",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 39
+    },
+    {
+      "h": 6,
+      "i": "c2d3e4f5-0004-4000-8000-000000000002",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 40
+    },
+    {
+      "h": 6,
+      "i": "c2d3e4f5-0004-4000-8000-000000000003",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 40
+    },
+    {
+      "h": 6,
+      "i": "c2d3e4f5-0004-4000-8000-000000000004",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 40
+    },
+    {
+      "h": 1,
+      "i": "c2d3e4f5-0005-4000-8000-000000000001",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 46
+    },
+    {
+      "h": 6,
+      "i": "c2d3e4f5-0005-4000-8000-000000000002",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 47
+    },
+    {
+      "h": 6,
+      "i": "c2d3e4f5-0005-4000-8000-000000000003",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 47
+    },
+    {
+      "h": 6,
+      "i": "c2d3e4f5-0005-4000-8000-000000000004",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 53
+    },
+    {
+      "h": 6,
+      "i": "c2d3e4f5-0005-4000-8000-000000000005",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 53
+    },
+    {
+      "h": 1,
+      "i": "c2d3e4f5-0006-4000-8000-000000000001",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 59
+    },
+    {
+      "h": 6,
+      "i": "c2d3e4f5-0006-4000-8000-000000000002",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 60
+    },
+    {
+      "h": 6,
+      "i": "c2d3e4f5-0006-4000-8000-000000000003",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 60
+    },
+    {
+      "h": 6,
+      "i": "c2d3e4f5-0006-4000-8000-000000000004",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 66
+    },
+    {
+      "h": 6,
+      "i": "c2d3e4f5-0006-4000-8000-000000000005",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 66
+    },
+    {
+      "h": 1,
+      "i": "c2d3e4f5-0007-4000-8000-000000000001",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 72
+    },
+    {
+      "h": 6,
+      "i": "c2d3e4f5-0007-4000-8000-000000000002",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 73
+    },
+    {
+      "h": 6,
+      "i": "c2d3e4f5-0007-4000-8000-000000000003",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 73
+    },
+    {
+      "h": 1,
+      "i": "c2d3e4f5-0008-4000-8000-000000000001",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 79
+    },
+    {
+      "h": 6,
+      "i": "c2d3e4f5-0008-4000-8000-000000000002",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 80
+    },
+    {
+      "h": 6,
+      "i": "c2d3e4f5-0008-4000-8000-000000000003",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 80
+    }
+  ],
+  "panelMap": {
+    "c2d3e4f5-0001-4000-8000-000000000001": {
+      "collapsed": false,
+      "widgets": [
+        "c2d3e4f5-0001-4000-8000-000000000002",
+        "c2d3e4f5-0001-4000-8000-000000000003",
+        "c2d3e4f5-0001-4000-8000-000000000004",
+        "c2d3e4f5-0001-4000-8000-000000000005"
+      ]
+    },
+    "c2d3e4f5-0002-4000-8000-000000000001": {
+      "collapsed": false,
+      "widgets": [
+        "c2d3e4f5-0002-4000-8000-000000000002",
+        "c2d3e4f5-0002-4000-8000-000000000003",
+        "c2d3e4f5-0002-4000-8000-000000000004",
+        "c2d3e4f5-0002-4000-8000-000000000005",
+        "c2d3e4f5-0002-4000-8000-000000000006"
+      ]
+    },
+    "c2d3e4f5-0003-4000-8000-000000000001": {
+      "collapsed": false,
+      "widgets": [
+        "c2d3e4f5-0003-4000-8000-000000000002",
+        "c2d3e4f5-0003-4000-8000-000000000003",
+        "c2d3e4f5-0003-4000-8000-000000000004",
+        "c2d3e4f5-0003-4000-8000-000000000005"
+      ]
+    },
+    "c2d3e4f5-0004-4000-8000-000000000001": {
+      "collapsed": false,
+      "widgets": [
+        "c2d3e4f5-0004-4000-8000-000000000002",
+        "c2d3e4f5-0004-4000-8000-000000000003",
+        "c2d3e4f5-0004-4000-8000-000000000004"
+      ]
+    },
+    "c2d3e4f5-0005-4000-8000-000000000001": {
+      "collapsed": false,
+      "widgets": [
+        "c2d3e4f5-0005-4000-8000-000000000002",
+        "c2d3e4f5-0005-4000-8000-000000000003",
+        "c2d3e4f5-0005-4000-8000-000000000004",
+        "c2d3e4f5-0005-4000-8000-000000000005"
+      ]
+    },
+    "c2d3e4f5-0006-4000-8000-000000000001": {
+      "collapsed": false,
+      "widgets": [
+        "c2d3e4f5-0006-4000-8000-000000000002",
+        "c2d3e4f5-0006-4000-8000-000000000003",
+        "c2d3e4f5-0006-4000-8000-000000000004",
+        "c2d3e4f5-0006-4000-8000-000000000005"
+      ]
+    },
+    "c2d3e4f5-0007-4000-8000-000000000001": {
+      "collapsed": false,
+      "widgets": [
+        "c2d3e4f5-0007-4000-8000-000000000002",
+        "c2d3e4f5-0007-4000-8000-000000000003"
+      ]
+    },
+    "c2d3e4f5-0008-4000-8000-000000000001": {
+      "collapsed": false,
+      "widgets": [
+        "c2d3e4f5-0008-4000-8000-000000000002",
+        "c2d3e4f5-0008-4000-8000-000000000003"
+      ]
+    }
+  },
+  "tags": [
+    "gcp",
+    "monitoring",
+    "observability"
+  ],
+  "title": "GCP Cloud Monitoring",
+  "uploadedGrafana": false,
+  "variables": {
+    "a9d50f71-6ce3-42fd-aa53-5ea04ca77401": {
+      "customValue": "",
+      "description": "GCP Project ID",
+      "id": "a9d50f71-6ce3-42fd-aa53-5ea04ca77401",
+      "modificationUUID": "a3bbcacd-2a6d-43c7-9ac3-ec7abb7f3a54",
+      "multiSelect": false,
+      "name": "project_id",
+      "order": 0,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'project_id'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name LIKE '%monitoring%'",
+      "showALLOption": false,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "dc3e8a60-ec57-4da0-b84b-d00189f1291f": {
+      "customValue": "",
+      "description": "GCP Service Name",
+      "id": "dc3e8a60-ec57-4da0-b84b-d00189f1291f",
+      "modificationUUID": "95d4e6bb-2ee3-4565-86f9-f0a08aa14ed5",
+      "multiSelect": true,
+      "name": "service_name",
+      "order": 1,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'service_name'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name LIKE '%monitoring%'\nAND JSONExtractString(labels, 'project_id') = '{{.project_id}}'",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "version": "v4",
+  "widgets": [
+    {
+      "description": "",
+      "id": "c2d3e4f5-0001-4000-8000-000000000001",
+      "panelTypes": "row",
+      "title": "Uptime Checks"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Whether uptime checks passed (1=up, 0=down)",
+      "fillSpans": false,
+      "id": "c2d3e4f5-0001-4000-8000-000000000002",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "monitoring.googleapis.com/uptime_check/check_passed--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "monitoring.googleapis.com/uptime_check/check_passed",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d41b02b1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "check_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "check_id",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "checked_resource_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "checked_resource_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{check_id}} / {{checked_resource_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "95a815da-c4e5-4149-98ec-54ef728ab9af",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Uptime Check Passed",
+      "yAxisUnit": "percentunit"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Latency of uptime check requests",
+      "fillSpans": false,
+      "id": "c2d3e4f5-0001-4000-8000-000000000003",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "monitoring.googleapis.com/uptime_check/request_latency--float64--Summary--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "monitoring.googleapis.com/uptime_check/request_latency",
+                "type": "Summary"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d012926a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "check_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "check_id",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "checker_location--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "checker_location",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{check_id}} / {{checker_location}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "301d8a18-8a99-4e1c-b7cc-063f7caac39d",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Uptime Check Latency",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Content mismatch events from uptime checks",
+      "fillSpans": false,
+      "id": "c2d3e4f5-0001-4000-8000-000000000004",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "monitoring.googleapis.com/uptime_check/content_mismatch--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "monitoring.googleapis.com/uptime_check/content_mismatch",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "36629400",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "check_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "check_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{check_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "sum"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "175f0546-7ad1-47dd-849a-e75770b99971",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Uptime Check Content Mismatch",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Days until SSL certificate expiry for monitored endpoints",
+      "fillSpans": false,
+      "id": "c2d3e4f5-0001-4000-8000-000000000005",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "monitoring.googleapis.com/uptime_check/time_until_ssl_cert_expires--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "monitoring.googleapis.com/uptime_check/time_until_ssl_cert_expires",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "14516f8a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "check_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "check_id",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "checked_resource_id--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "checked_resource_id",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{check_id}} / {{checked_resource_id}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d92058af-088a-4c1b-ab6a-cf0f8fcf0dd2",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Uptime Check Time Until SSL Cert Expiry",
+      "yAxisUnit": "days"
+    },
+    {
+      "description": "",
+      "id": "c2d3e4f5-0002-4000-8000-000000000001",
+      "panelTypes": "row",
+      "title": "Alerting Policies"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of currently active (firing) alerts per policy",
+      "fillSpans": false,
+      "id": "c2d3e4f5-0002-4000-8000-000000000002",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "monitoring.googleapis.com/alert_policy/active_alerts--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "monitoring.googleapis.com/alert_policy/active_alerts",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "91e83a88",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "policy_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "policy_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{policy_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ba12b48a-0835-448d-ad9e-0e354893e322",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Alert Policy Active Alerts",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of notifications sent per alert policy",
+      "fillSpans": false,
+      "id": "c2d3e4f5-0002-4000-8000-000000000003",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "monitoring.googleapis.com/alert_policy/notification_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "monitoring.googleapis.com/alert_policy/notification_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "4cdec62b",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "policy_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "policy_name",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "notification_channel_type--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "notification_channel_type",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{policy_name}} / {{notification_channel_type}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "89f19265-2553-4240-81fc-10e3f3837b3c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Alert Notification Rate",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "New incidents opened per alert policy",
+      "fillSpans": false,
+      "id": "c2d3e4f5-0002-4000-8000-000000000004",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "monitoring.googleapis.com/alert_policy/incident_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "monitoring.googleapis.com/alert_policy/incident_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f5dd0c4f",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "policy_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "policy_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{policy_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f6122a0f-d233-4b3f-802e-3af43da8c0d4",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Alert Policy Incident Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Time to evaluate alert conditions",
+      "fillSpans": false,
+      "id": "c2d3e4f5-0002-4000-8000-000000000005",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "monitoring.googleapis.com/alert_policy/condition_evaluation_duration--float64--Summary--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "monitoring.googleapis.com/alert_policy/condition_evaluation_duration",
+                "type": "Summary"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "0e426982",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "policy_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "policy_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{policy_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "fd648b89-cdaf-41b6-9676-94efafef45e1",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Alert Condition Evaluation Duration",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Failed alert notifications by channel type and error",
+      "fillSpans": false,
+      "id": "c2d3e4f5-0002-4000-8000-000000000006",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "monitoring.googleapis.com/alert_policy/notification_error_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "monitoring.googleapis.com/alert_policy/notification_error_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "0b53b4ed",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "notification_channel_type--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "notification_channel_type",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "error_type--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "error_type",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{notification_channel_type}} / {{error_type}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "9a3271af-c401-4ed4-b7bb-ef774dafef1c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Alert Notification Errors",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "id": "c2d3e4f5-0003-4000-8000-000000000001",
+      "panelTypes": "row",
+      "title": "Metric Ingestion"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total number of active metric descriptors",
+      "fillSpans": false,
+      "id": "c2d3e4f5-0003-4000-8000-000000000002",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "monitoring.googleapis.com/billing/metric_descriptor_count--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "monitoring.googleapis.com/billing/metric_descriptor_count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "659da9b2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "metric_type--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "metric_type",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{metric_type}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d4bc986e-0baf-4240-b017-336c2f21aa56",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Metric Descriptor Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Bytes of metric data ingested",
+      "fillSpans": false,
+      "id": "c2d3e4f5-0003-4000-8000-000000000003",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "monitoring.googleapis.com/billing/bytes_ingested--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "monitoring.googleapis.com/billing/bytes_ingested",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "908cde10",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "metric_type--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "metric_type",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{metric_type}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f0be854a-89b8-4feb-90f5-0aef64f196c3",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Metric Bytes Ingested",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Active time series count (cost driver)",
+      "fillSpans": false,
+      "id": "c2d3e4f5-0003-4000-8000-000000000004",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "monitoring.googleapis.com/billing/time_series_count--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "monitoring.googleapis.com/billing/time_series_count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "7b6a741f",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "metric_domain--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "metric_domain",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{metric_domain}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b6fa03e1-4150-4113-8ff9-abe0b5c0868f",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Time Series Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of metric samples ingested",
+      "fillSpans": false,
+      "id": "c2d3e4f5-0003-4000-8000-000000000005",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "monitoring.googleapis.com/billing/ingested_samples_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "monitoring.googleapis.com/billing/ingested_samples_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "5cfe1e5c",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "metric_domain--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "metric_domain",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{metric_domain}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "1d040c37-9c20-4178-be07-3d77d83e159b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Ingested Samples Rate",
+      "yAxisUnit": "ops"
+    },
+    {
+      "description": "",
+      "id": "c2d3e4f5-0004-4000-8000-000000000001",
+      "panelTypes": "row",
+      "title": "Monitoring API Usage"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Cloud Monitoring API requests by method and status",
+      "fillSpans": false,
+      "id": "c2d3e4f5-0004-4000-8000-000000000002",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "monitoring.googleapis.com/api/request_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "monitoring.googleapis.com/api/request_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "9a2fcfa6",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "method--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "method",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "response_code--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "response_code",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{method}} / {{response_code}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "88262c56-4ab7-4648-a50e-a9a97e8f029c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "API Request Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Latency of Monitoring API calls",
+      "fillSpans": false,
+      "id": "c2d3e4f5-0004-4000-8000-000000000003",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "monitoring.googleapis.com/api/request_latencies--float64--Summary--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "monitoring.googleapis.com/api/request_latencies",
+                "type": "Summary"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b7ceeb7e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "method--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "method",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{method}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "41cd297d-d724-4a29-b412-4877f5e82b28",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "API Request Latency",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "API requests resulting in errors (4xx/5xx)",
+      "fillSpans": false,
+      "id": "c2d3e4f5-0004-4000-8000-000000000004",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "monitoring.googleapis.com/api/request_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "monitoring.googleapis.com/api/request_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "8f3c0376",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "response_code_class--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "response_code_class",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{response_code_class}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "130cdda9-dcba-48a9-927c-13235177a6d4",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "API Error Rate",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "id": "c2d3e4f5-0005-4000-8000-000000000001",
+      "panelTypes": "row",
+      "title": "Notification Channels"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Successful notification deliveries by channel",
+      "fillSpans": false,
+      "id": "c2d3e4f5-0005-4000-8000-000000000002",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "monitoring.googleapis.com/notification/delivery_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "monitoring.googleapis.com/notification/delivery_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "fcae3cd9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "channel_type--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "channel_type",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "status--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "status",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{channel_type}} / {{status}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b97b3d11-a5c7-4e70-b142-8f42251d7f9a",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Notification Delivery Success Rate",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Time to deliver notifications by channel type",
+      "fillSpans": false,
+      "id": "c2d3e4f5-0005-4000-8000-000000000003",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "monitoring.googleapis.com/notification/delivery_latency--float64--Summary--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "monitoring.googleapis.com/notification/delivery_latency",
+                "type": "Summary"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "7210b2c4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "channel_type--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "channel_type",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{channel_type}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "fd301559-5da2-4e5b-9506-ad4dbaabf3d4",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Notification Delivery Latency",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Failed notification delivery attempts",
+      "fillSpans": false,
+      "id": "c2d3e4f5-0005-4000-8000-000000000004",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "monitoring.googleapis.com/notification/error_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "monitoring.googleapis.com/notification/error_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "29b1d385",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "channel_type--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "channel_type",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "error_type--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "error_type",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{channel_type}} / {{error_type}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "5fdc6be5-c71f-4484-a10e-4c8f060033b7",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Notification Channel Errors",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total notifications sent per channel",
+      "fillSpans": false,
+      "id": "c2d3e4f5-0005-4000-8000-000000000005",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "monitoring.googleapis.com/notification/sent_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "monitoring.googleapis.com/notification/sent_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "1aaceeee",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "channel_type--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "channel_type",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{channel_type}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "6f12230e-4034-433e-8545-b102c958a5b9",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Notifications per Channel",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "id": "c2d3e4f5-0006-4000-8000-000000000001",
+      "panelTypes": "row",
+      "title": "Service Level Objectives (SLO)"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Current SLO compliance percentage",
+      "fillSpans": false,
+      "id": "c2d3e4f5-0006-4000-8000-000000000002",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "monitoring.googleapis.com/slo/compliance--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "monitoring.googleapis.com/slo/compliance",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "9685e14d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "service_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "service_name",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "slo_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "slo_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{service_name}} / {{slo_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f95a2db8-5b5b-4156-88c1-c28693804e86",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "SLO Compliance",
+      "yAxisUnit": "percentunit"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Remaining error budget for each SLO",
+      "fillSpans": false,
+      "id": "c2d3e4f5-0006-4000-8000-000000000003",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "monitoring.googleapis.com/slo/error_budget_remaining--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "monitoring.googleapis.com/slo/error_budget_remaining",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "ce20aebd",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "service_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "service_name",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "slo_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "slo_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{service_name}} / {{slo_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "49c36be1-d39d-4888-95f7-ac1e5bdc419c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "SLO Error Budget Remaining",
+      "yAxisUnit": "percentunit"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Ratio of good to total events for SLO",
+      "fillSpans": false,
+      "id": "c2d3e4f5-0006-4000-8000-000000000004",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "monitoring.googleapis.com/slo/good_total_ratio--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "monitoring.googleapis.com/slo/good_total_ratio",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "9f46ac29",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "service_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "service_name",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "slo_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "slo_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{service_name}} / {{slo_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "de5178f1-d8f7-488d-936e-824b733477fd",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "SLO Good Events Rate",
+      "yAxisUnit": "percentunit"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of error budget consumption (>1 = burning faster than budget allows)",
+      "fillSpans": false,
+      "id": "c2d3e4f5-0006-4000-8000-000000000005",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "monitoring.googleapis.com/slo/burn_rate--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "monitoring.googleapis.com/slo/burn_rate",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "27470c40",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "service_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "service_name",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "slo_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "slo_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{service_name}} / {{slo_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8c60cf65-ac4a-4926-8104-bcf6c2696ac0",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "SLO Burn Rate",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "id": "c2d3e4f5-0007-4000-8000-000000000001",
+      "panelTypes": "row",
+      "title": "Logging Integration"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Log entries matching log-based metrics",
+      "fillSpans": false,
+      "id": "c2d3e4f5-0007-4000-8000-000000000002",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "monitoring.googleapis.com/log_based_metric/entry_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "monitoring.googleapis.com/log_based_metric/entry_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "e990f098",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "metric_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "metric_name",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{metric_name}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "79cbead7-88bb-4c62-9455-7215e8f7b53f",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Log-Based Metric Entries",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Errors during log-based metric extraction",
+      "fillSpans": false,
+      "id": "c2d3e4f5-0007-4000-8000-000000000003",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "monitoring.googleapis.com/log_based_metric/error_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "monitoring.googleapis.com/log_based_metric/error_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "df0cf812",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "metric_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "metric_name",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "id": "error_type--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "error_type",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{metric_name}} / {{error_type}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "52e5db4d-6847-4c34-9ed8-e35ba5e76f4a",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Log Metric Extraction Errors",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "id": "c2d3e4f5-0008-4000-8000-000000000001",
+      "panelTypes": "row",
+      "title": "Custom & Agent Metrics"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of custom metric descriptors in use",
+      "fillSpans": false,
+      "id": "c2d3e4f5-0008-4000-8000-000000000002",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "monitoring.googleapis.com/billing/custom_metric_descriptor_count--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "monitoring.googleapis.com/billing/custom_metric_descriptor_count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "0ae3327e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "total",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "26ba7411-7249-4501-96c4-2704cdfc20a8",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Custom Metric Descriptor Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Metric bytes ingested from Ops Agent / legacy agents",
+      "fillSpans": false,
+      "id": "c2d3e4f5-0008-4000-8000-000000000003",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "monitoring.googleapis.com/billing/agent_bytes_ingested--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "monitoring.googleapis.com/billing/agent_bytes_ingested",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "6207f15d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "agent_type--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "agent_type",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{agent_type}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "eef47d36-1446-4449-849e-600d36b63089",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Agent Metric Bytes Ingested",
+      "yAxisUnit": "bytes"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Meta-monitoring dashboard for GCP Cloud Monitoring — **monitor the monitoring platform itself**. Tracks uptime checks, alerting policies, metric ingestion costs, API usage, notification channels, SLO compliance, and log-based metrics. **28 panels** across **8 sections**.

Closes SigNoz/signoz#6389

## Dashboard Sections

| Section | Panels | Key Metrics |
|---------|--------|-------------|
| Uptime Checks | 4 | Pass rate, latency, content mismatch, SSL cert expiry |
| Alerting Policies | 5 | Active alerts, notifications, incidents, eval duration, errors |
| Metric Ingestion | 4 | Descriptor count, bytes ingested, time series count, sample rate |
| Monitoring API Usage | 3 | Request count, latency, error rate |
| Notification Channels | 4 | Delivery rate, latency, channel errors |
| Service Level Objectives | 4 | SLO compliance, error budget, good events ratio, burn rate |
| Logging Integration | 2 | Log-based metric entries, extraction errors |
| Custom & Agent Metrics | 2 | Custom descriptor count, agent bytes ingested |

## Variables
- `project_id` — GCP Project ID (query-based)
- `service_name` — GCP Service Name (multi-select, query-based)

## Data Source
Google Cloud Monitoring metrics via Prometheus exporter (`monitoring.googleapis.com/*`)

## Files
- `gcp/gcp-cloud-monitoring-prometheus-v1.json` — Dashboard definition (4.7K lines)
- `gcp/README-cloud-monitoring.md` — Documentation

Closes SigNoz/signoz#6389