### PR TITLE
feat(dashboard): Add GCP Cloud Storage monitoring dashboard (Prometheus v1)

### DIFF
--- a/gcp/cloud-storage/README-cloud-storage.md
+++ b/gcp/cloud-storage/README-cloud-storage.md
@@ -1,0 +1,78 @@
+# GCP Cloud Storage Dashboard - OTLP
+
+## Data Ingestion
+
+### Integrate GCP Cloud Storage with OpenTelemetry Collector
+
+To collect GCP Cloud Storage metrics via the OpenTelemetry Collector, you need to configure the `googlecloudmonitoring` receiver to scrape Cloud Storage metrics and export them to SigNoz.
+
+#### Prerequisites
+
+1. A GCP project with Cloud Storage buckets configured.
+2. A service account with the `roles/monitoring.viewer` IAM role.
+3. OpenTelemetry Collector installed and running.
+
+#### OpenTelemetry Collector Configuration
+
+Add the following to your OpenTelemetry Collector configuration:
+
+```yaml
+receivers:
+  googlecloudmonitoring:
+    collection_interval: 60s
+    project_id: "<your-gcp-project-id>"
+    metrics_list:
+      - metric_name: "storage.googleapis.com/storage/total_bytes"
+      - metric_name: "storage.googleapis.com/storage/object_count"
+      - metric_name: "storage.googleapis.com/storage/total_byte_seconds"
+      - metric_name: "storage.googleapis.com/api/request_count"
+      - metric_name: "storage.googleapis.com/api/received_bytes_count"
+      - metric_name: "storage.googleapis.com/api/sent_bytes_count"
+      - metric_name: "storage.googleapis.com/network/received_bytes_count"
+      - metric_name: "storage.googleapis.com/network/sent_bytes_count"
+      - metric_name: "storage.googleapis.com/replication/object_count"
+      - metric_name: "storage.googleapis.com/replication/bytes_to_replicate"
+
+exporters:
+  otlp:
+    endpoint: "<signoz-otel-collector-endpoint>:4317"
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    metrics:
+      receivers: [googlecloudmonitoring]
+      exporters: [otlp]
+```
+
+Replace `<your-gcp-project-id>` with your GCP project ID and `<signoz-otel-collector-endpoint>` with the address of your SigNoz OTel Collector.
+
+## Dashboard Panels
+
+## Variables
+
+- `{{deployment.environment}}`: The deployment environment for the service.
+- `{{project_id}}`: GCP Project ID.
+- `{{bucket_name}}`: GCP Cloud Storage bucket name.
+
+### Sections
+
+- Overview
+  - Total Storage Bytes - `storage.googleapis.com/storage/total_bytes`
+  - Total Object Count - `storage.googleapis.com/storage/object_count`
+  - Total Byte Seconds by Storage Class - `storage.googleapis.com/storage/total_byte_seconds`
+- Storage Metrics
+  - Total Bytes by Bucket - `storage.googleapis.com/storage/total_bytes`
+  - Object Count by Bucket - `storage.googleapis.com/storage/object_count`
+- API Metrics
+  - API Request Count by Method - `storage.googleapis.com/api/request_count`
+  - API Request Count by Response Code - `storage.googleapis.com/api/request_count`
+  - API Received Bytes - `storage.googleapis.com/api/received_bytes_count`
+  - API Sent Bytes - `storage.googleapis.com/api/sent_bytes_count`
+- Network Metrics
+  - Network Received Bytes - `storage.googleapis.com/network/received_bytes_count`
+  - Network Sent Bytes - `storage.googleapis.com/network/sent_bytes_count`
+- Replication Metrics
+  - Replication Object Count - `storage.googleapis.com/replication/object_count`
+  - Bytes Pending Replication - `storage.googleapis.com/replication/bytes_to_replicate`

--- a/gcp/cloud-storage/gcp-cloud-storage-otlp-v1.json
+++ b/gcp/cloud-storage/gcp-cloud-storage-otlp-v1.json
@@ -1,0 +1,2968 @@
+{
+  "description": "This dashboard plots all the important metrics for GCP Cloud Storage.",
+  "image": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE0Ljk0OTQgMTMuOTQyQzE2LjIzMTggMTIuNDI1OCAxNy4zMjY4IDkuNzAyMiAxNi4xOTU2IDYuNTc0ODdDMTUuNjQ0MyA1LjA1MjQ1IDE1LjAyMTkgNC4yMDI0OSAxNC4yOTY5IDMuNjYyNTJDMTMuODU1NyAzLjMzMzc5IDEyLjA5MzMgMi41MDYzMyA5Ljc1OTY1IDIuODY3NTZDOC4wNTM0OSAzLjEzMjU1IDUuNzc0ODcgNC4yMDg3NCA0LjI5MzY5IDUuOTU5OUMyLjg1NzUyIDcuNjYxMDYgMS43NDg4MyA5LjAwNDc0IDEuNjk3NTggMTAuMzA5N0MxLjYzMTMzIDExLjk4ODMgMi44OTYyNyAxMy40MzA4IDMuMDUwMDEgMTMuNjY0NUMzLjMyMzc0IDE0LjA3OTUgNS4xOTExNSAxNi40NTE4IDguNjk5NzEgMTYuNTczMUMxMS43OTcgMTYuNjc5MyAxMy44MTQ0IDE1LjI4NDQgMTQuOTQ5NCAxMy45NDJaIiBmaWxsPSIjNDAzRDNFIi8+CjxwYXRoIGQ9Ik00LjU1MzYzIDIuNzM3NDdDMi45Mzc0NiAzLjg5MTE2IDEuMTIxMzEgNi4yNTEwMyAxLjQ0NzU0IDkuNTYwODZDMS42MDYyOCAxMS4xNzIgMi4wMDI1MSAxMi4xNDk1IDIuNTcxMjMgMTIuODUwN0MyLjkxNzQ2IDEzLjI3ODIgNC40MTk4OCAxNC41NDkzIDYuNzczNTEgMTQuNzM2OEM5LjE0NTg4IDE0LjkyNTYgMTAuOTQ5NSAxNC4zOTQ0IDEyLjgzMzIgMTMuMDg0NEMxNi42NjE3IDEwLjQyMDggMTYuMDk4IDYuMzkzNTMgMTUuOTM0MyA1LjkyNDhDMTUuNzcwNSA1LjQ1NjA3IDE0LjU0NDQgMi42OTYyMiAxMS4xNzMzIDEuNzE1MDJDOC4xOTg0NCAwLjg1MDA2OCA1Ljk4MzU1IDEuNzE1MDIgNC41NTM2MyAyLjczNzQ3WiIgZmlsbD0iIzVFNjM2NyIvPgo8cGF0aCBkPSJNNy4zOTM1MyAyLjk2MTA5QzUuNjE3MzcgMi44OTczNCAzLjkxOTk2IDQuMjg4NTIgMy43NTYyMiA2LjAwNTkzQzMuNTkyNDggNy43MjIwOSA0LjY1NDkyIDkuMDI5NTIgNi4zMDk4MyA5LjI5NTc2QzcuOTY0NzUgOS41NjA3NCA5Ljg3ODM5IDguNTU1OCAxMC4yNjM0IDYuNDUwOTFDMTAuNjYwOSA0LjI4MjI3IDkuMDg5NjkgMy4wMjIzNCA3LjM5MzUzIDIuOTYxMDlaIiBmaWxsPSJ3aGl0ZSIvPgo8cGF0aCBkPSJNNy45NDIxNyA1LjkwMTE1QzcuOTQyMTcgNS45MDExNSA4LjM2OTY1IDUuODEyNCA4LjQ1NDY1IDUuMTgyNDRDOC41MzgzOSA0LjU2MjQ3IDguMjMwOTEgNC4wMzM3NSA3LjUxMzQ1IDMuODQzNzZDNi43MzM0OSAzLjYzNzUyIDYuMjA0NzcgNC4wNjYyNSA2LjA2NzI3IDQuNTE3NDdDNS44NzYwMyA1LjE0NDk0IDYuMTU4NTIgNS40NDM2NyA2LjE1ODUyIDUuNDQzNjdDNi4xNTg1MiA1LjQ0MzY3IDUuMzkzNTYgNS42Mjc0MSA1LjMzMjMxIDYuNTI5ODdDNS4yNzQ4MSA3LjM4MTA3IDUuODU2MDMgNy44Mzg1NSA2LjQzOTc1IDcuOTc4NTRDNy4xNjA5NiA4LjE1MjI4IDcuOTc4NDIgNy45NTQ3OSA4LjE3ODQxIDcuMDM0ODRDOC4zNDQ2NSA2LjI3NzM4IDcuOTQyMTcgNS45MDExNSA3Ljk0MjE3IDUuOTAxMTVaIiBmaWxsPSIjMzAzMDMwIi8+CjxwYXRoIGQ9Ik02LjczOTgzIDQuNzUzNjJDNi42NzEwOSA1LjAxMjM1IDYuODA4NTggNS4yNjIzNCA3LjA3ODU3IDUuMzMxMDlDNy4zNjk4IDUuNDA0ODMgNy42MzQ3OSA1LjMwODU5IDcuNzA2MDMgNS4wMTExQzcuNzY4NTMgNC43NDczNyA3LjY0MzU0IDQuNTE0ODggNy4zMzYwNSA0LjQzOTg4QzcuMDgzNTcgNC4zNzczOSA2LjgxNDgzIDQuNDcxMTMgNi43Mzk4MyA0Ljc1MzYyWiIgZmlsbD0id2hpdGUiLz4KPHBhdGggZD0iTTYuOTU5NzggNi4wMzk3NEM2LjYzMjMgNS45Mzg0OSA2LjE5OTgyIDYuMDY0NzMgNi4xMzEwNyA2LjUwNDcxQzYuMDYyMzMgNi45NDQ2OSA2LjMyNjA2IDcuMTY5NjggNi42NzEwNCA3LjIzMjE3QzcuMDE2MDMgNy4yOTQ2NyA3LjM0MjI2IDcuMTEzNDMgNy40MDYwMSA2Ljc2MDk1QzcuNDY4NSA2LjQwOTcyIDcuMjg2MDEgNi4xMzk3MyA2Ljk1OTc4IDYuMDM5NzRaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K",
+  "layout":
+  [
+    {
+      "h": 1,
+      "i": "a2aec56a-e4c1-4038-ad6c-8df563cca84c",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 7,
+      "i": "47f80186-79fc-4d8e-a517-89ed3896a63c",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 0,
+      "y": 1
+    },
+    {
+      "h": 7,
+      "i": "1c819de7-0530-461a-85f7-9449aef4bcee",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 3,
+      "y": 1
+    },
+    {
+      "h": 7,
+      "i": "a29bff6e-35d2-4e00-a206-1be376aef229",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 1
+    },
+    {
+      "h": 1,
+      "i": "41c11610-c6a5-4bf1-99d5-02d82fac8434",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 8
+    },
+    {
+      "h": 6,
+      "i": "da30ad86-37bb-47e2-b17d-24156f33639f",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 9
+    },
+    {
+      "h": 6,
+      "i": "361e1321-2dfd-4dc0-b727-54366bcb8a00",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 9
+    },
+    {
+      "h": 1,
+      "i": "efb0828e-9451-403c-84d1-c040cfdaf6ea",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 15
+    },
+    {
+      "h": 6,
+      "i": "74e6ae27-c794-4184-a4cd-f8b255d008c7",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 16
+    },
+    {
+      "h": 6,
+      "i": "ddf82171-fda7-4a94-8ef4-b181e4c69d45",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 16
+    },
+    {
+      "h": 6,
+      "i": "1adb2780-a648-4410-8df8-fb546e06d72a",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 22
+    },
+    {
+      "h": 6,
+      "i": "420257cf-1f76-4178-b06d-476c7f6b49a3",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 22
+    },
+    {
+      "h": 1,
+      "i": "0aa58962-29b2-4ad6-a583-f229bdecf628",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 28
+    },
+    {
+      "h": 6,
+      "i": "07df0480-52e3-4c33-a8e4-056aef001b90",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 29
+    },
+    {
+      "h": 6,
+      "i": "64ecaf43-5ac5-4663-8726-a254c94caf81",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 29
+    },
+    {
+      "h": 1,
+      "i": "e09e1879-e22b-4ac6-acfe-94aa4216bc27",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 35
+    },
+    {
+      "h": 6,
+      "i": "6989c490-8c0d-43d0-875c-bf11755d6e31",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 36
+    },
+    {
+      "h": 6,
+      "i": "242b483e-8da0-4148-a5cd-0689c6e16271",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 36
+    }
+  ],
+  "panelMap":
+  {
+    "a2aec56a-e4c1-4038-ad6c-8df563cca84c":
+    {
+      "collapsed": false,
+      "widgets":
+      [
+        {
+          "h": 7,
+          "i": "47f80186-79fc-4d8e-a517-89ed3896a63c",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 0,
+          "y": 1
+        },
+        {
+          "h": 7,
+          "i": "1c819de7-0530-461a-85f7-9449aef4bcee",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 3,
+          "y": 1
+        },
+        {
+          "h": 7,
+          "i": "a29bff6e-35d2-4e00-a206-1be376aef229",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 1
+        }
+      ]
+    },
+    "41c11610-c6a5-4bf1-99d5-02d82fac8434":
+    {
+      "collapsed": false,
+      "widgets":
+      [
+        {
+          "h": 6,
+          "i": "da30ad86-37bb-47e2-b17d-24156f33639f",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 9
+        },
+        {
+          "h": 6,
+          "i": "361e1321-2dfd-4dc0-b727-54366bcb8a00",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 9
+        }
+      ]
+    },
+    "efb0828e-9451-403c-84d1-c040cfdaf6ea":
+    {
+      "collapsed": false,
+      "widgets":
+      [
+        {
+          "h": 6,
+          "i": "74e6ae27-c794-4184-a4cd-f8b255d008c7",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 16
+        },
+        {
+          "h": 6,
+          "i": "ddf82171-fda7-4a94-8ef4-b181e4c69d45",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 16
+        },
+        {
+          "h": 6,
+          "i": "1adb2780-a648-4410-8df8-fb546e06d72a",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 22
+        },
+        {
+          "h": 6,
+          "i": "420257cf-1f76-4178-b06d-476c7f6b49a3",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 22
+        }
+      ]
+    },
+    "0aa58962-29b2-4ad6-a583-f229bdecf628":
+    {
+      "collapsed": false,
+      "widgets":
+      [
+        {
+          "h": 6,
+          "i": "07df0480-52e3-4c33-a8e4-056aef001b90",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 29
+        },
+        {
+          "h": 6,
+          "i": "64ecaf43-5ac5-4663-8726-a254c94caf81",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 29
+        }
+      ]
+    },
+    "e09e1879-e22b-4ac6-acfe-94aa4216bc27":
+    {
+      "collapsed": false,
+      "widgets":
+      [
+        {
+          "h": 6,
+          "i": "6989c490-8c0d-43d0-875c-bf11755d6e31",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 36
+        },
+        {
+          "h": 6,
+          "i": "242b483e-8da0-4148-a5cd-0689c6e16271",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 36
+        }
+      ]
+    }
+  },
+  "tags":
+  [],
+  "title": "GCP Cloud Storage Dashboard",
+  "uploadedGrafana": false,
+  "variables":
+  {
+    "3c56b07a-3960-4c22-90d4-2257c5014f2e":
+    {
+      "customValue": "",
+      "description": "GCP Project ID",
+      "id": "3c56b07a-3960-4c22-90d4-2257c5014f2e",
+      "modificationUUID": "e7a67d89-a6ff-4cb0-9eca-f6d977d2a690",
+      "multiSelect": false,
+      "name": "project_id",
+      "order": 0,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'project_id'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name like '%storage%'",
+      "showALLOption": false,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "3132fb2e-16fb-42d7-baa1-430aecfd0104":
+    {
+      "customValue": "",
+      "description": "GCP Cloud Storage bucket name",
+      "id": "3132fb2e-16fb-42d7-baa1-430aecfd0104",
+      "modificationUUID": "ed912a3d-3bb3-4d95-ace0-6de6e2b23b77",
+      "multiSelect": false,
+      "name": "bucket_name",
+      "order": 1,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'bucket_name'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name like '%storage%'",
+      "showALLOption": false,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "a245243b-cfc1-4141-8e43-9d747880f540":
+    {
+      "customValue": "",
+      "description": "The deployment environment for the service.",
+      "id": "a245243b-cfc1-4141-8e43-9d747880f540",
+      "modificationUUID": "3a8808aa-62cc-4e7d-ac23-9fb1c64a82d3",
+      "multiSelect": false,
+      "name": "deployment.environment",
+      "order": 2,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'deployment.environment'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name like '%storage%'",
+      "showALLOption": false,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "version": "v4",
+  "widgets":
+  [
+    {
+      "description": "",
+      "id": "a2aec56a-e4c1-4038-ad6c-8df563cca84c",
+      "panelTypes": "row",
+      "title": "Overview"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits":
+      {},
+      "description": "Total size of all objects in the bucket, in bytes.",
+      "fillSpans": false,
+      "id": "47f80186-79fc-4d8e-a517-89ed3896a63c",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query":
+      {
+        "builder":
+        {
+          "queryData":
+          [
+            {
+              "aggregateAttribute":
+              {
+                "dataType": "float64",
+                "id": "storage.googleapis.com/storage/total_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "storage.googleapis.com/storage/total_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters":
+              {
+                "items":
+                [
+                  {
+                    "id": "f1a01001",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "f1a01002",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "f1a01003",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "bucket_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "bucket_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.bucket_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions":
+              [],
+              "groupBy":
+              [],
+              "having":
+              [],
+              "legend": "",
+              "limit": null,
+              "orderBy":
+              [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas":
+          []
+        },
+        "clickhouse_sql":
+        [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "3ffa3300-23ba-418d-bec8-c731dcf8c941",
+        "promql":
+        [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields":
+      [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields":
+      [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds":
+      [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Storage Bytes",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits":
+      {},
+      "description": "Total number of objects in the bucket.",
+      "fillSpans": false,
+      "id": "1c819de7-0530-461a-85f7-9449aef4bcee",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query":
+      {
+        "builder":
+        {
+          "queryData":
+          [
+            {
+              "aggregateAttribute":
+              {
+                "dataType": "float64",
+                "id": "storage.googleapis.com/storage/object_count--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "storage.googleapis.com/storage/object_count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters":
+              {
+                "items":
+                [
+                  {
+                    "id": "f2a01001",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "f2a01002",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "f2a01003",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "bucket_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "bucket_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.bucket_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions":
+              [],
+              "groupBy":
+              [],
+              "having":
+              [],
+              "legend": "",
+              "limit": null,
+              "orderBy":
+              [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas":
+          []
+        },
+        "clickhouse_sql":
+        [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ef05236f-7b0e-41c9-8f7c-43d0cbdc9cc0",
+        "promql":
+        [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields":
+      [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields":
+      [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds":
+      [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Object Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits":
+      {},
+      "description": "Total daily storage in byte-seconds used by the bucket, grouped by storage class.",
+      "fillSpans": false,
+      "id": "a29bff6e-35d2-4e00-a206-1be376aef229",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query":
+      {
+        "builder":
+        {
+          "queryData":
+          [
+            {
+              "aggregateAttribute":
+              {
+                "dataType": "float64",
+                "id": "storage.googleapis.com/storage/total_byte_seconds--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "storage.googleapis.com/storage/total_byte_seconds",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters":
+              {
+                "items":
+                [
+                  {
+                    "id": "f3a01001",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "f3a01002",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "f3a01003",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "bucket_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "bucket_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.bucket_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions":
+              [],
+              "groupBy":
+              [
+                {
+                  "dataType": "string",
+                  "id": "storage_class--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "storage_class",
+                  "type": "tag"
+                }
+              ],
+              "having":
+              [],
+              "legend": "Storage Class: {{storage_class}}",
+              "limit": null,
+              "orderBy":
+              [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas":
+          []
+        },
+        "clickhouse_sql":
+        [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b313875b-022b-45dd-a194-feef8835257c",
+        "promql":
+        [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields":
+      [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields":
+      [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds":
+      [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Byte Seconds by Storage Class",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "id": "41c11610-c6a5-4bf1-99d5-02d82fac8434",
+      "panelTypes": "row",
+      "title": "Storage Metrics"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits":
+      {},
+      "description": "Total size of all objects in each bucket, grouped by bucket name.",
+      "fillSpans": false,
+      "id": "da30ad86-37bb-47e2-b17d-24156f33639f",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query":
+      {
+        "builder":
+        {
+          "queryData":
+          [
+            {
+              "aggregateAttribute":
+              {
+                "dataType": "float64",
+                "id": "storage.googleapis.com/storage/total_bytes--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "storage.googleapis.com/storage/total_bytes",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters":
+              {
+                "items":
+                [
+                  {
+                    "id": "f4a01001",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "f4a01002",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "f4a01003",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "bucket_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "bucket_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.bucket_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions":
+              [],
+              "groupBy":
+              [
+                {
+                  "dataType": "string",
+                  "id": "bucket_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "bucket_name",
+                  "type": "tag"
+                }
+              ],
+              "having":
+              [],
+              "legend": "Bucket: {{bucket_name}}",
+              "limit": null,
+              "orderBy":
+              [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas":
+          []
+        },
+        "clickhouse_sql":
+        [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c5d6a13c-53d9-4357-b511-4d37ebb614f7",
+        "promql":
+        [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields":
+      [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields":
+      [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds":
+      [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Bytes by Bucket",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits":
+      {},
+      "description": "Total number of objects per bucket, grouped by bucket name.",
+      "fillSpans": false,
+      "id": "361e1321-2dfd-4dc0-b727-54366bcb8a00",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query":
+      {
+        "builder":
+        {
+          "queryData":
+          [
+            {
+              "aggregateAttribute":
+              {
+                "dataType": "float64",
+                "id": "storage.googleapis.com/storage/object_count--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "storage.googleapis.com/storage/object_count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters":
+              {
+                "items":
+                [
+                  {
+                    "id": "f5a01001",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "f5a01002",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "f5a01003",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "bucket_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "bucket_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.bucket_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions":
+              [],
+              "groupBy":
+              [
+                {
+                  "dataType": "string",
+                  "id": "bucket_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "bucket_name",
+                  "type": "tag"
+                }
+              ],
+              "having":
+              [],
+              "legend": "Bucket: {{bucket_name}}",
+              "limit": null,
+              "orderBy":
+              [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas":
+          []
+        },
+        "clickhouse_sql":
+        [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "1d648c91-a8f5-4bf9-9d76-d32501633073",
+        "promql":
+        [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields":
+      [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields":
+      [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds":
+      [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Object Count by Bucket",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "id": "efb0828e-9451-403c-84d1-c040cfdaf6ea",
+      "panelTypes": "row",
+      "title": "API Metrics"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits":
+      {},
+      "description": "Number of API calls made to Cloud Storage, grouped by method.",
+      "fillSpans": false,
+      "id": "74e6ae27-c794-4184-a4cd-f8b255d008c7",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query":
+      {
+        "builder":
+        {
+          "queryData":
+          [
+            {
+              "aggregateAttribute":
+              {
+                "dataType": "float64",
+                "id": "storage.googleapis.com/api/request_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "storage.googleapis.com/api/request_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters":
+              {
+                "items":
+                [
+                  {
+                    "id": "f6a01001",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "f6a01002",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "f6a01003",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "bucket_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "bucket_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.bucket_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions":
+              [],
+              "groupBy":
+              [
+                {
+                  "dataType": "string",
+                  "id": "method--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "method",
+                  "type": "tag"
+                }
+              ],
+              "having":
+              [],
+              "legend": "Method: {{method}}",
+              "limit": null,
+              "orderBy":
+              [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas":
+          []
+        },
+        "clickhouse_sql":
+        [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "1f7349e0-acc0-42a7-a930-981614dfa065",
+        "promql":
+        [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields":
+      [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields":
+      [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds":
+      [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "API Request Count by Method",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits":
+      {},
+      "description": "Number of API calls made to Cloud Storage, grouped by response code.",
+      "fillSpans": false,
+      "id": "ddf82171-fda7-4a94-8ef4-b181e4c69d45",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query":
+      {
+        "builder":
+        {
+          "queryData":
+          [
+            {
+              "aggregateAttribute":
+              {
+                "dataType": "float64",
+                "id": "storage.googleapis.com/api/request_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "storage.googleapis.com/api/request_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters":
+              {
+                "items":
+                [
+                  {
+                    "id": "f7a01001",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "f7a01002",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "f7a01003",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "bucket_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "bucket_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.bucket_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions":
+              [],
+              "groupBy":
+              [
+                {
+                  "dataType": "string",
+                  "id": "response_code--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "response_code",
+                  "type": "tag"
+                }
+              ],
+              "having":
+              [],
+              "legend": "Response Code: {{response_code}}",
+              "limit": null,
+              "orderBy":
+              [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas":
+          []
+        },
+        "clickhouse_sql":
+        [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c129c59f-a8aa-405a-9e6d-ddd020e7ed27",
+        "promql":
+        [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields":
+      [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields":
+      [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds":
+      [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "API Request Count by Response Code",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits":
+      {},
+      "description": "Total bytes received by the API, grouped by method.",
+      "fillSpans": false,
+      "id": "1adb2780-a648-4410-8df8-fb546e06d72a",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query":
+      {
+        "builder":
+        {
+          "queryData":
+          [
+            {
+              "aggregateAttribute":
+              {
+                "dataType": "float64",
+                "id": "storage.googleapis.com/api/received_bytes_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "storage.googleapis.com/api/received_bytes_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters":
+              {
+                "items":
+                [
+                  {
+                    "id": "f8a01001",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "f8a01002",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "f8a01003",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "bucket_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "bucket_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.bucket_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions":
+              [],
+              "groupBy":
+              [
+                {
+                  "dataType": "string",
+                  "id": "method--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "method",
+                  "type": "tag"
+                }
+              ],
+              "having":
+              [],
+              "legend": "Method: {{method}}",
+              "limit": null,
+              "orderBy":
+              [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas":
+          []
+        },
+        "clickhouse_sql":
+        [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b181cfa6-ec3f-408b-84c9-9e4a206306fd",
+        "promql":
+        [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields":
+      [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields":
+      [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds":
+      [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "API Received Bytes",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits":
+      {},
+      "description": "Total bytes sent by the API, grouped by method.",
+      "fillSpans": false,
+      "id": "420257cf-1f76-4178-b06d-476c7f6b49a3",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query":
+      {
+        "builder":
+        {
+          "queryData":
+          [
+            {
+              "aggregateAttribute":
+              {
+                "dataType": "float64",
+                "id": "storage.googleapis.com/api/sent_bytes_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "storage.googleapis.com/api/sent_bytes_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters":
+              {
+                "items":
+                [
+                  {
+                    "id": "f9a01001",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "f9a01002",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "f9a01003",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "bucket_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "bucket_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.bucket_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions":
+              [],
+              "groupBy":
+              [
+                {
+                  "dataType": "string",
+                  "id": "method--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "method",
+                  "type": "tag"
+                }
+              ],
+              "having":
+              [],
+              "legend": "Method: {{method}}",
+              "limit": null,
+              "orderBy":
+              [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas":
+          []
+        },
+        "clickhouse_sql":
+        [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "533e10b3-893d-45cc-aa8f-a5050d4e5596",
+        "promql":
+        [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields":
+      [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields":
+      [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds":
+      [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "API Sent Bytes",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "",
+      "id": "0aa58962-29b2-4ad6-a583-f229bdecf628",
+      "panelTypes": "row",
+      "title": "Network Metrics"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits":
+      {},
+      "description": "Count of bytes received over the network by the bucket.",
+      "fillSpans": false,
+      "id": "07df0480-52e3-4c33-a8e4-056aef001b90",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query":
+      {
+        "builder":
+        {
+          "queryData":
+          [
+            {
+              "aggregateAttribute":
+              {
+                "dataType": "float64",
+                "id": "storage.googleapis.com/network/received_bytes_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "storage.googleapis.com/network/received_bytes_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters":
+              {
+                "items":
+                [
+                  {
+                    "id": "f10a01001",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "f10a01002",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "f10a01003",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "bucket_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "bucket_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.bucket_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions":
+              [],
+              "groupBy":
+              [
+                {
+                  "dataType": "string",
+                  "id": "bucket_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "bucket_name",
+                  "type": "tag"
+                }
+              ],
+              "having":
+              [],
+              "legend": "Bucket: {{bucket_name}}",
+              "limit": null,
+              "orderBy":
+              [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas":
+          []
+        },
+        "clickhouse_sql":
+        [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "19b7a0ae-f1ba-4326-8aec-1745eb426346",
+        "promql":
+        [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields":
+      [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields":
+      [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds":
+      [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Network Received Bytes",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits":
+      {},
+      "description": "Count of bytes sent over the network by the bucket.",
+      "fillSpans": false,
+      "id": "64ecaf43-5ac5-4663-8726-a254c94caf81",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query":
+      {
+        "builder":
+        {
+          "queryData":
+          [
+            {
+              "aggregateAttribute":
+              {
+                "dataType": "float64",
+                "id": "storage.googleapis.com/network/sent_bytes_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "storage.googleapis.com/network/sent_bytes_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "increase",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters":
+              {
+                "items":
+                [
+                  {
+                    "id": "f11a01001",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "f11a01002",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "f11a01003",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "bucket_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "bucket_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.bucket_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions":
+              [],
+              "groupBy":
+              [
+                {
+                  "dataType": "string",
+                  "id": "bucket_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "bucket_name",
+                  "type": "tag"
+                }
+              ],
+              "having":
+              [],
+              "legend": "Bucket: {{bucket_name}}",
+              "limit": null,
+              "orderBy":
+              [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "increase"
+            }
+          ],
+          "queryFormulas":
+          []
+        },
+        "clickhouse_sql":
+        [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c4489210-11cd-4caf-9ffe-dc0c6756e83d",
+        "promql":
+        [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields":
+      [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields":
+      [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds":
+      [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Network Sent Bytes",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "",
+      "id": "e09e1879-e22b-4ac6-acfe-94aa4216bc27",
+      "panelTypes": "row",
+      "title": "Replication Metrics"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits":
+      {},
+      "description": "Number of objects pending replication, grouped by bucket.",
+      "fillSpans": false,
+      "id": "6989c490-8c0d-43d0-875c-bf11755d6e31",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query":
+      {
+        "builder":
+        {
+          "queryData":
+          [
+            {
+              "aggregateAttribute":
+              {
+                "dataType": "float64",
+                "id": "storage.googleapis.com/replication/object_count--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "storage.googleapis.com/replication/object_count",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters":
+              {
+                "items":
+                [
+                  {
+                    "id": "f12a01001",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "f12a01002",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "f12a01003",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "bucket_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "bucket_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.bucket_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions":
+              [],
+              "groupBy":
+              [
+                {
+                  "dataType": "string",
+                  "id": "bucket_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "bucket_name",
+                  "type": "tag"
+                }
+              ],
+              "having":
+              [],
+              "legend": "Bucket: {{bucket_name}}",
+              "limit": null,
+              "orderBy":
+              [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas":
+          []
+        },
+        "clickhouse_sql":
+        [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "df745584-c739-4f44-95a0-61337e6ef3de",
+        "promql":
+        [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields":
+      [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields":
+      [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds":
+      [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Replication Object Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits":
+      {},
+      "description": "Total bytes pending replication, grouped by bucket.",
+      "fillSpans": false,
+      "id": "242b483e-8da0-4148-a5cd-0689c6e16271",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query":
+      {
+        "builder":
+        {
+          "queryData":
+          [
+            {
+              "aggregateAttribute":
+              {
+                "dataType": "float64",
+                "id": "storage.googleapis.com/replication/bytes_to_replicate--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "storage.googleapis.com/replication/bytes_to_replicate",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters":
+              {
+                "items":
+                [
+                  {
+                    "id": "f13a01001",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.deployment.environment}}"
+                  },
+                  {
+                    "id": "f13a01002",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "project_id--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "project_id",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.project_id}}"
+                  },
+                  {
+                    "id": "f13a01003",
+                    "key":
+                    {
+                      "dataType": "string",
+                      "id": "bucket_name--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "bucket_name",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "{{.bucket_name}}"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions":
+              [],
+              "groupBy":
+              [
+                {
+                  "dataType": "string",
+                  "id": "bucket_name--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "bucket_name",
+                  "type": "tag"
+                }
+              ],
+              "having":
+              [],
+              "legend": "Bucket: {{bucket_name}}",
+              "limit": null,
+              "orderBy":
+              [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas":
+          []
+        },
+        "clickhouse_sql":
+        [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "e07df3d2-c9ff-498c-96bf-1c25590309f3",
+        "promql":
+        [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields":
+      [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields":
+      [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds":
+      [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Bytes Pending Replication",
+      "yAxisUnit": "bytes"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Comprehensive GCP Cloud Storage monitoring dashboard for SigNoz using Prometheus/OTLP metrics from Google Cloud Monitoring.

- **18 panels** across 5 sections: Overview, Storage, API, Network, Replication
- Covers bucket-level storage metrics, API request patterns, network throughput, and replication status
- Variables for bucket name, project ID, and instance filtering

### Sections

| Section | Panels | Key Metrics |
|---------|--------|-------------|
| Overview | 3 | Total bytes stored, object count, byte-seconds |
| Storage | 3 | Storage by bucket, object count trends, storage class distribution |
| API | 4 | Request count by method/response code, bytes sent/received |
| Network | 4 | Network received/sent bytes, throughput rates |
| Replication | 4 | Replication object count, bytes to replicate, reclassification |

### Files

- `gcp/cloud-storage/gcp-cloud-storage-otlp-v1.json` — Dashboard JSON (3,046 lines)
- `gcp/cloud-storage/README-cloud-storage.md` — Setup guide and metrics reference

Closes SigNoz/signoz#6385