### PR TITLE
Add AWS MSK cluster monitoring dashboard (CloudWatch)

### DIFF
--- a/aws-msk/README.md
+++ b/aws-msk/README.md
@@ -1,0 +1,190 @@
+# AWS MSK Cluster Dashboard - CloudWatch
+
+Monitoring dashboard for Amazon Managed Streaming for Apache Kafka (MSK) using CloudWatch metrics ingested via the SigNoz AWS integration.
+
+## Metrics Ingestion
+
+This dashboard uses CloudWatch metrics from the `AWS/Kafka` namespace. Metrics are collected automatically when you enable the [SigNoz AWS integration](https://signoz.io/docs/integrations/aws/) and configure a CloudWatch Metric Stream that includes the `AWS/Kafka` namespace.
+
+### Prerequisites
+
+- An active AWS MSK cluster
+- SigNoz AWS integration configured with CloudWatch Metric Streams
+- The `AWS/Kafka` namespace included in your metric stream filter
+
+### Setup
+
+1. Follow the [SigNoz AWS integration guide](https://signoz.io/docs/integrations/aws/) to connect your AWS account
+2. Ensure your CloudWatch Metric Stream includes the `AWS/Kafka` namespace
+3. Import this dashboard JSON into SigNoz
+
+### Alternative: OpenTelemetry Collector with CloudWatch Receiver
+
+If you prefer using the OpenTelemetry Collector directly, configure the [`awscloudwatch` receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awscloudwatchmetricsreceiver):
+
+```yaml
+receivers:
+  awscloudwatch:
+    region: us-east-1
+    poll_interval: 300s
+    metrics:
+      named:
+        AWS/Kafka:
+          - metric_name: CpuUser
+            statistics: [Maximum]
+          - metric_name: CpuSystem
+            statistics: [Maximum]
+          - metric_name: MemoryUsed
+            statistics: [Maximum]
+          - metric_name: MemoryFree
+            statistics: [Maximum]
+          - metric_name: KafkaDataLogsDiskUsed
+            statistics: [Maximum]
+          - metric_name: BytesInPerSec
+            statistics: [Sum]
+          - metric_name: BytesOutPerSec
+            statistics: [Sum]
+          - metric_name: MessagesInPerSec
+            statistics: [Sum]
+          - metric_name: UnderReplicatedPartitions
+            statistics: [Maximum]
+          - metric_name: UnderMinIsrPartitionCount
+            statistics: [Maximum]
+          - metric_name: PartitionCount
+            statistics: [Maximum]
+          - metric_name: GlobalPartitionCount
+            statistics: [Maximum]
+          - metric_name: MaxOffsetLag
+            statistics: [Maximum]
+          - metric_name: EstimatedMaxTimeLag
+            statistics: [Maximum]
+          - metric_name: BurstBalance
+            statistics: [Minimum]
+          - metric_name: ActiveControllerCount
+            statistics: [Maximum]
+          - metric_name: OfflinePartitionsCount
+            statistics: [Maximum]
+          - metric_name: ConnectionCount
+            statistics: [Maximum]
+          - metric_name: NetworkRxPackets
+            statistics: [Sum]
+          - metric_name: NetworkTxPackets
+            statistics: [Sum]
+
+processors:
+  batch:
+    send_batch_size: 1000
+    timeout: 10s
+  resource/env:
+    attributes:
+      - key: deployment.environment
+        value: production
+        action: upsert
+
+exporters:
+  otlp:
+    endpoint: "ingest.{region}.signoz.cloud:443"
+    tls:
+      insecure: false
+    headers:
+      "signoz-access-token": "<your-ingestion-key>"
+
+service:
+  pipelines:
+    metrics:
+      receivers: [awscloudwatch]
+      processors: [resource/env, batch]
+      exporters: [otlp]
+```
+
+## Variables
+
+- `{{deployment_environment}}`: Deployment environment (e.g., production, staging). Filters all panels to a specific environment.
+- `{{broker_id}}`: MSK Broker ID. Supports multi-select to compare brokers side-by-side. Use "ALL" to view all brokers.
+- `{{topic}}`: Kafka topic name. Filters topic-level panels. Supports multi-select.
+- `{{consumer_group}}`: Consumer group name. Filters consumer lag panels. Supports multi-select.
+
+## Dashboard Panels
+
+### Broker Metrics
+
+Monitors the health and resource utilization of individual MSK brokers.
+
+- **Broker CPU Usage** — User and system CPU utilization per broker, displayed as a stacked graph. High sustained CPU (>80%) indicates the broker may need scaling.
+  - Metrics: `aws_Kafka_CpuUser_max`, `aws_Kafka_CpuSystem_max`
+
+- **Broker Memory Usage** — Memory consumed by each broker in bytes.
+  - Metric: `aws_Kafka_MemoryUsed_max`
+
+- **Network Packets In/Out** — Packet counts for inbound and outbound network traffic per broker.
+  - Metrics: `aws_Kafka_NetworkRxPackets_sum`, `aws_Kafka_NetworkTxPackets_sum`
+
+- **Disk Usage** — Percentage of disk space used for Kafka data logs. Alert if this approaches 85%.
+  - Metric: `aws_Kafka_KafkaDataLogsDiskUsed_max`
+
+- **Broker Network Throughput (Kafka)** — Bytes per second flowing through the Kafka protocol on each broker (producer/consumer traffic).
+  - Metrics: `aws_Kafka_BytesInPerSec_sum`, `aws_Kafka_BytesOutPerSec_sum`
+
+- **Broker Memory Free** — Free memory available on each broker in bytes.
+  - Metric: `aws_Kafka_MemoryFree_max`
+
+### Topic Metrics
+
+Tracks throughput at the topic level to identify hot topics or throughput imbalances.
+
+- **Messages In Per Second** — Rate of messages produced to each topic.
+  - Metric: `aws_Kafka_MessagesInPerSec_sum`
+
+- **Bytes In Per Second** — Data volume produced to each topic per second.
+  - Metric: `aws_Kafka_BytesInPerSec_sum`
+
+- **Bytes Out Per Second** — Data volume consumed from each topic per second.
+  - Metric: `aws_Kafka_BytesOutPerSec_sum`
+
+### Partition Metrics
+
+Monitors partition health across the cluster. Under-replicated or under-min-ISR partitions indicate potential data durability risks.
+
+- **Under-Replicated Partitions** — Partitions where one or more replicas are not in sync. Non-zero values require investigation.
+  - Metric: `aws_Kafka_UnderReplicatedPartitions_max`
+
+- **Under Min ISR Partition Count** — Partitions below the minimum in-sync replica threshold. This is a critical alert condition.
+  - Metric: `aws_Kafka_UnderMinIsrPartitionCount_max`
+
+- **Partition Count** — Total partitions per broker. Uneven distribution indicates a need for partition reassignment.
+  - Metric: `aws_Kafka_PartitionCount_max`
+
+- **Global Partition Count** — Total partitions across the entire cluster.
+  - Metric: `aws_Kafka_GlobalPartitionCount_max`
+
+### Consumer Metrics
+
+Tracks consumer group lag to detect slow or stalled consumers.
+
+- **Consumer Lag — Max Offset Lag** — Maximum offset lag per consumer group in message count. Grouped by consumer group for per-group visibility.
+  - Metric: `aws_Kafka_MaxOffsetLag_max`
+
+- **Consumer Lag — Estimated Time** — Estimated time (seconds) for each consumer group to catch up. Grouped by consumer group.
+  - Metric: `aws_Kafka_EstimatedMaxTimeLag_max`
+
+### AWS Metrics / Cluster Health
+
+Cluster-wide health indicators and AWS-specific resource metrics.
+
+- **Burst Balance** — Remaining CPU burst credits for burstable broker instance types. Approaching 0% means the broker will be throttled.
+  - Metric: `aws_Kafka_BurstBalance_min`
+
+- **Active Controller Count** — Number of active controllers in the cluster. Should always be exactly 1.
+  - Metric: `aws_Kafka_ActiveControllerCount_max`
+
+- **Offline Partitions Count** — Partitions with no active leader. Should always be 0. Any non-zero value is a critical issue.
+  - Metric: `aws_Kafka_OfflinePartitionsCount_max`
+
+- **Connection Count** — Total active connections per broker.
+  - Metric: `aws_Kafka_ConnectionCount_max`
+
+## Reference
+
+- [AWS MSK CloudWatch Metrics](https://docs.aws.amazon.com/msk/latest/developerguide/metrics-details.html)
+- [AWS Distro for OpenTelemetry with MSK](https://aws.amazon.com/about-aws/whats-new/2023/04/apache-kafka-aws-distro-opentelemetry/)
+- [Grafana MSK Dashboard (reference)](https://grafana.com/grafana/dashboards/12009-aws-kafka-cluster/)

--- a/aws-msk/aws-msk-cloudwatch-v1.json
+++ b/aws-msk/aws-msk-cloudwatch-v1.json
@@ -1,0 +1,3828 @@
+{
+  "id": "aws-msk-cloudwatch",
+  "description": "Overview of AWS MSK (Managed Streaming for Apache Kafka) CloudWatch metrics. Provides broker-level, topic-level, partition, consumer lag, and cluster health metrics.",
+  "layout": [
+    {
+      "h": 1,
+      "i": "a2d783f9-6ebe-4348-b071-e529142d412c",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 5,
+      "i": "8e0902b1-a6b9-4fd6-aaf9-3499b95faf6d",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 1
+    },
+    {
+      "h": 5,
+      "i": "2e3543f8-7771-4d10-a1f0-0f76ead15d8a",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 1
+    },
+    {
+      "h": 5,
+      "i": "94eca1eb-48b8-458e-a85f-d4ed971809e2",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 6
+    },
+    {
+      "h": 5,
+      "i": "2fcd147b-7af4-4f75-a697-6227bebbbd41",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 6
+    },
+    {
+      "h": 5,
+      "i": "be97770b-6182-4c4c-863a-027715ecd9a4",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 11
+    },
+    {
+      "h": 1,
+      "i": "b5360bfe-3d94-4943-a175-f793024b0d4d",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 16
+    },
+    {
+      "h": 5,
+      "i": "48bc5bb0-159f-4d33-9517-e85be9fdc8b4",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 17
+    },
+    {
+      "h": 5,
+      "i": "b9fbfcaa-fda9-4617-984e-9b31cbf19c29",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 17
+    },
+    {
+      "h": 5,
+      "i": "4439c9b5-240c-4c09-8f66-d0f71b10aac2",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 22
+    },
+    {
+      "h": 1,
+      "i": "1dc3f19f-0ec5-47c6-a75c-35c897f5356a",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 27
+    },
+    {
+      "h": 5,
+      "i": "ab0a1b9b-da00-4fcb-aea7-fc71c5ac2100",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 28
+    },
+    {
+      "h": 5,
+      "i": "778cb9c0-286e-4f2a-a784-0ba9cb23e935",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 28
+    },
+    {
+      "h": 5,
+      "i": "811eff9b-5a1d-46cb-a1f0-2162e0d60cb2",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 33
+    },
+    {
+      "h": 1,
+      "i": "10f10117-c025-4b2a-9877-c95c58af5166",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 38
+    },
+    {
+      "h": 5,
+      "i": "a622a2f2-8194-47fd-a412-021692af19f1",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 39
+    },
+    {
+      "h": 5,
+      "i": "1f1360e1-5828-4030-92b0-18cceece7019",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 39
+    },
+    {
+      "h": 1,
+      "i": "b06f037e-8184-4787-bcba-e2f4c05d0b4d",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 44
+    },
+    {
+      "h": 5,
+      "i": "b4e742ce-50f7-4313-bf34-49006072297a",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 45
+    },
+    {
+      "h": 5,
+      "i": "061f0cd9-4a8c-4f6d-9d08-bac9b06f9469",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 45
+    },
+    {
+      "h": 5,
+      "i": "7d225a53-c60b-4601-9ffa-b8df51e0af57",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 50
+    },
+    {
+      "h": 5,
+      "i": "f26c8305-eee5-44cb-9616-ac8cf9392fc8",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 50
+    },
+    {
+      "h": 5,
+      "i": "e56cb835-edb2-4c82-97a0-081bdc83a827",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 33
+    },
+    {
+      "h": 5,
+      "i": "87807c14-5976-4733-99e5-13720c9ca5de",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 11
+    }
+  ],
+  "panelMap": {
+    "a2d783f9-6ebe-4348-b071-e529142d412c": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 5,
+          "i": "8e0902b1-a6b9-4fd6-aaf9-3499b95faf6d",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 1
+        },
+        {
+          "h": 5,
+          "i": "2e3543f8-7771-4d10-a1f0-0f76ead15d8a",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 1
+        },
+        {
+          "h": 5,
+          "i": "94eca1eb-48b8-458e-a85f-d4ed971809e2",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 6
+        },
+        {
+          "h": 5,
+          "i": "2fcd147b-7af4-4f75-a697-6227bebbbd41",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 6
+        },
+        {
+          "h": 5,
+          "i": "be97770b-6182-4c4c-863a-027715ecd9a4",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 11
+        },
+        {
+          "h": 5,
+          "i": "87807c14-5976-4733-99e5-13720c9ca5de",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 11
+        }
+      ]
+    },
+    "b5360bfe-3d94-4943-a175-f793024b0d4d": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 5,
+          "i": "48bc5bb0-159f-4d33-9517-e85be9fdc8b4",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 17
+        },
+        {
+          "h": 5,
+          "i": "b9fbfcaa-fda9-4617-984e-9b31cbf19c29",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 17
+        },
+        {
+          "h": 5,
+          "i": "4439c9b5-240c-4c09-8f66-d0f71b10aac2",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 22
+        }
+      ]
+    },
+    "1dc3f19f-0ec5-47c6-a75c-35c897f5356a": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 5,
+          "i": "ab0a1b9b-da00-4fcb-aea7-fc71c5ac2100",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 28
+        },
+        {
+          "h": 5,
+          "i": "778cb9c0-286e-4f2a-a784-0ba9cb23e935",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 28
+        },
+        {
+          "h": 5,
+          "i": "811eff9b-5a1d-46cb-a1f0-2162e0d60cb2",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 33
+        },
+        {
+          "h": 5,
+          "i": "e56cb835-edb2-4c82-97a0-081bdc83a827",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 33
+        }
+      ]
+    },
+    "10f10117-c025-4b2a-9877-c95c58af5166": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 5,
+          "i": "a622a2f2-8194-47fd-a412-021692af19f1",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 39
+        },
+        {
+          "h": 5,
+          "i": "1f1360e1-5828-4030-92b0-18cceece7019",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 39
+        }
+      ]
+    },
+    "b06f037e-8184-4787-bcba-e2f4c05d0b4d": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 5,
+          "i": "b4e742ce-50f7-4313-bf34-49006072297a",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 45
+        },
+        {
+          "h": 5,
+          "i": "061f0cd9-4a8c-4f6d-9d08-bac9b06f9469",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 45
+        },
+        {
+          "h": 5,
+          "i": "7d225a53-c60b-4601-9ffa-b8df51e0af57",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 50
+        },
+        {
+          "h": 5,
+          "i": "f26c8305-eee5-44cb-9616-ac8cf9392fc8",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 50
+        }
+      ]
+    }
+  },
+  "tags": [
+    "aws",
+    "kafka",
+    "msk",
+    "streaming"
+  ],
+  "title": "AWS MSK Cluster",
+  "uploadedGrafana": false,
+  "uuid": "e11c7db5-8056-45df-b2d4-d176032564d7",
+  "variables": {
+    "022a450c-8ccc-4c5e-bd1a-70656684df67": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "The deployment environment for the service.",
+      "id": "022a450c-8ccc-4c5e-bd1a-70656684df67",
+      "modificationUUID": "4570b86f-6c3a-4a9d-9cd2-9561cf0c6821",
+      "multiSelect": false,
+      "name": "deployment_environment",
+      "order": 0,
+      "queryValue": "SELECT JSONExtractString(labels, 'deployment.environment') as deployment_environment\nFROM signoz_metrics.distributed_time_series_v4_1day\nWHERE metric_name like 'aws_Kafka_%'\nGROUP BY deployment_environment",
+      "selectedValue": [
+        ""
+      ],
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "08e59f66-af77-4a7d-a72d-0da774afdab8": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "The MSK broker identifier.",
+      "id": "08e59f66-af77-4a7d-a72d-0da774afdab8",
+      "modificationUUID": "b52e334c-24bd-4bf6-88d2-3256bc7f8198",
+      "multiSelect": true,
+      "name": "broker_id",
+      "order": 1,
+      "queryValue": "SELECT JSONExtractString(labels, 'Broker ID') as broker_id\nFROM signoz_metrics.distributed_time_series_v4_1day\nWHERE metric_name like 'aws_Kafka_%'\nGROUP BY broker_id",
+      "selectedValue": [
+        ""
+      ],
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "231701ac-f20a-4dc4-9391-902afe2e8156": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "The Kafka topic name.",
+      "id": "231701ac-f20a-4dc4-9391-902afe2e8156",
+      "modificationUUID": "5058a087-56aa-47c2-b268-83e822d98199",
+      "multiSelect": true,
+      "name": "topic",
+      "order": 2,
+      "queryValue": "SELECT JSONExtractString(labels, 'Topic') as topic FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name like 'aws_Kafka_%' GROUP BY topic",
+      "selectedValue": [
+        ""
+      ],
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "394325e4-6fbe-45aa-9fe7-de17c8ebbe1f": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "The Kafka consumer group name.",
+      "id": "394325e4-6fbe-45aa-9fe7-de17c8ebbe1f",
+      "modificationUUID": "26756ff3-2445-4774-9a09-7994ae769980",
+      "multiSelect": true,
+      "name": "consumer_group",
+      "order": 3,
+      "queryValue": "SELECT JSONExtractString(labels, 'Consumer Group') as consumer_group FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name like 'aws_Kafka_%' GROUP BY consumer_group",
+      "selectedValue": [
+        ""
+      ],
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "version": "v4",
+  "widgets": [
+    {
+      "description": "",
+      "id": "a2d783f9-6ebe-4348-b071-e529142d412c",
+      "panelTypes": "row",
+      "title": "Broker Metrics"
+    },
+    {
+      "description": "",
+      "fillSpans": false,
+      "id": "8e0902b1-a6b9-4fd6-aaf9-3499b95faf6d",
+      "isStacked": true,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_Kafka_CpuUser_max--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_Kafka_CpuUser_max",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "bd03922c",
+                    "key": {
+                      "dataType": "string",
+                      "id": "Broker ID--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "Broker ID",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.broker_id}}"
+                    ]
+                  },
+                  {
+                    "id": "a1b2c3d4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "Broker ID--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "Broker ID",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "User CPU - Broker {{Broker ID}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_Kafka_CpuSystem_max--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_Kafka_CpuSystem_max",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f349dd6b",
+                    "key": {
+                      "dataType": "string",
+                      "id": "Broker ID--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "Broker ID",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.broker_id}}"
+                    ]
+                  },
+                  {
+                    "id": "e5f6a7b8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "Broker ID--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "Broker ID",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "System CPU - Broker {{Broker ID}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0e35ec75-0e06-4ce6-adb8-b6f0179c9ccf",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Broker CPU Usage",
+      "yAxisUnit": "percent"
+    },
+    {
+      "description": "",
+      "fillSpans": false,
+      "id": "2e3543f8-7771-4d10-a1f0-0f76ead15d8a",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_Kafka_MemoryUsed_max--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_Kafka_MemoryUsed_max",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "eef79cec",
+                    "key": {
+                      "dataType": "string",
+                      "id": "Broker ID--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "Broker ID",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.broker_id}}"
+                    ]
+                  },
+                  {
+                    "id": "c9d0e1f2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "Broker ID--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "Broker ID",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Broker {{Broker ID}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d79b3f54-9a1c-4fa7-b7d5-daac63af7c50",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Broker Memory Usage",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "",
+      "fillSpans": false,
+      "id": "94eca1eb-48b8-458e-a85f-d4ed971809e2",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_Kafka_NetworkRxPackets_sum--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_Kafka_NetworkRxPackets_sum",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "d37b6164",
+                    "key": {
+                      "dataType": "string",
+                      "id": "Broker ID--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "Broker ID",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.broker_id}}"
+                    ]
+                  },
+                  {
+                    "id": "a3b4c5d6",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "Broker ID--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "Broker ID",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Rx - Broker {{Broker ID}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_Kafka_NetworkTxPackets_sum--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_Kafka_NetworkTxPackets_sum",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "ffafc96a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "Broker ID--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "Broker ID",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.broker_id}}"
+                    ]
+                  },
+                  {
+                    "id": "e7f8a9b0",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "Broker ID--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "Broker ID",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Tx - Broker {{Broker ID}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "eecc41c3-069f-4d39-928f-37cedcee8713",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Network Packets In/Out",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "fillSpans": false,
+      "id": "2fcd147b-7af4-4f75-a697-6227bebbbd41",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_Kafka_KafkaDataLogsDiskUsed_max--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_Kafka_KafkaDataLogsDiskUsed_max",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "2be4d4a5",
+                    "key": {
+                      "dataType": "string",
+                      "id": "Broker ID--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "Broker ID",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.broker_id}}"
+                    ]
+                  },
+                  {
+                    "id": "c1d2e3f4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "Broker ID--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "Broker ID",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Broker {{Broker ID}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "5fb1c324-bee7-4182-ace6-c7115fc1f294",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Disk Usage",
+      "yAxisUnit": "percent"
+    },
+    {
+      "description": "",
+      "fillSpans": false,
+      "id": "be97770b-6182-4c4c-863a-027715ecd9a4",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_Kafka_BytesInPerSec_sum--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_Kafka_BytesInPerSec_sum",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "1d8afc69",
+                    "key": {
+                      "dataType": "string",
+                      "id": "Broker ID--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "Broker ID",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.broker_id}}"
+                    ]
+                  },
+                  {
+                    "id": "a5b6c7d8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "Broker ID--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "Broker ID",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Bytes In - Broker {{Broker ID}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_Kafka_BytesOutPerSec_sum--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_Kafka_BytesOutPerSec_sum",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "56e38bdf",
+                    "key": {
+                      "dataType": "string",
+                      "id": "Broker ID--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "Broker ID",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.broker_id}}"
+                    ]
+                  },
+                  {
+                    "id": "e9f0a1b2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "Broker ID--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "Broker ID",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Bytes Out - Broker {{Broker ID}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "2d094111-1411-4570-ac0c-fa21a10e27a5",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Broker Network Throughput (Kafka)",
+      "yAxisUnit": "binBps"
+    },
+    {
+      "description": "",
+      "fillSpans": false,
+      "id": "87807c14-5976-4733-99e5-13720c9ca5de",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_Kafka_MemoryFree_max--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_Kafka_MemoryFree_max",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f3a4b5c6",
+                    "key": {
+                      "dataType": "string",
+                      "id": "Broker ID--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "Broker ID",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.broker_id}}"
+                    ]
+                  },
+                  {
+                    "id": "d7e8f9a0",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "Broker ID--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "Broker ID",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Broker {{Broker ID}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "19d0d10f-65bd-41e8-8756-c5411eb69427",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Broker Memory Free",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "",
+      "id": "b5360bfe-3d94-4943-a175-f793024b0d4d",
+      "panelTypes": "row",
+      "title": "Topic Metrics"
+    },
+    {
+      "description": "",
+      "fillSpans": false,
+      "id": "48bc5bb0-159f-4d33-9517-e85be9fdc8b4",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_Kafka_MessagesInPerSec_sum--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_Kafka_MessagesInPerSec_sum",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "536b8d73",
+                    "key": {
+                      "dataType": "string",
+                      "id": "Broker ID--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "Broker ID",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.broker_id}}"
+                    ]
+                  },
+                  {
+                    "id": "c3d4e5f6",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  },
+                  {
+                    "id": "a7b8c9d0",
+                    "key": {
+                      "dataType": "string",
+                      "id": "Topic--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "Topic",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.topic}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "Topic--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "Topic",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{Topic}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ad1e4a94-2f3f-487e-9be6-90c1a3ad75aa",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Messages In Per Second",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "fillSpans": false,
+      "id": "b9fbfcaa-fda9-4617-984e-9b31cbf19c29",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_Kafka_BytesInPerSec_sum--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_Kafka_BytesInPerSec_sum",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "836bbfe9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "Broker ID--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "Broker ID",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.broker_id}}"
+                    ]
+                  },
+                  {
+                    "id": "e1f2a3b4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  },
+                  {
+                    "id": "c5d6e7f8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "Topic--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "Topic",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.topic}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "Topic--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "Topic",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{Topic}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "fff03dee-b074-40bf-892c-6f4247023899",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Bytes In Per Second (by Topic)",
+      "yAxisUnit": "binBps"
+    },
+    {
+      "description": "",
+      "fillSpans": false,
+      "id": "4439c9b5-240c-4c09-8f66-d0f71b10aac2",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_Kafka_BytesOutPerSec_sum--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_Kafka_BytesOutPerSec_sum",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "31c56376",
+                    "key": {
+                      "dataType": "string",
+                      "id": "Broker ID--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "Broker ID",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.broker_id}}"
+                    ]
+                  },
+                  {
+                    "id": "a9b0c1d2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  },
+                  {
+                    "id": "e3f4a5b6",
+                    "key": {
+                      "dataType": "string",
+                      "id": "Topic--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "Topic",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.topic}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "Topic--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "Topic",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{Topic}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b0ff6eaa-f3db-4219-ae9a-619cfeda860e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Bytes Out Per Second (by Topic)",
+      "yAxisUnit": "binBps"
+    },
+    {
+      "description": "",
+      "id": "1dc3f19f-0ec5-47c6-a75c-35c897f5356a",
+      "panelTypes": "row",
+      "title": "Partition Metrics"
+    },
+    {
+      "description": "",
+      "fillSpans": false,
+      "id": "ab0a1b9b-da00-4fcb-aea7-fc71c5ac2100",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_Kafka_UnderReplicatedPartitions_max--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_Kafka_UnderReplicatedPartitions_max",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "max",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b85dbc46",
+                    "key": {
+                      "dataType": "string",
+                      "id": "Broker ID--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "Broker ID",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.broker_id}}"
+                    ]
+                  },
+                  {
+                    "id": "c7d8e9f0",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "Broker ID--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "Broker ID",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Broker {{Broker ID}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "max",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "max"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8e04016b-879c-4c44-bf83-bb9c0d997973",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Under-Replicated Partitions",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "fillSpans": false,
+      "id": "778cb9c0-286e-4f2a-a784-0ba9cb23e935",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_Kafka_UnderMinIsrPartitionCount_max--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_Kafka_UnderMinIsrPartitionCount_max",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "max",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "bebeab59",
+                    "key": {
+                      "dataType": "string",
+                      "id": "Broker ID--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "Broker ID",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.broker_id}}"
+                    ]
+                  },
+                  {
+                    "id": "a0b1c2d3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "Broker ID--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "Broker ID",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Broker {{Broker ID}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "max",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "max"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "f8e420f1-cc50-4615-ac67-a6b21740266c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Under Min ISR Partition Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "fillSpans": false,
+      "id": "811eff9b-5a1d-46cb-a1f0-2162e0d60cb2",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_Kafka_PartitionCount_max--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_Kafka_PartitionCount_max",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "212829bb",
+                    "key": {
+                      "dataType": "string",
+                      "id": "Broker ID--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "Broker ID",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.broker_id}}"
+                    ]
+                  },
+                  {
+                    "id": "e4f5a6b7",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "Broker ID--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "Broker ID",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Broker {{Broker ID}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ab60902a-d95a-43cf-9f50-6ddeb445dde4",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Partition Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "fillSpans": false,
+      "id": "e56cb835-edb2-4c82-97a0-081bdc83a827",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_Kafka_GlobalPartitionCount_max--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_Kafka_GlobalPartitionCount_max",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b9c0d1e2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "1496186b-f6dc-4c80-b064-111b8f0ac7a1",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Global Partition Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "id": "10f10117-c025-4b2a-9877-c95c58af5166",
+      "panelTypes": "row",
+      "title": "Consumer Metrics"
+    },
+    {
+      "description": "",
+      "fillSpans": false,
+      "id": "a622a2f2-8194-47fd-a412-021692af19f1",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_Kafka_MaxOffsetLag_max--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_Kafka_MaxOffsetLag_max",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "max",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "c8d9e0f1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  },
+                  {
+                    "id": "a2b3c4d5",
+                    "key": {
+                      "dataType": "string",
+                      "id": "Consumer Group--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "Consumer Group",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.consumer_group}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "Consumer Group--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "Consumer Group",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{Consumer Group}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "max",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "max"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0aed519c-c17e-46f4-95a5-c7f8825ae741",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Consumer Lag - Max Offset Lag",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "fillSpans": false,
+      "id": "1f1360e1-5828-4030-92b0-18cceece7019",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_Kafka_EstimatedMaxTimeLag_max--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_Kafka_EstimatedMaxTimeLag_max",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "max",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "e6f7a8b9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  },
+                  {
+                    "id": "ca0b1c2d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "Consumer Group--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "Consumer Group",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.consumer_group}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "Consumer Group--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "Consumer Group",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{Consumer Group}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "max",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "max"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "056156df-4d4f-4339-a277-cb9f51e15988",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Consumer Lag - Estimated Time",
+      "yAxisUnit": "s"
+    },
+    {
+      "description": "",
+      "id": "b06f037e-8184-4787-bcba-e2f4c05d0b4d",
+      "panelTypes": "row",
+      "title": "AWS Metrics / Cluster Health"
+    },
+    {
+      "description": "",
+      "fillSpans": false,
+      "id": "b4e742ce-50f7-4313-bf34-49006072297a",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_Kafka_BurstBalance_min--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_Kafka_BurstBalance_min",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "min",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "891caea3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "Broker ID--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "Broker ID",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.broker_id}}"
+                    ]
+                  },
+                  {
+                    "id": "d3e4f5a6",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "Broker ID--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "Broker ID",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Broker {{Broker ID}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "min",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "min"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "0c6c93de-f5e3-45c7-8a72-1f91d6afc990",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Burst Balance",
+      "yAxisUnit": "percent"
+    },
+    {
+      "description": "",
+      "fillSpans": false,
+      "id": "061f0cd9-4a8c-4f6d-9d08-bac9b06f9469",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_Kafka_ActiveControllerCount_max--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_Kafka_ActiveControllerCount_max",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b7c8d9e0",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "2d45183f-acfb-447f-a6e5-c77a59c31b71",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Controller Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "fillSpans": false,
+      "id": "7d225a53-c60b-4601-9ffa-b8df51e0af57",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_Kafka_OfflinePartitionsCount_max--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_Kafka_OfflinePartitionsCount_max",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "latest",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f1a2b3c4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "latest"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "00a4b54e-5012-4e98-85db-d6a40a193efc",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Offline Partitions Count",
+      "yAxisUnit": "none"
+    },
+    {
+      "description": "",
+      "fillSpans": false,
+      "id": "f26c8305-eee5-44cb-9616-ac8cf9392fc8",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "aws_Kafka_ConnectionCount_max--float64--Gauge--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "aws_Kafka_ConnectionCount_max",
+                "type": "Gauge"
+              },
+              "aggregateOperator": "avg",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "453fdef6",
+                    "key": {
+                      "dataType": "string",
+                      "id": "Broker ID--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "Broker ID",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.broker_id}}"
+                    ]
+                  },
+                  {
+                    "id": "d5e6f7a8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "deployment.environment--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "deployment.environment",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "{{.deployment_environment}}"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "Broker ID--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "Broker ID",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "Broker {{Broker ID}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60,
+              "timeAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d99ad940-723d-4863-8839-d65a10f1dea5",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Connection Count",
+      "yAxisUnit": "none"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a comprehensive AWS MSK (Managed Streaming for Apache Kafka) dashboard template using CloudWatch metrics from the `AWS/Kafka` namespace.

- **24 widgets** across **5 collapsible sections**: Broker Metrics, Topic Metrics, Partition Metrics, Consumer Metrics, AWS Metrics / Cluster Health
- **4 variables**: `deployment_environment`, `broker_id` (multi-select), `topic` (multi-select), `consumer_group` (multi-select)
- Metric names sourced from SigNoz's official MSK integration definition
- Semantic aggregation: `max` for safety metrics (under-replicated partitions, ISR), `min` for floor metrics (burst balance), `sum` for throughput, `avg` for gauges
- Cluster-level panels (ActiveControllerCount, OfflinePartitionsCount, GlobalPartitionCount) correctly omit broker-level filtering
- Consumer lag panels grouped by Consumer Group (not Broker ID) matching CloudWatch dimension model
- Full README with SigNoz AWS integration setup + standalone OTel Collector config

### Panels

| Section | Panels |
|---------|--------|
| Broker Metrics | CPU (stacked), Memory Used, Memory Free, Network Packets, Disk Usage, Network Throughput |
| Topic Metrics | Messages In/s, Bytes In/s, Bytes Out/s — grouped by topic |
| Partition Metrics | Under-Replicated, Under Min ISR, Per-Broker Count, Global Count |
| Consumer Metrics | Max Offset Lag, Estimated Time Lag — grouped by consumer group |
| Cluster Health | Burst Balance, Active Controller (value), Offline Partitions (value), Connections |

### Notes

- Screenshots: Happy to add screenshots once I have access to a SigNoz test tenant with MSK metrics. Please let me know if you can invite me via Slack.
- Follows the naming convention `aws-msk-cloudwatch-v1.json` per CONTRIBUTING.md

Resolves SigNoz/signoz#6036

/claim #6036