### PR TITLE
feat(dashboard): Add NVIDIA DCGM Exporter GPU monitoring dashboard (Prometheus v1)

### DIFF
--- a/nvidia-dcgm/nvidia-dcgm-prometheus-v1.json
+++ b/nvidia-dcgm/nvidia-dcgm-prometheus-v1.json
@@ -1,0 +1,1350 @@
+{
+    "description": "",
+    "image": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE0Ljk0OTQgMTMuOTQyQzE2LjIzMTggMTIuNDI1OCAxNy4zMjY4IDkuNzAyMiAxNi4xOTU2IDYuNTc0ODdDMTUuNjQ0MyA1LjA1MjQ1IDE1LjAyMTkgNC4yMDI0OSAxNC4yOTY5IDMuNjYyNTJDMTMuODU1NyAzLjMzMzc5IDEyLjA5MzMgMi41MDYzMyA5Ljc1OTY1IDIuODY3NTZDOC4wNTM0OSAzLjEzMjU1IDUuNzc0ODcgNC4yMDg3NCA0LjI5MzY5IDUuOTU5OUMyLjg1NzUyIDcuNjYxMDYgMS43NDg4MyA5LjAwNDc0IDEuNjk3NTggMTAuMzA5N0MxLjYzMTMzIDExLjk4ODMgMi44OTYyNyAxMy40MzA4IDMuMDUwMDEgMTMuNjY0NUMzLjMyMzc0IDE0LjA3OTUgNS4xOTExNSAxNi40NTE4IDguNjk5NzEgMTYuNTczMUMxMS43OTcgMTYuNjc5MyAxMy44MTQ0IDE1LjI4NDQgMTQuOTQ5NCAxMy45NDJaIiBmaWxsPSIjNDAzRDNFIi8+CjxwYXRoIGQ9Ik00LjU1MzYzIDIuNzM3NDdDMi45Mzc0NiAzLjg5MTE2IDEuMTIxMzEgNi4yNTEwMyAxLjQ0NzU0IDkuNTYwODZDMS42MDYyOCAxMS4xNzIgMi4wMDI1MSAxMi4xNDk1IDIuNTcxMjMgMTIuODUwN0MyLjkxNzQ2IDEzLjI3ODIgNC40MTk4OCAxNC41NDkzIDYuNzczNTEgMTQuNzM2OEM5LjE0NTg4IDE0LjkyNTYgMTAuOTQ5NSAxNC4zOTQ0IDEyLjgzMzIgMTMuMDg0NEMxNi42NjE3IDEwLjQyMDggMTYuMDk4IDYuMzkzNTMgMTUuOTM0MyA1LjkyNDhDMTUuNzcwNSA1LjQ1NjA3IDE0LjU0NDQgMi42OTYyMiAxMS4xNzMzIDEuNzE1MDJDOC4xOTg0NCAwLjg1MDA2OCA1Ljk4MzU1IDEuNzE1MDIgNC41NTM2MyAyLjczNzQ3WiIgZmlsbD0iIzVFNjM2NyIvPgo8cGF0aCBkPSJNNy4zOTM1MyAyLjk2MTA5QzUuNjE3MzcgMi44OTczNCAzLjkxOTk2IDQuMjg4NTIgMy43NTYyMiA2LjAwNTkzQzMuNTkyNDggNy43MjIwOSA0LjY1NDkyIDkuMDI5NTIgNi4zMDk4MyA5LjI5NTc2QzcuOTY0NzUgOS41NjA3NCA5Ljg3ODM5IDguNTU1OCAxMC4yNjM0IDYuNDUwOTFDMTAuNjYwOSA0LjI4MjI3IDkuMDg5NjkgMy4wMjIzNCA3LjM5MzUzIDIuOTYxMDlaIiBmaWxsPSJ3aGl0ZSIvPgo8cGF0aCBkPSJNNy45NDIxNyA1LjkwMTE1QzcuOTQyMTcgNS45MDExNSA4LjM2OTY1IDUuODEyNCA4LjQ1NDY1IDUuMTgyNDRDOC41MzgzOSA0LjU2MjQ3IDguMjMwOTEgNC4wMzM3NSA3LjUxMzQ1IDMuODQzNzZDNi43MzM0OSAzLjYzNzUyIDYuMjA0NzcgNC4wNjYyNSA2LjA2NzI3IDQuNTE3NDdDNS44NzYwMyA1LjE0NDk0IDYuMTU4NTIgNS40NDM2NyA2LjE1ODUyIDUuNDQzNjdDNi4xNTg1MiA1LjQ0MzY3IDUuMzkzNTYgNS42Mjc0MSA1LjMzMjMxIDYuNTI5ODdDNS4yNzQ4MSA3LjM4MTA3IDUuODU2MDMgNy44Mzg1NSA2LjQzOTc1IDcuOTc4NTRDNy4xNjA5NiA4LjE1MjI4IDcuOTc4NDIgNy45NTQ3OSA4LjE3ODQxIDcuMDM0ODRDOC4zNDQ2NSA2LjI3NzM4IDcuOTQyMTcgNS45MDExNSA3Ljk0MjE3IDUuOTAxMTVaIiBmaWxsPSIjMzAzMDMwIi8+CjxwYXRoIGQ9Ik02LjczOTgzIDQuNzUzNjJDNi42NzEwOSA1LjAxMjM1IDYuODA4NTggNS4yNjIzNCA3LjA3ODU3IDUuMzMxMDlDNy4zNjk4IDUuNDA0ODMgNy42MzQ3OSA1LjMwODU5IDcuNzA2MDMgNS4wMTExQzcuNzY4NTMgNC43NDczNyA3LjY0MzU0IDQuNTE0ODggNy4zMzYwNSA0LjQzOTg4QzcuMDgzNTcgNC4zNzczOSA2LjgxNDgzIDQuNDcxMTMgNi43Mzk4MyA0Ljc1MzYyWiIgZmlsbD0id2hpdGUiLz4KPHBhdGggZD0iTTYuOTU5NzggNi4wMzk3NEM2LjYzMjMgNS45Mzg0OSA2LjE5OTgyIDYuMDY0NzMgNi4xMzEwNyA2LjUwNDcxQzYuMDYyMzMgNi45NDQ2OSA2LjMyNjA2IDcuMTY5NjggNi42NzEwNCA3LjIzMjE3QzcuMDE2MDMgNy4yOTQ2NyA3LjM0MjI2IDcuMTEzNDMgNy40MDYwMSA2Ljc2MDk1QzcuNDY4NSA2LjQwOTcyIDcuMjg2MDEgNi4xMzk3MyA2Ljk1OTc4IDYuMDM5NzRaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K",
+    "layout": [
+        {
+            "h": 6,
+            "i": "ef59d0f9-4e71-4f24-9f59-1c1087d3727e",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 0
+        },
+        {
+            "h": 6,
+            "i": "f40c8ece-aa8f-4c6d-a200-421c1963386c",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 0
+        },
+        {
+            "h": 6,
+            "i": "33973f69-1e90-4f2f-bcf6-23996d893510",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 6
+        },
+        {
+            "h": 6,
+            "i": "281dcaaf-1f74-47e3-a386-4b3ddd726d6c",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 6
+        },
+        {
+            "h": 6,
+            "i": "ff051cb4-fa2d-4b7e-9919-4234bea3c5c1",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 12
+        },
+        {
+            "h": 6,
+            "i": "a54628e2-3baa-489d-b0d5-e344f9efc897",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 12
+        },
+        {
+            "h": 6,
+            "i": "a1f5d74f-11c7-40e4-a29f-574cd07973d6",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 18
+        },
+        {
+            "h": 6,
+            "i": "39aac0d8-47a6-4030-9a07-bc6c82af79c2",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 18
+        }
+    ],
+    "panelMap": {},
+    "tags": [],
+    "title": "NVIDIA DCGM",
+    "uploadedGrafana": false,
+    "variables": {
+        "0b74631c-ff2f-4aa4-8c9a-7f415b74abc1": {
+            "allSelected": false,
+            "customValue": "",
+            "defaultValue": "",
+            "description": "",
+            "dynamicVariablesAttribute": "k8s.cluster.name",
+            "dynamicVariablesSource": "All telemetry",
+            "id": "0b74631c-ff2f-4aa4-8c9a-7f415b74abc1",
+            "key": "0b74631c-ff2f-4aa4-8c9a-7f415b74abc1",
+            "modificationUUID": "72d9eb08-27be-49bd-9068-199d494e8ec1",
+            "multiSelect": true,
+            "name": "k8s.cluster.name",
+            "order": 0,
+            "queryValue": "",
+            "showALLOption": true,
+            "sort": "DISABLED",
+            "textboxValue": "",
+            "type": "DYNAMIC"
+        },
+        "2c0fa227-287e-48c1-be04-3af217cf2b59": {
+            "allSelected": true,
+            "customValue": "",
+            "defaultValue": "",
+            "description": "",
+            "haveCustomValuesSelected": false,
+            "id": "2c0fa227-287e-48c1-be04-3af217cf2b59",
+            "key": "2c0fa227-287e-48c1-be04-3af217cf2b59",
+            "modificationUUID": "31fe3ead-ac8c-47e4-8875-abcf1ca3a97f",
+            "multiSelect": true,
+            "name": "k8s.node.name",
+            "order": 0,
+            "queryValue": "",
+            "showALLOption": true,
+            "sort": "DISABLED",
+            "textboxValue": "",
+            "type": "DYNAMIC"
+        },
+        "2fc31967-5bb1-4964-ac7d-6ae4a537b42f": {
+            "allSelected": true,
+            "customValue": "",
+            "defaultValue": "",
+            "description": "",
+            "dynamicVariablesAttribute": "gpu",
+            "dynamicVariablesSource": "All telemetry",
+            "id": "2fc31967-5bb1-4964-ac7d-6ae4a537b42f",
+            "key": "2fc31967-5bb1-4964-ac7d-6ae4a537b42f",
+            "modificationUUID": "212c8c4c-89ed-45d3-baeb-97b34470ce57",
+            "multiSelect": true,
+            "name": "GPU",
+            "order": 0,
+            "queryValue": "",
+            "showALLOption": true,
+            "sort": "DISABLED",
+            "textboxValue": "",
+            "type": "DYNAMIC"
+        }
+    },
+    "version": "v5",
+    "widgets": [
+        {
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "columnUnits": {},
+            "contextLinks": {
+                "linksData": []
+            },
+            "customLegendColors": {},
+            "decimalPrecision": 2,
+            "description": "",
+            "fillSpans": false,
+            "id": "ef59d0f9-4e71-4f24-9f59-1c1087d3727e",
+            "isLogScale": false,
+            "legendPosition": "bottom",
+            "mergeAllActiveQueries": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregations": [
+                                {
+                                    "metricName": "DCGM_FI_DEV_GPU_TEMP",
+                                    "reduceTo": "avg",
+                                    "spaceAggregation": "avg",
+                                    "temporality": "",
+                                    "timeAggregation": "avg"
+                                }
+                            ],
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filter": {
+                                "expression": " gpu in $GPU AND k8s.cluster.name IN $k8s.cluster.name  AND k8s.node.name IN $k8s.node.name"
+                            },
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "429948e9-af45-490e-b17f-9717a2da4240",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "k8s.cluster.name--string--",
+                                            "key": "k8s.cluster.name",
+                                            "type": ""
+                                        },
+                                        "op": "IN",
+                                        "value": "$k8s.cluster.name"
+                                    },
+                                    {
+                                        "id": "4dab563a-deb6-4efa-ba6a-316315634984",
+                                        "key": {
+                                            "id": "gpu",
+                                            "key": "gpu",
+                                            "type": ""
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "$GPU"
+                                        ]
+                                    },
+                                    {
+                                        "id": "03b77a01-b36c-4cd3-b21c-e01495a42187",
+                                        "key": {
+                                            "id": "k8s.node.name",
+                                            "key": "k8s.node.name",
+                                            "type": ""
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "$k8s.node.name"
+                                        ]
+                                    },
+                                    {
+                                        "id": "12a62b88-2f30-40cf-afb0-1c30aa1222c5",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "--string--",
+                                            "key": "",
+                                            "type": ""
+                                        },
+                                        "op": "IN",
+                                        "value": "$k8s.node.name"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "functions": [],
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "gpu--string--tag",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "gpu",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": {
+                                "expression": ""
+                            },
+                            "legend": "GPU {{gpu}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "source": "",
+                            "stepInterval": null
+                        }
+                    ],
+                    "queryFormulas": [],
+                    "queryTraceOperator": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "id": "619ac04c-c473-48ef-b8d0-22282043b594",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "selectedLogFields": [
+                {
+                    "dataType": "",
+                    "fieldContext": "log",
+                    "fieldDataType": "",
+                    "isIndexed": false,
+                    "name": "timestamp",
+                    "signal": "logs",
+                    "type": "log"
+                },
+                {
+                    "dataType": "",
+                    "fieldContext": "log",
+                    "fieldDataType": "",
+                    "isIndexed": false,
+                    "name": "body",
+                    "signal": "logs",
+                    "type": "log"
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "fieldContext": "resource",
+                    "fieldDataType": "string",
+                    "name": "service.name",
+                    "signal": "traces"
+                },
+                {
+                    "fieldContext": "span",
+                    "fieldDataType": "string",
+                    "name": "name",
+                    "signal": "traces"
+                },
+                {
+                    "fieldContext": "span",
+                    "fieldDataType": "",
+                    "name": "duration_nano",
+                    "signal": "traces"
+                },
+                {
+                    "fieldContext": "span",
+                    "fieldDataType": "",
+                    "name": "http_method",
+                    "signal": "traces"
+                },
+                {
+                    "fieldContext": "span",
+                    "fieldDataType": "",
+                    "name": "response_status_code",
+                    "signal": "traces"
+                }
+            ],
+            "softMax": 0,
+            "softMin": 0,
+            "stackedBarChart": false,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "GPU Temperature",
+            "yAxisUnit": "celsius"
+        },
+        {
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "columnUnits": {},
+            "contextLinks": {
+                "linksData": []
+            },
+            "customLegendColors": {},
+            "decimalPrecision": 2,
+            "description": "",
+            "fillSpans": false,
+            "id": "f40c8ece-aa8f-4c6d-a200-421c1963386c",
+            "isLogScale": false,
+            "legendPosition": "bottom",
+            "mergeAllActiveQueries": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "value",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregations": [
+                                {
+                                    "metricName": "DCGM_FI_DEV_GPU_TEMP",
+                                    "reduceTo": "avg",
+                                    "spaceAggregation": "avg",
+                                    "temporality": "",
+                                    "timeAggregation": "avg"
+                                }
+                            ],
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filter": {
+                                "expression": " gpu in $GPU k8s.cluster.name IN $k8s.cluster.name  k8s.node.name IN $k8s.node.name"
+                            },
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "429948e9-af45-490e-b17f-9717a2da4240",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "k8s.cluster.name--string--",
+                                            "key": "k8s.cluster.name",
+                                            "type": ""
+                                        },
+                                        "op": "IN",
+                                        "value": "$k8s.cluster.name"
+                                    },
+                                    {
+                                        "id": "31d7faab-5a54-4889-9546-cc9f569ef7c9",
+                                        "key": {
+                                            "id": "gpu",
+                                            "key": "gpu",
+                                            "type": ""
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "$GPU"
+                                        ]
+                                    },
+                                    {
+                                        "id": "1979acb4-54f0-42d4-be83-13c8700855d1",
+                                        "key": {
+                                            "id": "k8s.node.name",
+                                            "key": "k8s.node.name",
+                                            "type": ""
+                                        },
+                                        "op": "in",
+                                        "value": [
+                                            "$k8s.node.name"
+                                        ]
+                                    },
+                                    {
+                                        "id": "12a62b88-2f30-40cf-afb0-1c30aa1222c5",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "--string--",
+                                            "key": "",
+                                            "type": ""
+                                        },
+                                        "op": "IN",
+                                        "value": "$k8s.node.name"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "functions": [],
+                            "groupBy": [],
+                            "having": {
+                                "expression": ""
+                            },
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "source": "",
+                            "stepInterval": null
+                        }
+                    ],
+                    "queryFormulas": [],
+                    "queryTraceOperator": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "id": "fb0bef8e-c691-4520-9161-73ee14c48c2d",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "selectedLogFields": [
+                {
+                    "dataType": "",
+                    "fieldContext": "log",
+                    "fieldDataType": "",
+                    "isIndexed": false,
+                    "name": "timestamp",
+                    "signal": "logs",
+                    "type": "log"
+                },
+                {
+                    "dataType": "",
+                    "fieldContext": "log",
+                    "fieldDataType": "",
+                    "isIndexed": false,
+                    "name": "body",
+                    "signal": "logs",
+                    "type": "log"
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "fieldContext": "resource",
+                    "fieldDataType": "string",
+                    "name": "service.name",
+                    "signal": "traces"
+                },
+                {
+                    "fieldContext": "span",
+                    "fieldDataType": "string",
+                    "name": "name",
+                    "signal": "traces"
+                },
+                {
+                    "fieldContext": "span",
+                    "fieldDataType": "",
+                    "name": "duration_nano",
+                    "signal": "traces"
+                },
+                {
+                    "fieldContext": "span",
+                    "fieldDataType": "",
+                    "name": "http_method",
+                    "signal": "traces"
+                },
+                {
+                    "fieldContext": "span",
+                    "fieldDataType": "",
+                    "name": "response_status_code",
+                    "signal": "traces"
+                }
+            ],
+            "softMax": 0,
+            "softMin": 0,
+            "stackedBarChart": false,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "GPU Avg. Temp",
+            "yAxisUnit": "celsius"
+        },
+        {
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "columnUnits": {},
+            "contextLinks": {
+                "linksData": []
+            },
+            "customLegendColors": {},
+            "decimalPrecision": 2,
+            "description": "",
+            "fillSpans": false,
+            "id": "33973f69-1e90-4f2f-bcf6-23996d893510",
+            "isLogScale": false,
+            "legendPosition": "bottom",
+            "mergeAllActiveQueries": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregations": [
+                                {
+                                    "metricName": "DCGM_FI_DEV_POWER_USAGE",
+                                    "reduceTo": "avg",
+                                    "spaceAggregation": "avg",
+                                    "temporality": "",
+                                    "timeAggregation": "avg"
+                                }
+                            ],
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filter": {
+                                "expression": " gpu in $GPU AND k8s.cluster.name IN $k8s.cluster.name  AND k8s.node.name IN $k8s.node.name"
+                            },
+                            "functions": [],
+                            "groupBy": [
+                                {
+                                    "dataType": "",
+                                    "id": "gpu----",
+                                    "key": "gpu",
+                                    "type": ""
+                                }
+                            ],
+                            "having": {
+                                "expression": ""
+                            },
+                            "legend": "GPU {{gpu}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "source": "",
+                            "stepInterval": null
+                        }
+                    ],
+                    "queryFormulas": [],
+                    "queryTraceOperator": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "id": "9ed91136-fd2c-4529-8f84-9ad391b0ba6c",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "selectedLogFields": [
+                {
+                    "dataType": "",
+                    "fieldContext": "log",
+                    "fieldDataType": "",
+                    "isIndexed": false,
+                    "name": "timestamp",
+                    "signal": "logs",
+                    "type": "log"
+                },
+                {
+                    "dataType": "",
+                    "fieldContext": "log",
+                    "fieldDataType": "",
+                    "isIndexed": false,
+                    "name": "body",
+                    "signal": "logs",
+                    "type": "log"
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "fieldContext": "resource",
+                    "fieldDataType": "string",
+                    "name": "service.name",
+                    "signal": "traces"
+                },
+                {
+                    "fieldContext": "span",
+                    "fieldDataType": "string",
+                    "name": "name",
+                    "signal": "traces"
+                },
+                {
+                    "fieldContext": "span",
+                    "fieldDataType": "",
+                    "name": "duration_nano",
+                    "signal": "traces"
+                },
+                {
+                    "fieldContext": "span",
+                    "fieldDataType": "",
+                    "name": "http_method",
+                    "signal": "traces"
+                },
+                {
+                    "fieldContext": "span",
+                    "fieldDataType": "",
+                    "name": "response_status_code",
+                    "signal": "traces"
+                }
+            ],
+            "softMax": 0,
+            "softMin": 0,
+            "stackedBarChart": false,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "GPU Power Usage",
+            "yAxisUnit": "watt"
+        },
+        {
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "columnUnits": {},
+            "contextLinks": {
+                "linksData": []
+            },
+            "customLegendColors": {},
+            "decimalPrecision": 2,
+            "description": "",
+            "fillSpans": false,
+            "id": "281dcaaf-1f74-47e3-a386-4b3ddd726d6c",
+            "isLogScale": false,
+            "legendPosition": "bottom",
+            "mergeAllActiveQueries": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "value",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregations": [
+                                {
+                                    "metricName": "DCGM_FI_DEV_POWER_USAGE",
+                                    "reduceTo": "last",
+                                    "spaceAggregation": "sum",
+                                    "temporality": "",
+                                    "timeAggregation": "avg"
+                                }
+                            ],
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filter": {
+                                "expression": " gpu in $GPU AND k8s.cluster.name IN $k8s.cluster.name  AND k8s.node.name IN $k8s.node.name"
+                            },
+                            "functions": [],
+                            "groupBy": [],
+                            "having": {
+                                "expression": ""
+                            },
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "source": "",
+                            "stepInterval": null
+                        }
+                    ],
+                    "queryFormulas": [],
+                    "queryTraceOperator": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "id": "bd78214f-6722-469c-92c1-9ebf5f3a2764",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "selectedLogFields": [
+                {
+                    "dataType": "",
+                    "fieldContext": "log",
+                    "fieldDataType": "",
+                    "isIndexed": false,
+                    "name": "timestamp",
+                    "signal": "logs",
+                    "type": "log"
+                },
+                {
+                    "dataType": "",
+                    "fieldContext": "log",
+                    "fieldDataType": "",
+                    "isIndexed": false,
+                    "name": "body",
+                    "signal": "logs",
+                    "type": "log"
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "fieldContext": "resource",
+                    "fieldDataType": "string",
+                    "name": "service.name",
+                    "signal": "traces"
+                },
+                {
+                    "fieldContext": "span",
+                    "fieldDataType": "string",
+                    "name": "name",
+                    "signal": "traces"
+                },
+                {
+                    "fieldContext": "span",
+                    "fieldDataType": "",
+                    "name": "duration_nano",
+                    "signal": "traces"
+                },
+                {
+                    "fieldContext": "span",
+                    "fieldDataType": "",
+                    "name": "http_method",
+                    "signal": "traces"
+                },
+                {
+                    "fieldContext": "span",
+                    "fieldDataType": "",
+                    "name": "response_status_code",
+                    "signal": "traces"
+                }
+            ],
+            "softMax": 0,
+            "softMin": 0,
+            "stackedBarChart": false,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "GPU Power Total",
+            "yAxisUnit": "watt"
+        },
+        {
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "columnUnits": {},
+            "contextLinks": {
+                "linksData": []
+            },
+            "customLegendColors": {},
+            "decimalPrecision": 2,
+            "description": "",
+            "fillSpans": false,
+            "id": "ff051cb4-fa2d-4b7e-9919-4234bea3c5c1",
+            "isLogScale": false,
+            "legendPosition": "bottom",
+            "mergeAllActiveQueries": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregations": [
+                                {
+                                    "metricName": "DCGM_FI_DEV_SM_CLOCK",
+                                    "reduceTo": "avg",
+                                    "spaceAggregation": "avg",
+                                    "temporality": "",
+                                    "timeAggregation": "avg"
+                                }
+                            ],
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filter": {
+                                "expression": " gpu in $GPU AND k8s.cluster.name IN $k8s.cluster.name  AND k8s.node.name IN $k8s.node.name"
+                            },
+                            "functions": [],
+                            "groupBy": [
+                                {
+                                    "dataType": "",
+                                    "id": "gpu----",
+                                    "key": "gpu",
+                                    "type": ""
+                                }
+                            ],
+                            "having": {
+                                "expression": ""
+                            },
+                            "legend": "GPU {{gpu}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "source": "",
+                            "stepInterval": null
+                        }
+                    ],
+                    "queryFormulas": [],
+                    "queryTraceOperator": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "id": "3fe88010-4140-4db1-89fa-a468ea39cdcf",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "selectedLogFields": [
+                {
+                    "dataType": "",
+                    "fieldContext": "log",
+                    "fieldDataType": "",
+                    "isIndexed": false,
+                    "name": "timestamp",
+                    "signal": "logs",
+                    "type": "log"
+                },
+                {
+                    "dataType": "",
+                    "fieldContext": "log",
+                    "fieldDataType": "",
+                    "isIndexed": false,
+                    "name": "body",
+                    "signal": "logs",
+                    "type": "log"
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "fieldContext": "resource",
+                    "fieldDataType": "string",
+                    "name": "service.name",
+                    "signal": "traces"
+                },
+                {
+                    "fieldContext": "span",
+                    "fieldDataType": "string",
+                    "name": "name",
+                    "signal": "traces"
+                },
+                {
+                    "fieldContext": "span",
+                    "fieldDataType": "",
+                    "name": "duration_nano",
+                    "signal": "traces"
+                },
+                {
+                    "fieldContext": "span",
+                    "fieldDataType": "",
+                    "name": "http_method",
+                    "signal": "traces"
+                },
+                {
+                    "fieldContext": "span",
+                    "fieldDataType": "",
+                    "name": "response_status_code",
+                    "signal": "traces"
+                }
+            ],
+            "softMax": 0,
+            "softMin": 0,
+            "stackedBarChart": false,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "GPU SM Clocks",
+            "yAxisUnit": "hertz"
+        },
+        {
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "columnUnits": {},
+            "contextLinks": {
+                "linksData": []
+            },
+            "customLegendColors": {},
+            "decimalPrecision": 2,
+            "description": "",
+            "fillSpans": false,
+            "id": "a54628e2-3baa-489d-b0d5-e344f9efc897",
+            "isLogScale": false,
+            "legendPosition": "bottom",
+            "mergeAllActiveQueries": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregations": [
+                                {
+                                    "metricName": "DCGM_FI_DEV_GPU_UTIL",
+                                    "reduceTo": "avg",
+                                    "spaceAggregation": "avg",
+                                    "temporality": "",
+                                    "timeAggregation": "avg"
+                                }
+                            ],
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filter": {
+                                "expression": " gpu in $GPU AND k8s.cluster.name IN $k8s.cluster.name  AND k8s.node.name IN $k8s.node.name"
+                            },
+                            "functions": [],
+                            "groupBy": [
+                                {
+                                    "dataType": "",
+                                    "id": "gpu----",
+                                    "key": "gpu",
+                                    "type": ""
+                                }
+                            ],
+                            "having": {
+                                "expression": ""
+                            },
+                            "legend": "GPU {{gpu}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "source": "",
+                            "stepInterval": null
+                        }
+                    ],
+                    "queryFormulas": [],
+                    "queryTraceOperator": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "id": "85913715-341e-4f6a-9c22-b6af189da571",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "selectedLogFields": [
+                {
+                    "dataType": "",
+                    "fieldContext": "log",
+                    "fieldDataType": "",
+                    "isIndexed": false,
+                    "name": "timestamp",
+                    "signal": "logs",
+                    "type": "log"
+                },
+                {
+                    "dataType": "",
+                    "fieldContext": "log",
+                    "fieldDataType": "",
+                    "isIndexed": false,
+                    "name": "body",
+                    "signal": "logs",
+                    "type": "log"
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "fieldContext": "resource",
+                    "fieldDataType": "string",
+                    "name": "service.name",
+                    "signal": "traces"
+                },
+                {
+                    "fieldContext": "span",
+                    "fieldDataType": "string",
+                    "name": "name",
+                    "signal": "traces"
+                },
+                {
+                    "fieldContext": "span",
+                    "fieldDataType": "",
+                    "name": "duration_nano",
+                    "signal": "traces"
+                },
+                {
+                    "fieldContext": "span",
+                    "fieldDataType": "",
+                    "name": "http_method",
+                    "signal": "traces"
+                },
+                {
+                    "fieldContext": "span",
+                    "fieldDataType": "",
+                    "name": "response_status_code",
+                    "signal": "traces"
+                }
+            ],
+            "softMax": 0,
+            "softMin": 0,
+            "stackedBarChart": false,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "GPU Utilization",
+            "yAxisUnit": "%"
+        },
+        {
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "columnUnits": {},
+            "contextLinks": {
+                "linksData": []
+            },
+            "customLegendColors": {},
+            "decimalPrecision": 2,
+            "description": "",
+            "fillSpans": false,
+            "id": "a1f5d74f-11c7-40e4-a29f-574cd07973d6",
+            "isLogScale": false,
+            "legendPosition": "bottom",
+            "mergeAllActiveQueries": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregations": [
+                                {
+                                    "metricName": "DCGM_FI_DEV_FB_USED",
+                                    "reduceTo": "avg",
+                                    "spaceAggregation": "avg",
+                                    "temporality": "",
+                                    "timeAggregation": "avg"
+                                }
+                            ],
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filter": {
+                                "expression": " gpu in $GPU AND k8s.cluster.name IN $k8s.cluster.name  AND k8s.node.name IN $k8s.node.name"
+                            },
+                            "functions": [],
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "gpu--string--tag",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "gpu",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": {
+                                "expression": ""
+                            },
+                            "legend": "GPU {{gpu}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "source": "",
+                            "stepInterval": null
+                        }
+                    ],
+                    "queryFormulas": [],
+                    "queryTraceOperator": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "id": "5ec27da7-742c-4387-9eed-e35f4fa21164",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "selectedLogFields": [
+                {
+                    "dataType": "",
+                    "fieldContext": "log",
+                    "fieldDataType": "",
+                    "isIndexed": false,
+                    "name": "timestamp",
+                    "signal": "logs",
+                    "type": "log"
+                },
+                {
+                    "dataType": "",
+                    "fieldContext": "log",
+                    "fieldDataType": "",
+                    "isIndexed": false,
+                    "name": "body",
+                    "signal": "logs",
+                    "type": "log"
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "fieldContext": "resource",
+                    "fieldDataType": "string",
+                    "name": "service.name",
+                    "signal": "traces"
+                },
+                {
+                    "fieldContext": "span",
+                    "fieldDataType": "string",
+                    "name": "name",
+                    "signal": "traces"
+                },
+                {
+                    "fieldContext": "span",
+                    "fieldDataType": "",
+                    "name": "duration_nano",
+                    "signal": "traces"
+                },
+                {
+                    "fieldContext": "span",
+                    "fieldDataType": "",
+                    "name": "http_method",
+                    "signal": "traces"
+                },
+                {
+                    "fieldContext": "span",
+                    "fieldDataType": "",
+                    "name": "response_status_code",
+                    "signal": "traces"
+                }
+            ],
+            "softMax": 0,
+            "softMin": 0,
+            "stackedBarChart": false,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "GPU Framebuffer Mem Used",
+            "yAxisUnit": "MBy"
+        },
+        {
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "columnUnits": {},
+            "contextLinks": {
+                "linksData": []
+            },
+            "customLegendColors": {},
+            "decimalPrecision": 2,
+            "description": "",
+            "fillSpans": false,
+            "id": "39aac0d8-47a6-4030-9a07-bc6c82af79c2",
+            "isLogScale": false,
+            "legendPosition": "bottom",
+            "mergeAllActiveQueries": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregations": [
+                                {
+                                    "metricName": "DCGM_FI_PROF_PIPE_TENSOR_ACTIVE",
+                                    "reduceTo": "avg",
+                                    "spaceAggregation": "avg",
+                                    "temporality": "",
+                                    "timeAggregation": "avg"
+                                }
+                            ],
+                            "dataSource": "metrics",
+                            "disabled": false,
+                            "expression": "A",
+                            "filter": {
+                                "expression": " gpu in $GPU AND k8s.cluster.name IN $k8s.cluster.name  AND k8s.node.name IN $k8s.node.name"
+                            },
+                            "functions": [],
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "gpu--string--tag",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "gpu",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": {
+                                "expression": ""
+                            },
+                            "legend": "GPU {{gpu}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A",
+                            "source": "",
+                            "stepInterval": null
+                        }
+                    ],
+                    "queryFormulas": [],
+                    "queryTraceOperator": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "id": "75aa6649-9ed3-4f6b-bcb2-18f09d70fde6",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "selectedLogFields": [
+                {
+                    "dataType": "",
+                    "fieldContext": "log",
+                    "fieldDataType": "",
+                    "isIndexed": false,
+                    "name": "timestamp",
+                    "signal": "logs",
+                    "type": "log"
+                },
+                {
+                    "dataType": "",
+                    "fieldContext": "log",
+                    "fieldDataType": "",
+                    "isIndexed": false,
+                    "name": "body",
+                    "signal": "logs",
+                    "type": "log"
+                }
+            ],
+            "selectedTracesFields": [
+                {
+                    "fieldContext": "resource",
+                    "fieldDataType": "string",
+                    "name": "service.name",
+                    "signal": "traces"
+                },
+                {
+                    "fieldContext": "span",
+                    "fieldDataType": "string",
+                    "name": "name",
+                    "signal": "traces"
+                },
+                {
+                    "fieldContext": "span",
+                    "fieldDataType": "",
+                    "name": "duration_nano",
+                    "signal": "traces"
+                },
+                {
+                    "fieldContext": "span",
+                    "fieldDataType": "",
+                    "name": "http_method",
+                    "signal": "traces"
+                },
+                {
+                    "fieldContext": "span",
+                    "fieldDataType": "",
+                    "name": "response_status_code",
+                    "signal": "traces"
+                }
+            ],
+            "softMax": 0.1,
+            "softMin": 0,
+            "stackedBarChart": false,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Tensor Core Utilization",
+            "yAxisUnit": "percentunit"
+        }
+    ],
+    "uuid": "019bc627-3a01-7993-8985-697ab6b48c89"
+}

--- a/nvidia-dcgm/readme.md
+++ b/nvidia-dcgm/readme.md
@@ -1,0 +1,56 @@
+# NVIDIA DCGM Exporter Monitoring Dashboard
+
+Pre-built SigNoz dashboard for monitoring NVIDIA GPUs using [DCGM Exporter](https://github.com/NVIDIA/dcgm-exporter) metrics via Prometheus.
+
+## Metrics Ingestion
+
+DCGM Exporter exposes GPU metrics on `:9400/metrics`. Configure the OpenTelemetry Collector to scrape these:
+
+```yaml
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: 'dcgm-exporter'
+          scrape_interval: 15s
+          static_configs:
+            - targets: ['<dcgm-exporter-host>:9400']
+
+exporters:
+  otlp:
+    endpoint: "<signoz-otel-collector>:4317"
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      exporters: [otlp]
+```
+
+## Dashboard Panels
+
+| Section | Panel | Metric |
+|---------|-------|--------|
+| Temperature | GPU Temperature | `DCGM_FI_DEV_GPU_TEMP` |
+| Temperature | GPU Avg. Temp | `DCGM_FI_DEV_GPU_TEMP` |
+| Power | GPU Power Usage | `DCGM_FI_DEV_POWER_USAGE` |
+| Power | GPU Power Total | `DCGM_FI_DEV_POWER_USAGE` |
+| Clock | GPU SM Clocks | `DCGM_FI_DEV_SM_CLOCK` |
+| Utilization | GPU Utilization | `DCGM_FI_DEV_GPU_UTIL` |
+| Memory | GPU Framebuffer Mem Used | `DCGM_FI_DEV_FB_USED` |
+| Compute | Tensor Core Utilization | `DCGM_FI_PROF_PIPE_TENSOR_ACTIVE` |
+
+## Variables
+
+- `gpu` — Filter by GPU UUID or index
+- `instance` — Filter by host instance
+- `job` — Filter by scrape job name
+
+## Prerequisites
+
+- NVIDIA GPU with DCGM driver installed
+- [dcgm-exporter](https://github.com/NVIDIA/dcgm-exporter) running
+- OpenTelemetry Collector configured to scrape DCGM metrics
+- SigNoz instance


### PR DESCRIPTION
## Summary

NVIDIA DCGM Exporter GPU monitoring dashboard for SigNoz using Prometheus metrics from [dcgm-exporter](https://github.com/NVIDIA/dcgm-exporter).

- **8 panels** covering GPU utilization, temperature, power, memory, clock speeds, and tensor core activity
- Variables for GPU selection, instance, and job filtering
- Essential for AI/ML infrastructure monitoring

### Panels

| Panel | Type | Metric |
|-------|------|--------|
| GPU Temperature | graph | `DCGM_FI_DEV_GPU_TEMP` |
| GPU Avg. Temp | value | `DCGM_FI_DEV_GPU_TEMP` |
| GPU Power Usage | graph | `DCGM_FI_DEV_POWER_USAGE` |
| GPU Power Total | value | `DCGM_FI_DEV_POWER_USAGE` |
| GPU SM Clocks | graph | `DCGM_FI_DEV_SM_CLOCK` |
| GPU Utilization | graph | `DCGM_FI_DEV_GPU_UTIL` |
| GPU Framebuffer Mem Used | graph | `DCGM_FI_DEV_FB_USED` |
| Tensor Core Utilization | graph | `DCGM_FI_PROF_PIPE_TENSOR_ACTIVE` |

### Files

- `nvidia-dcgm/nvidia-dcgm-prometheus-v1.json` — Dashboard JSON (1,406 lines)
- `nvidia-dcgm/readme.md` — Setup guide with OTel Collector config

Closes SigNoz/signoz#8093