### PR TITLE
feat: add NeonDB monitoring dashboard

### DIFF
--- a/neon/neon.json
+++ b/neon/neon.json
@@ -1,0 +1,1400 @@
+{
+  "id": "neon-overview",
+  "description": "Monitor your Neon Postgres database — connections, storage, Local File Cache, replication lag, and compute metrics. Compatible with Neon's OpenTelemetry integration.",
+  "layout": [
+    {"h": 3, "i": "a1111111-1111-1111-1111-111111111111", "w": 3, "x": 0, "y": 0},
+    {"h": 3, "i": "a2222222-2222-2222-2222-222222222222", "w": 3, "x": 3, "y": 0},
+    {"h": 3, "i": "a3333333-3333-3333-3333-333333333333", "w": 3, "x": 6, "y": 0},
+    {"h": 3, "i": "a4444444-4444-4444-4444-444444444444", "w": 3, "x": 9, "y": 0},
+    {"h": 3, "i": "a5555555-5555-5555-5555-555555555555", "w": 6, "x": 0, "y": 3},
+    {"h": 3, "i": "a6666666-6666-6666-6666-666666666666", "w": 6, "x": 6, "y": 3},
+    {"h": 3, "i": "a7777777-7777-7777-7777-777777777777", "w": 6, "x": 0, "y": 6},
+    {"h": 3, "i": "a8888888-8888-8888-8888-888888888888", "w": 6, "x": 6, "y": 6},
+    {"h": 3, "i": "a9999999-9999-9999-9999-999999999999", "w": 6, "x": 0, "y": 9},
+    {"h": 3, "i": "b0000000-0000-0000-0000-000000000000", "w": 6, "x": 6, "y": 9},
+    {"h": 3, "i": "b1111111-1111-1111-1111-111111111111", "w": 6, "x": 0, "y": 12},
+    {"h": 3, "i": "b2222222-2222-2222-2222-222222222222", "w": 6, "x": 6, "y": 12},
+    {"h": 3, "i": "b3333333-3333-3333-3333-333333333333", "w": 12, "x": 0, "y": 15},
+    {"h": 3, "i": "b4444444-4444-4444-4444-444444444444", "w": 6, "x": 0, "y": 18},
+    {"h": 3, "i": "b5555555-5555-5555-5555-555555555555", "w": 6, "x": 6, "y": 18}
+  ],
+  "name": "",
+  "tags": ["neon", "postgres", "database"],
+  "title": "NeonDB Overview",
+  "variables": {
+    "endpoint_id": {
+      "allSelected": false,
+      "customValue": "",
+      "description": "Neon endpoint ID",
+      "id": "v1111111-1111-1111-1111-111111111111",
+      "modificationUUID": "v1111111-1111-1111-1111-111111111111",
+      "multiSelect": true,
+      "name": "endpoint_id",
+      "order": 0,
+      "queryValue": "SELECT JSONExtractString(labels, 'endpoint_id') AS `endpoint_id` FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'neon_connection_counts' GROUP BY `endpoint_id`",
+      "selectedValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "widgets": [
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {"linksData": []},
+      "customLegendColors": {},
+      "decimalPrecision": 0,
+      "description": "Total number of active database connections",
+      "fillSpans": false,
+      "id": "a1111111-1111-1111-1111-111111111111",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "neon_connection_counts",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {"expression": "endpoint_id = $endpoint_id AND state = 'active'"},
+              "functions": [],
+              "groupBy": [],
+              "having": {"expression": ""},
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q1111111-1111-1111-1111-111111111111",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "timestamp", "signal": "logs", "type": "log"},
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "body", "signal": "logs", "type": "log"}
+      ],
+      "selectedTracesFields": [
+        {"fieldContext": "resource", "fieldDataType": "string", "name": "service.name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "string", "name": "name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "duration_nano", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "http_method", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "response_status_code", "signal": "traces"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Connections",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {"linksData": []},
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Total size of the database in bytes",
+      "fillSpans": false,
+      "id": "a2222222-2222-2222-2222-222222222222",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "neon_db_total_size",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {"expression": "endpoint_id = $endpoint_id"},
+              "functions": [],
+              "groupBy": [],
+              "having": {"expression": ""},
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q2222222-2222-2222-2222-222222222222",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "timestamp", "signal": "logs", "type": "log"},
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "body", "signal": "logs", "type": "log"}
+      ],
+      "selectedTracesFields": [
+        {"fieldContext": "resource", "fieldDataType": "string", "name": "service.name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "string", "name": "name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "duration_nano", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "http_method", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "response_status_code", "signal": "traces"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "DB Total Size",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {"linksData": []},
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Current replication delay in seconds",
+      "fillSpans": false,
+      "id": "a3333333-3333-3333-3333-333333333333",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "neon_replication_delay_seconds",
+                  "reduceTo": "last",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {"expression": "endpoint_id = $endpoint_id"},
+              "functions": [],
+              "groupBy": [],
+              "having": {"expression": ""},
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q3333333-3333-3333-3333-333333333333",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "timestamp", "signal": "logs", "type": "log"},
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "body", "signal": "logs", "type": "log"}
+      ],
+      "selectedTracesFields": [
+        {"fieldContext": "resource", "fieldDataType": "string", "name": "service.name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "string", "name": "name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "duration_nano", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "http_method", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "response_status_code", "signal": "traces"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Replication Delay",
+      "yAxisUnit": "s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {"linksData": []},
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Local File Cache hit rate percentage (hits / (hits + misses) * 100)",
+      "fillSpans": false,
+      "id": "a4444444-4444-4444-4444-444444444444",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "neon_lfc_hits",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "A",
+              "filter": {"expression": "endpoint_id = $endpoint_id"},
+              "functions": [],
+              "groupBy": [],
+              "having": {"expression": ""},
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "neon_lfc_misses",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "B",
+              "filter": {"expression": "endpoint_id = $endpoint_id"},
+              "functions": [],
+              "groupBy": [],
+              "having": {"expression": ""},
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "A / (A + B) * 100",
+              "legend": "LFC Hit Rate",
+              "queryName": "F1"
+            }
+          ],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q4444444-4444-4444-4444-444444444444",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "timestamp", "signal": "logs", "type": "log"},
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "body", "signal": "logs", "type": "log"}
+      ],
+      "selectedTracesFields": [
+        {"fieldContext": "resource", "fieldDataType": "string", "name": "service.name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "string", "name": "name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "duration_nano", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "http_method", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "response_status_code", "signal": "traces"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "LFC Hit Rate",
+      "yAxisUnit": "%"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {"linksData": []},
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Number of connections grouped by state (active, idle, other)",
+      "fillSpans": true,
+      "id": "a5555555-5555-5555-5555-555555555555",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "neon_connection_counts",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {"expression": "endpoint_id = $endpoint_id"},
+              "functions": [],
+              "groupBy": [
+                {"fieldContext": "tag", "name": "state", "tagType": "tag", "type": "tag"}
+              ],
+              "having": {"expression": ""},
+              "legend": "{{state}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q5555555-5555-5555-5555-555555555555",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "timestamp", "signal": "logs", "type": "log"},
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "body", "signal": "logs", "type": "log"}
+      ],
+      "selectedTracesFields": [
+        {"fieldContext": "resource", "fieldDataType": "string", "name": "service.name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "string", "name": "name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "duration_nano", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "http_method", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "response_status_code", "signal": "traces"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Connections by State",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {"linksData": []},
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "PgBouncer client and server connection counts",
+      "fillSpans": false,
+      "id": "a6666666-6666-6666-6666-666666666666",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "neon_pgbouncer_pools_client_active_connections",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {"expression": "endpoint_id = $endpoint_id"},
+              "functions": [],
+              "groupBy": [],
+              "having": {"expression": ""},
+              "legend": "Active Clients",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "neon_pgbouncer_pools_client_waiting_connections",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filter": {"expression": "endpoint_id = $endpoint_id"},
+              "functions": [],
+              "groupBy": [],
+              "having": {"expression": ""},
+              "legend": "Waiting Clients",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "source": "",
+              "stepInterval": null
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "neon_pgbouncer_pools_server_active_connections",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "C",
+              "filter": {"expression": "endpoint_id = $endpoint_id"},
+              "functions": [],
+              "groupBy": [],
+              "having": {"expression": ""},
+              "legend": "Active Servers",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "C",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q6666666-6666-6666-6666-666666666666",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "timestamp", "signal": "logs", "type": "log"},
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "body", "signal": "logs", "type": "log"}
+      ],
+      "selectedTracesFields": [
+        {"fieldContext": "resource", "fieldDataType": "string", "name": "service.name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "string", "name": "name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "duration_nano", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "http_method", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "response_status_code", "signal": "traces"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "PgBouncer Connections",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {"linksData": []},
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Local File Cache hits vs misses over time",
+      "fillSpans": true,
+      "id": "a7777777-7777-7777-7777-777777777777",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "neon_lfc_hits",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {"expression": "endpoint_id = $endpoint_id"},
+              "functions": [],
+              "groupBy": [],
+              "having": {"expression": ""},
+              "legend": "Cache Hits",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "neon_lfc_misses",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filter": {"expression": "endpoint_id = $endpoint_id"},
+              "functions": [],
+              "groupBy": [],
+              "having": {"expression": ""},
+              "legend": "Cache Misses",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q7777777-7777-7777-7777-777777777777",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "timestamp", "signal": "logs", "type": "log"},
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "body", "signal": "logs", "type": "log"}
+      ],
+      "selectedTracesFields": [
+        {"fieldContext": "resource", "fieldDataType": "string", "name": "service.name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "string", "name": "name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "duration_nano", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "http_method", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "response_status_code", "signal": "traces"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "LFC Hits vs Misses",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {"linksData": []},
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Local File Cache used bytes vs cache size limit",
+      "fillSpans": false,
+      "id": "a8888888-8888-8888-8888-888888888888",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "neon_lfc_used",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "A",
+              "filter": {"expression": "endpoint_id = $endpoint_id"},
+              "functions": [],
+              "groupBy": [],
+              "having": {"expression": ""},
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "neon_lfc_cache_size_limit",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "B",
+              "filter": {"expression": "endpoint_id = $endpoint_id"},
+              "functions": [],
+              "groupBy": [],
+              "having": {"expression": ""},
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "A * 1048576",
+              "legend": "Used",
+              "queryName": "F1"
+            },
+            {
+              "disabled": false,
+              "expression": "B",
+              "legend": "Limit",
+              "queryName": "F2"
+            }
+          ],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q8888888-8888-8888-8888-888888888888",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "timestamp", "signal": "logs", "type": "log"},
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "body", "signal": "logs", "type": "log"}
+      ],
+      "selectedTracesFields": [
+        {"fieldContext": "resource", "fieldDataType": "string", "name": "service.name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "string", "name": "name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "duration_nano", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "http_method", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "response_status_code", "signal": "traces"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "LFC Usage",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {"linksData": []},
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Replication delay in seconds over time",
+      "fillSpans": false,
+      "id": "a9999999-9999-9999-9999-999999999999",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "neon_replication_delay_seconds",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {"expression": "endpoint_id = $endpoint_id"},
+              "functions": [],
+              "groupBy": [],
+              "having": {"expression": ""},
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "q9999999-9999-9999-9999-999999999999",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "timestamp", "signal": "logs", "type": "log"},
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "body", "signal": "logs", "type": "log"}
+      ],
+      "selectedTracesFields": [
+        {"fieldContext": "resource", "fieldDataType": "string", "name": "service.name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "string", "name": "name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "duration_nano", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "http_method", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "response_status_code", "signal": "traces"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Replication Delay (seconds)",
+      "yAxisUnit": "s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {"linksData": []},
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Replication delay in bytes over time",
+      "fillSpans": false,
+      "id": "b0000000-0000-0000-0000-000000000000",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "neon_replication_delay_bytes",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {"expression": "endpoint_id = $endpoint_id"},
+              "functions": [],
+              "groupBy": [],
+              "having": {"expression": ""},
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "r0000000-0000-0000-0000-000000000000",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "timestamp", "signal": "logs", "type": "log"},
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "body", "signal": "logs", "type": "log"}
+      ],
+      "selectedTracesFields": [
+        {"fieldContext": "resource", "fieldDataType": "string", "name": "service.name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "string", "name": "name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "duration_nano", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "http_method", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "response_status_code", "signal": "traces"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Replication Delay (bytes)",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {"linksData": []},
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "CPU usage percentage (excluding idle time)",
+      "fillSpans": false,
+      "id": "b1111111-1111-1111-1111-111111111111",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "host_cpu_seconds_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "A",
+              "filter": {"expression": "mode != 'idle'"},
+              "functions": [],
+              "groupBy": [],
+              "having": {"expression": ""},
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "A * 100",
+              "legend": "CPU Usage",
+              "queryName": "F1"
+            }
+          ],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "s1111111-1111-1111-1111-111111111111",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "timestamp", "signal": "logs", "type": "log"},
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "body", "signal": "logs", "type": "log"}
+      ],
+      "selectedTracesFields": [
+        {"fieldContext": "resource", "fieldDataType": "string", "name": "service.name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "string", "name": "name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "duration_nano", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "http_method", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "response_status_code", "signal": "traces"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "CPU Usage",
+      "yAxisUnit": "%"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {"linksData": []},
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Memory usage percentage (used / total * 100)",
+      "fillSpans": false,
+      "id": "b2222222-2222-2222-2222-222222222222",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "host_memory_available_bytes",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "A",
+              "filter": {"expression": ""},
+              "functions": [],
+              "groupBy": [],
+              "having": {"expression": ""},
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "host_memory_total_bytes",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "B",
+              "filter": {"expression": ""},
+              "functions": [],
+              "groupBy": [],
+              "having": {"expression": ""},
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "(1 - A / B) * 100",
+              "legend": "Memory Usage %",
+              "queryName": "F1"
+            }
+          ],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "s2222222-2222-2222-2222-222222222222",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "timestamp", "signal": "logs", "type": "log"},
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "body", "signal": "logs", "type": "log"}
+      ],
+      "selectedTracesFields": [
+        {"fieldContext": "resource", "fieldDataType": "string", "name": "service.name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "string", "name": "name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "duration_nano", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "http_method", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "response_status_code", "signal": "traces"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Memory Usage",
+      "yAxisUnit": "%"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {"linksData": []},
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "System load averages over 1, 5, and 15 minute windows",
+      "fillSpans": false,
+      "id": "b3333333-3333-3333-3333-333333333333",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "host_load1",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {"expression": ""},
+              "functions": [],
+              "groupBy": [],
+              "having": {"expression": ""},
+              "legend": "1m",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "host_load5",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filter": {"expression": ""},
+              "functions": [],
+              "groupBy": [],
+              "having": {"expression": ""},
+              "legend": "5m",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "source": "",
+              "stepInterval": null
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "host_load15",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "avg",
+                  "temporality": "",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "C",
+              "filter": {"expression": ""},
+              "functions": [],
+              "groupBy": [],
+              "having": {"expression": ""},
+              "legend": "15m",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "C",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "s3333333-3333-3333-3333-333333333333",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "timestamp", "signal": "logs", "type": "log"},
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "body", "signal": "logs", "type": "log"}
+      ],
+      "selectedTracesFields": [
+        {"fieldContext": "resource", "fieldDataType": "string", "name": "service.name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "string", "name": "name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "duration_nano", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "http_method", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "response_status_code", "signal": "traces"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Load Average",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {"linksData": []},
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Database row insert, update, and delete operations per second",
+      "fillSpans": true,
+      "id": "b4444444-4444-4444-4444-444444444444",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "neon_pg_stats_userdb",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {"expression": "endpoint_id = $endpoint_id AND kind = 'inserted'"},
+              "functions": [],
+              "groupBy": [],
+              "having": {"expression": ""},
+              "legend": "Inserts",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "neon_pg_stats_userdb",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filter": {"expression": "endpoint_id = $endpoint_id AND kind = 'updated'"},
+              "functions": [],
+              "groupBy": [],
+              "having": {"expression": ""},
+              "legend": "Updates",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "source": "",
+              "stepInterval": null
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "neon_pg_stats_userdb",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "C",
+              "filter": {"expression": "endpoint_id = $endpoint_id AND kind = 'deleted'"},
+              "functions": [],
+              "groupBy": [],
+              "having": {"expression": ""},
+              "legend": "Deletes",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "C",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "s4444444-4444-4444-4444-444444444444",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "timestamp", "signal": "logs", "type": "log"},
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "body", "signal": "logs", "type": "log"}
+      ],
+      "selectedTracesFields": [
+        {"fieldContext": "resource", "fieldDataType": "string", "name": "service.name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "string", "name": "name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "duration_nano", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "http_method", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "response_status_code", "signal": "traces"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "DB Operations",
+      "yAxisUnit": ""
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "contextLinks": {"linksData": []},
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Number of deadlocks detected in the database",
+      "fillSpans": false,
+      "id": "b5555555-5555-5555-5555-555555555555",
+      "isLogScale": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "neon_pg_stats_userdb",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "",
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filter": {"expression": "endpoint_id = $endpoint_id AND kind = 'deadlocks'"},
+              "functions": [],
+              "groupBy": [],
+              "having": {"expression": ""},
+              "legend": "Deadlocks",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "source": "",
+              "stepInterval": null
+            }
+          ],
+          "queryFormulas": [],
+          "queryTraceOperator": []
+        },
+        "clickhouse_sql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "id": "s5555555-5555-5555-5555-555555555555",
+        "promql": [{"disabled": false, "legend": "", "name": "A", "query": ""}],
+        "queryType": "builder",
+        "unit": ""
+      },
+      "selectedLogFields": [
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "timestamp", "signal": "logs", "type": "log"},
+        {"dataType": "", "fieldContext": "log", "fieldDataType": "", "isIndexed": false, "name": "body", "signal": "logs", "type": "log"}
+      ],
+      "selectedTracesFields": [
+        {"fieldContext": "resource", "fieldDataType": "string", "name": "service.name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "string", "name": "name", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "duration_nano", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "http_method", "signal": "traces"},
+        {"fieldContext": "span", "fieldDataType": "", "name": "response_status_code", "signal": "traces"}
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Deadlocks",
+      "yAxisUnit": ""
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a pre-built SigNoz dashboard for monitoring [Neon](https://neon.com) Postgres databases via Neon's [OpenTelemetry integration](https://neon.com/docs/guides/opentelemetry).

## Panels

| Section | Panels |
|---|---|
| Overview | Active Connections, DB Total Size, Replication Delay, LFC Hit Rate |
| Connections | Connections by State, PgBouncer Client/Server Connections |
| Local File Cache | LFC Hits vs Misses, LFC Usage vs Limit |
| Replication | Replication Delay (seconds), Replication Delay (bytes) |
| Compute | CPU Usage, Memory Usage, Load Average |
| DB Activity | DB Operations (inserts/updates/deletes), Deadlocks |

## Setup

Enable Neon's OpenTelemetry integration and point it to your SigNoz Cloud ingestion endpoint:

```yaml
endpoint: https://ingest.<REGION>.signoz.cloud:443
headers:
  signoz-ingestion-key: <SIGNOZ_INGESTION_KEY>
```

Full setup guide: https://neon.com/docs/guides/opentelemetry

## References

- [Neon Metrics Reference](https://neon.com/docs/reference/metrics-logs)
- [Neon OpenTelemetry Guide](https://neon.com/docs/guides/opentelemetry)