### PR TITLE
feat(dashboard): Add Apache Tomcat monitoring dashboard (Prometheus v1)

### DIFF
--- a/tomcat/readme.md
+++ b/tomcat/readme.md
@@ -1,0 +1,77 @@
+# Apache Tomcat Monitoring Dashboard
+
+Pre-built SigNoz dashboard for monitoring Apache Tomcat servers using Prometheus JMX Exporter metrics.
+
+## Metrics Ingestion
+
+Tomcat metrics are exposed via the [JMX Exporter](https://github.com/prometheus/jmx_exporter) or [Tomcat Prometheus Exporter](https://github.com/nlighten/tomcat_exporter). Configure the OpenTelemetry Collector to scrape:
+
+```yaml
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: 'tomcat'
+          scrape_interval: 15s
+          static_configs:
+            - targets: ['<tomcat-host>:9404']
+
+exporters:
+  otlp:
+    endpoint: "<signoz-otel-collector>:4317"
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      exporters: [otlp]
+```
+
+## Dashboard Sections
+
+| Section | Panels | Key Metrics |
+|---------|--------|-------------|
+| Overview | 6 values | Current/busy/max threads, request rate, error rate, active sessions |
+| Thread Pool | 2 | Current vs busy threads, busy vs max threads |
+| Request Processing | 4 | Request rate, error rate, processing time, avg duration |
+| Sessions | 4 | Active sessions, created/rejected/expired rates |
+| JVM Memory | 3 | Memory used, max, pool usage |
+| Garbage Collection | 2 | GC collection rate, GC time rate |
+| Network I/O | 2 | Bytes sent/received rates |
+| Class Loading | 3 | Currently loaded, total loaded, unloaded |
+
+## Variables
+
+- `instance` — Filter by Tomcat instance
+- `job` — Filter by Prometheus scrape job
+
+## Metrics Reference
+
+- `tomcat_threads_current_total` — Current thread pool size
+- `tomcat_threads_busy_total` — Busy threads in pool
+- `tomcat_threads_config_max_total` — Max configured threads
+- `tomcat_requestcount_total` — Total HTTP requests processed
+- `tomcat_errorcount_total` — Total HTTP errors
+- `tomcat_processingtime_total` — Cumulative request processing time
+- `tomcat_sessions_active_current_total` — Current active sessions
+- `tomcat_sessions_created_total` — Total sessions created
+- `tomcat_sessions_rejected_total` — Sessions rejected (capacity)
+- `tomcat_sessions_expired_total` — Sessions expired
+- `tomcat_bytessent_total` — Total bytes sent
+- `tomcat_bytesreceived_total` — Total bytes received
+- `jvm_memory_bytes_used` — JVM heap/non-heap memory used
+- `jvm_memory_bytes_max` — JVM max memory
+- `jvm_gc_collection_seconds_count` — GC invocation count
+- `jvm_gc_collection_seconds_sum` — Total GC time
+- `jvm_classes_loaded` — Currently loaded classes
+- `jvm_classes_loaded_total` — Total loaded since start
+- `jvm_classes_unloaded_total` — Total unloaded since start
+
+## Prerequisites
+
+- Apache Tomcat server
+- JMX Exporter or Tomcat Prometheus Exporter configured
+- OpenTelemetry Collector scraping Tomcat metrics
+- SigNoz instance

--- a/tomcat/tomcat-prometheus-v1.json
+++ b/tomcat/tomcat-prometheus-v1.json
@@ -1,0 +1,2470 @@
+{
+  "description": "Apache Tomcat monitoring dashboard with JMX/Prometheus metrics. Covers thread pools, request processing, sessions, JVM memory, garbage collection, network I/O, and class loading.",
+  "layout": [
+    {
+      "h": 1,
+      "i": "row-overview",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 3,
+      "i": "w-threads-current",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 1
+    },
+    {
+      "h": 3,
+      "i": "w-threads-busy",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 1
+    },
+    {
+      "h": 3,
+      "i": "w-threads-max",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 1
+    },
+    {
+      "h": 3,
+      "i": "w-request-rate",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 4
+    },
+    {
+      "h": 3,
+      "i": "w-error-rate",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 4
+    },
+    {
+      "h": 3,
+      "i": "w-active-sessions",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 4
+    },
+    {
+      "h": 1,
+      "i": "row-threadpool",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 7
+    },
+    {
+      "h": 6,
+      "i": "w-thread-pool-usage",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 8
+    },
+    {
+      "h": 6,
+      "i": "w-thread-pool-busy-vs-max",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 8
+    },
+    {
+      "h": 1,
+      "i": "row-requests",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 14
+    },
+    {
+      "h": 6,
+      "i": "w-request-count-rate",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 15
+    },
+    {
+      "h": 6,
+      "i": "w-error-count-rate",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 15
+    },
+    {
+      "h": 6,
+      "i": "w-processing-time-rate",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 21
+    },
+    {
+      "h": 6,
+      "i": "w-avg-request-duration",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 21
+    },
+    {
+      "h": 1,
+      "i": "row-sessions",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 27
+    },
+    {
+      "h": 6,
+      "i": "w-sessions-active",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 28
+    },
+    {
+      "h": 6,
+      "i": "w-sessions-created-rate",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 28
+    },
+    {
+      "h": 6,
+      "i": "w-sessions-rejected-rate",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 34
+    },
+    {
+      "h": 6,
+      "i": "w-sessions-expired-rate",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 34
+    },
+    {
+      "h": 1,
+      "i": "row-jvm-memory",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 40
+    },
+    {
+      "h": 6,
+      "i": "w-jvm-memory-used",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 41
+    },
+    {
+      "h": 6,
+      "i": "w-jvm-memory-max",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 41
+    },
+    {
+      "h": 6,
+      "i": "w-jvm-memory-pool-used",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 47
+    },
+    {
+      "h": 1,
+      "i": "row-gc",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 53
+    },
+    {
+      "h": 6,
+      "i": "w-gc-collection-count-rate",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 54
+    },
+    {
+      "h": 6,
+      "i": "w-gc-collection-time-rate",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 54
+    },
+    {
+      "h": 1,
+      "i": "row-network",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 60
+    },
+    {
+      "h": 6,
+      "i": "w-bytes-sent-rate",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 61
+    },
+    {
+      "h": 6,
+      "i": "w-bytes-received-rate",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 61
+    },
+    {
+      "h": 1,
+      "i": "row-classloading",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 67
+    },
+    {
+      "h": 6,
+      "i": "w-classes-loaded",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 68
+    },
+    {
+      "h": 6,
+      "i": "w-classes-loaded-total",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 68
+    },
+    {
+      "h": 6,
+      "i": "w-classes-unloaded-total",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 68
+    }
+  ],
+  "panelMap": {
+    "row-overview": {
+      "collapsed": false,
+      "widgets": [
+        { "h": 3, "i": "w-threads-current", "moved": false, "static": false, "w": 4, "x": 0, "y": 1 },
+        { "h": 3, "i": "w-threads-busy", "moved": false, "static": false, "w": 4, "x": 4, "y": 1 },
+        { "h": 3, "i": "w-threads-max", "moved": false, "static": false, "w": 4, "x": 8, "y": 1 },
+        { "h": 3, "i": "w-request-rate", "moved": false, "static": false, "w": 4, "x": 0, "y": 4 },
+        { "h": 3, "i": "w-error-rate", "moved": false, "static": false, "w": 4, "x": 4, "y": 4 },
+        { "h": 3, "i": "w-active-sessions", "moved": false, "static": false, "w": 4, "x": 8, "y": 4 }
+      ]
+    },
+    "row-threadpool": {
+      "collapsed": false,
+      "widgets": [
+        { "h": 6, "i": "w-thread-pool-usage", "moved": false, "static": false, "w": 6, "x": 0, "y": 8 },
+        { "h": 6, "i": "w-thread-pool-busy-vs-max", "moved": false, "static": false, "w": 6, "x": 6, "y": 8 }
+      ]
+    },
+    "row-requests": {
+      "collapsed": false,
+      "widgets": [
+        { "h": 6, "i": "w-request-count-rate", "moved": false, "static": false, "w": 6, "x": 0, "y": 15 },
+        { "h": 6, "i": "w-error-count-rate", "moved": false, "static": false, "w": 6, "x": 6, "y": 15 },
+        { "h": 6, "i": "w-processing-time-rate", "moved": false, "static": false, "w": 6, "x": 0, "y": 21 },
+        { "h": 6, "i": "w-avg-request-duration", "moved": false, "static": false, "w": 6, "x": 6, "y": 21 }
+      ]
+    },
+    "row-sessions": {
+      "collapsed": false,
+      "widgets": [
+        { "h": 6, "i": "w-sessions-active", "moved": false, "static": false, "w": 6, "x": 0, "y": 28 },
+        { "h": 6, "i": "w-sessions-created-rate", "moved": false, "static": false, "w": 6, "x": 6, "y": 28 },
+        { "h": 6, "i": "w-sessions-rejected-rate", "moved": false, "static": false, "w": 6, "x": 0, "y": 34 },
+        { "h": 6, "i": "w-sessions-expired-rate", "moved": false, "static": false, "w": 6, "x": 6, "y": 34 }
+      ]
+    },
+    "row-jvm-memory": {
+      "collapsed": false,
+      "widgets": [
+        { "h": 6, "i": "w-jvm-memory-used", "moved": false, "static": false, "w": 6, "x": 0, "y": 41 },
+        { "h": 6, "i": "w-jvm-memory-max", "moved": false, "static": false, "w": 6, "x": 6, "y": 41 },
+        { "h": 6, "i": "w-jvm-memory-pool-used", "moved": false, "static": false, "w": 12, "x": 0, "y": 47 }
+      ]
+    },
+    "row-gc": {
+      "collapsed": false,
+      "widgets": [
+        { "h": 6, "i": "w-gc-collection-count-rate", "moved": false, "static": false, "w": 6, "x": 0, "y": 54 },
+        { "h": 6, "i": "w-gc-collection-time-rate", "moved": false, "static": false, "w": 6, "x": 6, "y": 54 }
+      ]
+    },
+    "row-network": {
+      "collapsed": false,
+      "widgets": [
+        { "h": 6, "i": "w-bytes-sent-rate", "moved": false, "static": false, "w": 6, "x": 0, "y": 61 },
+        { "h": 6, "i": "w-bytes-received-rate", "moved": false, "static": false, "w": 6, "x": 6, "y": 61 }
+      ]
+    },
+    "row-classloading": {
+      "collapsed": false,
+      "widgets": [
+        { "h": 6, "i": "w-classes-loaded", "moved": false, "static": false, "w": 4, "x": 0, "y": 68 },
+        { "h": 6, "i": "w-classes-loaded-total", "moved": false, "static": false, "w": 4, "x": 4, "y": 68 },
+        { "h": 6, "i": "w-classes-unloaded-total", "moved": false, "static": false, "w": 4, "x": 8, "y": 68 }
+      ]
+    }
+  },
+  "tags": [
+    "tomcat",
+    "jvm",
+    "webserver"
+  ],
+  "title": "Apache Tomcat Overview",
+  "uploadedGrafana": false,
+  "version": "v4",
+  "variables": {
+    "var-instance": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Tomcat instance",
+      "id": "var-instance",
+      "key": "var-instance",
+      "modificationUUID": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "multiSelect": true,
+      "name": "instance",
+      "order": 0,
+      "queryValue": "SELECT JSONExtractString(labels, 'instance') AS `instance`\nFROM signoz_metrics.distributed_time_series_v4_1day\nWHERE metric_name = 'tomcat_threads_current'\nGROUP BY `instance`",
+      "selectedValue": [
+        ""
+      ],
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "var-job": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Prometheus scrape job",
+      "id": "var-job",
+      "key": "var-job",
+      "modificationUUID": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+      "multiSelect": true,
+      "name": "job",
+      "order": 1,
+      "queryValue": "SELECT JSONExtractString(labels, 'job') AS `job`\nFROM signoz_metrics.distributed_time_series_v4_1day\nWHERE metric_name = 'tomcat_threads_current'\nGROUP BY `job`",
+      "selectedValue": [
+        ""
+      ],
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "widgets": [
+    {
+      "description": "",
+      "id": "row-overview",
+      "panelTypes": "row",
+      "title": "Overview"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Current number of threads in the Tomcat thread pool",
+      "fillSpans": false,
+      "id": "w-threads-current",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "tomcat_threads_current--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "tomcat_threads_current",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f001",
+                    "key": {
+                      "dataType": "string",
+                      "id": "instance--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "instance",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.instance}}"]
+                  },
+                  {
+                    "id": "f002",
+                    "key": {
+                      "dataType": "string",
+                      "id": "job--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "job",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": ["{{.job}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Current Threads",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "q-threads-current",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Current Threads",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of busy threads in the Tomcat thread pool",
+      "fillSpans": false,
+      "id": "w-threads-busy",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "tomcat_threads_busy--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "tomcat_threads_busy",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f003",
+                    "key": { "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" },
+                    "op": "in",
+                    "value": ["{{.instance}}"]
+                  },
+                  {
+                    "id": "f004",
+                    "key": { "dataType": "string", "id": "job--string--tag--false", "isColumn": false, "isJSON": false, "key": "job", "type": "tag" },
+                    "op": "in",
+                    "value": ["{{.job}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Busy Threads",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "q-threads-busy",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Busy Threads",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Maximum configured threads in the Tomcat thread pool",
+      "fillSpans": false,
+      "id": "w-threads-max",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "tomcat_threads_config_max--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "tomcat_threads_config_max",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f005",
+                    "key": { "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" },
+                    "op": "in",
+                    "value": ["{{.instance}}"]
+                  },
+                  {
+                    "id": "f006",
+                    "key": { "dataType": "string", "id": "job--string--tag--false", "isColumn": false, "isJSON": false, "key": "job", "type": "tag" },
+                    "op": "in",
+                    "value": ["{{.job}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Max Threads",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "q-threads-max",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Max Threads",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of incoming requests per second",
+      "fillSpans": false,
+      "id": "w-request-rate",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "tomcat_requestcount_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "tomcat_requestcount_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f007",
+                    "key": { "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" },
+                    "op": "in",
+                    "value": ["{{.instance}}"]
+                  },
+                  {
+                    "id": "f008",
+                    "key": { "dataType": "string", "id": "job--string--tag--false", "isColumn": false, "isJSON": false, "key": "job", "type": "tag" },
+                    "op": "in",
+                    "value": ["{{.job}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Requests/s",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "q-request-rate",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Rate",
+      "yAxisUnit": "ops"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of errors per second",
+      "fillSpans": false,
+      "id": "w-error-rate",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "tomcat_errorcount_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "tomcat_errorcount_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f009",
+                    "key": { "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" },
+                    "op": "in",
+                    "value": ["{{.instance}}"]
+                  },
+                  {
+                    "id": "f010",
+                    "key": { "dataType": "string", "id": "job--string--tag--false", "isColumn": false, "isJSON": false, "key": "job", "type": "tag" },
+                    "op": "in",
+                    "value": ["{{.job}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Errors/s",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "q-error-rate",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Error Rate",
+      "yAxisUnit": "ops"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Current number of active sessions",
+      "fillSpans": false,
+      "id": "w-active-sessions",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "tomcat_sessions_active_current--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "tomcat_sessions_active_current",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f011",
+                    "key": { "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" },
+                    "op": "in",
+                    "value": ["{{.instance}}"]
+                  },
+                  {
+                    "id": "f012",
+                    "key": { "dataType": "string", "id": "job--string--tag--false", "isColumn": false, "isJSON": false, "key": "job", "type": "tag" },
+                    "op": "in",
+                    "value": ["{{.job}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Active Sessions",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "q-active-sessions",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Sessions",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "id": "row-threadpool",
+      "panelTypes": "row",
+      "title": "Thread Pool"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Tomcat thread pool current and busy threads over time",
+      "fillSpans": false,
+      "id": "w-thread-pool-usage",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "tomcat_threads_current--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "tomcat_threads_current",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f013",
+                    "key": { "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" },
+                    "op": "in",
+                    "value": ["{{.instance}}"]
+                  },
+                  {
+                    "id": "f014",
+                    "key": { "dataType": "string", "id": "job--string--tag--false", "isColumn": false, "isJSON": false, "key": "job", "type": "tag" },
+                    "op": "in",
+                    "value": ["{{.job}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                { "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }
+              ],
+              "having": [],
+              "legend": "Current::{{instance}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "tomcat_threads_busy--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "tomcat_threads_busy",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f015",
+                    "key": { "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" },
+                    "op": "in",
+                    "value": ["{{.instance}}"]
+                  },
+                  {
+                    "id": "f016",
+                    "key": { "dataType": "string", "id": "job--string--tag--false", "isColumn": false, "isJSON": false, "key": "job", "type": "tag" },
+                    "op": "in",
+                    "value": ["{{.job}}"]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                { "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }
+              ],
+              "having": [],
+              "legend": "Busy::{{instance}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "q-thread-pool-usage",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Thread Pool Current vs Busy",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Busy threads compared to the maximum configured thread count",
+      "fillSpans": false,
+      "id": "w-thread-pool-busy-vs-max",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "tomcat_threads_busy--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "tomcat_threads_busy",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  { "id": "f017", "key": { "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }, "op": "in", "value": ["{{.instance}}"] },
+                  { "id": "f018", "key": { "dataType": "string", "id": "job--string--tag--false", "isColumn": false, "isJSON": false, "key": "job", "type": "tag" }, "op": "in", "value": ["{{.job}}"] }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [{ "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }],
+              "having": [],
+              "legend": "Busy::{{instance}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "tomcat_threads_config_max--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "tomcat_threads_config_max",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "max",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  { "id": "f019", "key": { "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }, "op": "in", "value": ["{{.instance}}"] },
+                  { "id": "f020", "key": { "dataType": "string", "id": "job--string--tag--false", "isColumn": false, "isJSON": false, "key": "job", "type": "tag" }, "op": "in", "value": ["{{.job}}"] }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [{ "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }],
+              "having": [],
+              "legend": "Max::{{instance}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "q-thread-pool-busy-vs-max",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Busy Threads vs Max",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "id": "row-requests",
+      "panelTypes": "row",
+      "title": "Request Processing"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of total requests processed by Tomcat connectors",
+      "fillSpans": false,
+      "id": "w-request-count-rate",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "tomcat_requestcount_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "tomcat_requestcount_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  { "id": "f021", "key": { "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }, "op": "in", "value": ["{{.instance}}"] },
+                  { "id": "f022", "key": { "dataType": "string", "id": "job--string--tag--false", "isColumn": false, "isJSON": false, "key": "job", "type": "tag" }, "op": "in", "value": ["{{.job}}"] }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [{ "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }],
+              "having": [],
+              "legend": "Requests/s::{{instance}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "q-request-count-rate",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Rate",
+      "yAxisUnit": "ops"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of errors returned by Tomcat connectors",
+      "fillSpans": false,
+      "id": "w-error-count-rate",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "tomcat_errorcount_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "tomcat_errorcount_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  { "id": "f023", "key": { "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }, "op": "in", "value": ["{{.instance}}"] },
+                  { "id": "f024", "key": { "dataType": "string", "id": "job--string--tag--false", "isColumn": false, "isJSON": false, "key": "job", "type": "tag" }, "op": "in", "value": ["{{.job}}"] }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [{ "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }],
+              "having": [],
+              "legend": "Errors/s::{{instance}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "q-error-count-rate",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Error Rate",
+      "yAxisUnit": "ops"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total processing time spent by Tomcat handling requests",
+      "fillSpans": false,
+      "id": "w-processing-time-rate",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "tomcat_processingtime_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "tomcat_processingtime_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  { "id": "f025", "key": { "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }, "op": "in", "value": ["{{.instance}}"] },
+                  { "id": "f026", "key": { "dataType": "string", "id": "job--string--tag--false", "isColumn": false, "isJSON": false, "key": "job", "type": "tag" }, "op": "in", "value": ["{{.job}}"] }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [{ "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }],
+              "having": [],
+              "legend": "Processing time/s::{{instance}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "q-processing-time-rate",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Processing Time Rate",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Average request duration (processing time / request count)",
+      "fillSpans": false,
+      "id": "w-avg-request-duration",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "tomcat_processingtime_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "tomcat_processingtime_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  { "id": "f027", "key": { "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }, "op": "in", "value": ["{{.instance}}"] },
+                  { "id": "f028", "key": { "dataType": "string", "id": "job--string--tag--false", "isColumn": false, "isJSON": false, "key": "job", "type": "tag" }, "op": "in", "value": ["{{.job}}"] }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Processing Time Rate",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "tomcat_requestcount_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "tomcat_requestcount_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  { "id": "f029", "key": { "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }, "op": "in", "value": ["{{.instance}}"] },
+                  { "id": "f030", "key": { "dataType": "string", "id": "job--string--tag--false", "isColumn": false, "isJSON": false, "key": "job", "type": "tag" }, "op": "in", "value": ["{{.job}}"] }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "Request Rate",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "A/B",
+              "legend": "Avg Request Duration (ms)",
+              "queryName": "F1"
+            }
+          ]
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "q-avg-request-duration",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Avg Request Duration",
+      "yAxisUnit": "ms"
+    },
+    {
+      "description": "",
+      "id": "row-sessions",
+      "panelTypes": "row",
+      "title": "Sessions"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Current number of active sessions across Tomcat contexts",
+      "fillSpans": false,
+      "id": "w-sessions-active",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "tomcat_sessions_active_current--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "tomcat_sessions_active_current",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  { "id": "f031", "key": { "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }, "op": "in", "value": ["{{.instance}}"] },
+                  { "id": "f032", "key": { "dataType": "string", "id": "job--string--tag--false", "isColumn": false, "isJSON": false, "key": "job", "type": "tag" }, "op": "in", "value": ["{{.job}}"] }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [{ "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }],
+              "having": [],
+              "legend": "Active::{{instance}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "q-sessions-active",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Sessions",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of new sessions being created",
+      "fillSpans": false,
+      "id": "w-sessions-created-rate",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "tomcat_sessions_created_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "tomcat_sessions_created_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  { "id": "f033", "key": { "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }, "op": "in", "value": ["{{.instance}}"] },
+                  { "id": "f034", "key": { "dataType": "string", "id": "job--string--tag--false", "isColumn": false, "isJSON": false, "key": "job", "type": "tag" }, "op": "in", "value": ["{{.job}}"] }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [{ "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }],
+              "having": [],
+              "legend": "Created/s::{{instance}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "q-sessions-created-rate",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Sessions Created Rate",
+      "yAxisUnit": "ops"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of sessions being rejected (max active sessions reached)",
+      "fillSpans": false,
+      "id": "w-sessions-rejected-rate",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "tomcat_sessions_rejected_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "tomcat_sessions_rejected_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  { "id": "f035", "key": { "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }, "op": "in", "value": ["{{.instance}}"] },
+                  { "id": "f036", "key": { "dataType": "string", "id": "job--string--tag--false", "isColumn": false, "isJSON": false, "key": "job", "type": "tag" }, "op": "in", "value": ["{{.job}}"] }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [{ "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }],
+              "having": [],
+              "legend": "Rejected/s::{{instance}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "q-sessions-rejected-rate",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Sessions Rejected Rate",
+      "yAxisUnit": "ops"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of sessions expiring",
+      "fillSpans": false,
+      "id": "w-sessions-expired-rate",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "tomcat_sessions_expired_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "tomcat_sessions_expired_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  { "id": "f037", "key": { "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }, "op": "in", "value": ["{{.instance}}"] },
+                  { "id": "f038", "key": { "dataType": "string", "id": "job--string--tag--false", "isColumn": false, "isJSON": false, "key": "job", "type": "tag" }, "op": "in", "value": ["{{.job}}"] }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [{ "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }],
+              "having": [],
+              "legend": "Expired/s::{{instance}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "q-sessions-expired-rate",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Sessions Expired Rate",
+      "yAxisUnit": "ops"
+    },
+    {
+      "description": "",
+      "id": "row-jvm-memory",
+      "panelTypes": "row",
+      "title": "JVM Memory"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "JVM memory bytes used by area (heap / non-heap)",
+      "fillSpans": false,
+      "id": "w-jvm-memory-used",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm_memory_bytes_used--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm_memory_bytes_used",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  { "id": "f039", "key": { "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }, "op": "in", "value": ["{{.instance}}"] },
+                  { "id": "f040", "key": { "dataType": "string", "id": "job--string--tag--false", "isColumn": false, "isJSON": false, "key": "job", "type": "tag" }, "op": "in", "value": ["{{.job}}"] }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [{ "dataType": "string", "id": "area--string--tag--false", "isColumn": false, "isJSON": false, "key": "area", "type": "tag" }],
+              "having": [],
+              "legend": "Used::{{area}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "q-jvm-memory-used",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "JVM Memory Used",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Maximum JVM memory by area (heap / non-heap)",
+      "fillSpans": false,
+      "id": "w-jvm-memory-max",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm_memory_bytes_max--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm_memory_bytes_max",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "max",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  { "id": "f041", "key": { "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }, "op": "in", "value": ["{{.instance}}"] },
+                  { "id": "f042", "key": { "dataType": "string", "id": "job--string--tag--false", "isColumn": false, "isJSON": false, "key": "job", "type": "tag" }, "op": "in", "value": ["{{.job}}"] }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [{ "dataType": "string", "id": "area--string--tag--false", "isColumn": false, "isJSON": false, "key": "area", "type": "tag" }],
+              "having": [],
+              "legend": "Max::{{area}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "q-jvm-memory-max",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "JVM Memory Max",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "JVM memory pool usage by pool name (Eden, Survivor, Old Gen, etc.)",
+      "fillSpans": false,
+      "id": "w-jvm-memory-pool-used",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm_memory_pool_bytes_used--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm_memory_pool_bytes_used",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  { "id": "f043", "key": { "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }, "op": "in", "value": ["{{.instance}}"] },
+                  { "id": "f044", "key": { "dataType": "string", "id": "job--string--tag--false", "isColumn": false, "isJSON": false, "key": "job", "type": "tag" }, "op": "in", "value": ["{{.job}}"] }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [{ "dataType": "string", "id": "pool--string--tag--false", "isColumn": false, "isJSON": false, "key": "pool", "type": "tag" }],
+              "having": [],
+              "legend": "{{pool}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "q-jvm-memory-pool-used",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "JVM Memory Pool Usage",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "",
+      "id": "row-gc",
+      "panelTypes": "row",
+      "title": "Garbage Collection"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of garbage collection invocations by GC type",
+      "fillSpans": false,
+      "id": "w-gc-collection-count-rate",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm_gc_collection_seconds_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm_gc_collection_seconds_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  { "id": "f045", "key": { "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }, "op": "in", "value": ["{{.instance}}"] },
+                  { "id": "f046", "key": { "dataType": "string", "id": "job--string--tag--false", "isColumn": false, "isJSON": false, "key": "job", "type": "tag" }, "op": "in", "value": ["{{.job}}"] }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [{ "dataType": "string", "id": "gc--string--tag--false", "isColumn": false, "isJSON": false, "key": "gc", "type": "tag" }],
+              "having": [],
+              "legend": "Collections/s::{{gc}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "q-gc-collection-count-rate",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "GC Collection Rate",
+      "yAxisUnit": "ops"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of time spent in garbage collection by GC type",
+      "fillSpans": false,
+      "id": "w-gc-collection-time-rate",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm_gc_collection_seconds_sum--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm_gc_collection_seconds_sum",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  { "id": "f047", "key": { "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }, "op": "in", "value": ["{{.instance}}"] },
+                  { "id": "f048", "key": { "dataType": "string", "id": "job--string--tag--false", "isColumn": false, "isJSON": false, "key": "job", "type": "tag" }, "op": "in", "value": ["{{.job}}"] }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [{ "dataType": "string", "id": "gc--string--tag--false", "isColumn": false, "isJSON": false, "key": "gc", "type": "tag" }],
+              "having": [],
+              "legend": "GC Time/s::{{gc}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "q-gc-collection-time-rate",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "GC Collection Time Rate",
+      "yAxisUnit": "s"
+    },
+    {
+      "description": "",
+      "id": "row-network",
+      "panelTypes": "row",
+      "title": "Network I/O"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of bytes sent by Tomcat connectors",
+      "fillSpans": false,
+      "id": "w-bytes-sent-rate",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "tomcat_bytessent_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "tomcat_bytessent_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  { "id": "f049", "key": { "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }, "op": "in", "value": ["{{.instance}}"] },
+                  { "id": "f050", "key": { "dataType": "string", "id": "job--string--tag--false", "isColumn": false, "isJSON": false, "key": "job", "type": "tag" }, "op": "in", "value": ["{{.job}}"] }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [{ "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }],
+              "having": [],
+              "legend": "Sent::{{instance}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "q-bytes-sent-rate",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Bytes Sent Rate",
+      "yAxisUnit": "binBps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of bytes received by Tomcat connectors",
+      "fillSpans": false,
+      "id": "w-bytes-received-rate",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "tomcat_bytesreceived_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "tomcat_bytesreceived_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  { "id": "f051", "key": { "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }, "op": "in", "value": ["{{.instance}}"] },
+                  { "id": "f052", "key": { "dataType": "string", "id": "job--string--tag--false", "isColumn": false, "isJSON": false, "key": "job", "type": "tag" }, "op": "in", "value": ["{{.job}}"] }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [{ "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }],
+              "having": [],
+              "legend": "Received::{{instance}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "q-bytes-received-rate",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Bytes Received Rate",
+      "yAxisUnit": "binBps"
+    },
+    {
+      "description": "",
+      "id": "row-classloading",
+      "panelTypes": "row",
+      "title": "Class Loading"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of classes currently loaded in the JVM",
+      "fillSpans": false,
+      "id": "w-classes-loaded",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm_classes_loaded--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm_classes_loaded",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  { "id": "f053", "key": { "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }, "op": "in", "value": ["{{.instance}}"] },
+                  { "id": "f054", "key": { "dataType": "string", "id": "job--string--tag--false", "isColumn": false, "isJSON": false, "key": "job", "type": "tag" }, "op": "in", "value": ["{{.job}}"] }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [{ "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }],
+              "having": [],
+              "legend": "Loaded::{{instance}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "q-classes-loaded",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Classes Currently Loaded",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total number of classes loaded since JVM start",
+      "fillSpans": false,
+      "id": "w-classes-loaded-total",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm_classes_loaded_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm_classes_loaded_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  { "id": "f055", "key": { "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }, "op": "in", "value": ["{{.instance}}"] },
+                  { "id": "f056", "key": { "dataType": "string", "id": "job--string--tag--false", "isColumn": false, "isJSON": false, "key": "job", "type": "tag" }, "op": "in", "value": ["{{.job}}"] }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [{ "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }],
+              "having": [],
+              "legend": "Total Loaded::{{instance}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "q-classes-loaded-total",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Classes Loaded",
+      "yAxisUnit": "none"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total number of classes unloaded since JVM start",
+      "fillSpans": false,
+      "id": "w-classes-unloaded-total",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "jvm_classes_unloaded_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "jvm_classes_unloaded_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  { "id": "f057", "key": { "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }, "op": "in", "value": ["{{.instance}}"] },
+                  { "id": "f058", "key": { "dataType": "string", "id": "job--string--tag--false", "isColumn": false, "isJSON": false, "key": "job", "type": "tag" }, "op": "in", "value": ["{{.job}}"] }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [{ "dataType": "string", "id": "instance--string--tag--false", "isColumn": false, "isJSON": false, "key": "instance", "type": "tag" }],
+              "having": [],
+              "legend": "Unloaded::{{instance}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "id": "q-classes-unloaded-total",
+        "promql": [{ "disabled": false, "legend": "", "name": "A", "query": "" }],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        { "dataType": "string", "name": "body", "type": "" },
+        { "dataType": "string", "name": "timestamp", "type": "" }
+      ],
+      "selectedTracesFields": [],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Classes Unloaded",
+      "yAxisUnit": "none"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Comprehensive Apache Tomcat monitoring dashboard for SigNoz using Prometheus metrics from JMX Exporter.

- **34 panels** across 8 sections: Overview, Thread Pool, Request Processing, Sessions, JVM Memory, Garbage Collection, Network I/O, Class Loading
- 6 overview value widgets for at-a-glance status
- Variables for instance and job filtering

### Sections

| Section | Panels | Key Metrics |
|---------|--------|-------------|
| Overview | 6 values | Current/busy/max threads, request rate, error rate, active sessions |
| Thread Pool | 2 | `tomcat_threads_current_total`, `tomcat_threads_busy_total` |
| Request Processing | 4 | `tomcat_requestcount_total`, `tomcat_errorcount_total`, `tomcat_processingtime_total` |
| Sessions | 4 | `tomcat_sessions_active_current_total`, created/rejected/expired rates |
| JVM Memory | 3 | `jvm_memory_bytes_used`, `jvm_memory_bytes_max`, pool usage |
| Garbage Collection | 2 | `jvm_gc_collection_seconds_count`, `jvm_gc_collection_seconds_sum` |
| Network I/O | 2 | `tomcat_bytessent_total`, `tomcat_bytesreceived_total` |
| Class Loading | 3 | `jvm_classes_loaded`, loaded/unloaded totals |

### Files

- `tomcat/tomcat-prometheus-v1.json` — Dashboard JSON (2,547 lines)
- `tomcat/readme.md` — Setup guide with OTel Collector config and metrics reference

Closes SigNoz/signoz#9200