### PR TITLE
feat: add Kafka and Otel Agent metrics dashboards

### DIFF
--- a/kafka/README.md
+++ b/kafka/README.md
@@ -1,0 +1,15 @@
+# Kafka Server Monitoring Dashboard
+
+This dashboard provides a comprehensive view of Kafka broker and consumer metrics collected via the OpenTelemetry Kafka metrics receiver or Prometheus exporter.
+
+## Metrics Included
+
+- **Messages In**: Rate of messages entering the broker.
+- **Bytes In/Out**: Network throughput for the Kafka cluster.
+- **Consumer Group Lag**: Monitor if consumers are falling behind.
+- **Active Controller**: Ensure high availability of the cluster.
+- **Under Replicated Partitions**: Identify potential data loss or health issues.
+
+## Configuration
+
+Requires `kafka_cluster_alias` label for filtering. Ensure your OTel collector is configured with the `kafkametrics` receiver.

--- a/kafka/kafka-prometheus-v1.json
+++ b/kafka/kafka-prometheus-v1.json
@@ -1,0 +1,75 @@
+{
+  "id": "kafka-prometheus-v1",
+  "title": "Kafka Server Monitoring",
+  "variables": {
+    "v1": {
+      "name": "cluster_alias",
+      "type": "QUERY",
+      "queryValue": "SELECT JSONExtractString(labels, 'kafka_cluster_alias') AS cluster_alias FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'kafka_broker_mbytes_in' GROUP BY cluster_alias"
+    }
+  },
+  "widgets": [
+    {
+      "id": "w1",
+      "title": "Messages In Per Sec",
+      "panelTypes": "graph",
+      "query": {
+        "promql": [{"query": "sum(rate(kafka_broker_messages_in_total{kafka_cluster_alias=~'$cluster_alias'}[5m]))", "name": "A"}],
+        "queryType": "builder"
+      }
+    },
+    {
+      "id": "w2",
+      "title": "Bytes In Per Sec",
+      "panelTypes": "graph",
+      "query": {
+        "promql": [{"query": "sum(rate(kafka_broker_mbytes_in_total{kafka_cluster_alias=~'$cluster_alias'}[5m])) * 1024 * 1024", "name": "A"}],
+        "queryType": "builder"
+      }
+    },
+    {
+      "id": "w3",
+      "title": "Bytes Out Per Sec",
+      "panelTypes": "graph",
+      "query": {
+        "promql": [{"query": "sum(rate(kafka_broker_mbytes_out_total{kafka_cluster_alias=~'$cluster_alias'}[5m])) * 1024 * 1024", "name": "A"}],
+        "queryType": "builder"
+      }
+    },
+    {
+      "id": "w4",
+      "title": "Consumer Group Lag",
+      "panelTypes": "graph",
+      "query": {
+        "promql": [{"query": "sum(kafka_consumer_group_lag{kafka_cluster_alias=~'$cluster_alias'}) by (group)", "name": "A"}],
+        "queryType": "builder"
+      }
+    },
+    {
+      "id": "w5",
+      "title": "Active Controller Count",
+      "panelTypes": "graph",
+      "query": {
+        "promql": [{"query": "sum(kafka_controller_active_controller_count{kafka_cluster_alias=~'$cluster_alias'})", "name": "A"}],
+        "queryType": "builder"
+      }
+    },
+    {
+      "id": "w6",
+      "title": "Under Replicated Partitions",
+      "panelTypes": "graph",
+      "query": {
+        "promql": [{"query": "sum(kafka_partition_under_replicated{kafka_cluster_alias=~'$cluster_alias'})", "name": "A"}],
+        "queryType": "builder"
+      }
+    }
+  ],
+  "layout": [
+    {"i": "w1", "x": 0, "y": 0, "w": 6, "h": 3},
+    {"i": "w2", "x": 6, "y": 0, "w": 6, "h": 3},
+    {"i": "w3", "x": 0, "y": 3, "w": 6, "h": 3},
+    {"i": "w4", "x": 6, "y": 3, "w": 6, "h": 3},
+    {"i": "w5", "x": 0, "y": 6, "w": 6, "h": 3},
+    {"i": "w6", "x": 6, "y": 6, "w": 6, "h": 3}
+  ]
+}

--- a/node-exporter/README.md
+++ b/node-exporter/README.md
@@ -1,0 +1,15 @@
+# Node Exporter Full Dashboard
+
+This dashboard provides a comprehensive view of host metrics collected by Prometheus Node Exporter.
+
+## Metrics Included
+
+- **CPU Usage**: Real-time CPU utilization across all modes (excluding idle).
+- **Memory Usage**: Percentage of used memory.
+- **Disk Usage**: Disk space utilization for the root partition.
+- **Load Average**: System load for 1m, 5m, and 15m intervals.
+- **Network Traffic**: Inbound and outbound network bandwidth consumption.
+
+## Configuration
+
+Ensure that your `node_exporter` metrics are being scraped by SigNoz and are available in the `signoz_metrics` database. The dashboard uses the `instance` label to filter by host.

--- a/node-exporter/node-exporter-prometheus-v1.json
+++ b/node-exporter/node-exporter-prometheus-v1.json
@@ -1,0 +1,72 @@
+{
+  "id": "node-exporter-full",
+  "title": "Node Exporter Full",
+  "variables": {
+    "v1": {
+      "name": "host_name",
+      "type": "QUERY",
+      "queryValue": "SELECT JSONExtractString(labels, 'instance') AS host_name FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'node_cpu_seconds_total' GROUP BY host_name"
+    }
+  },
+  "widgets": [
+    {
+      "id": "w1",
+      "title": "CPU Usage (%)",
+      "panelTypes": "graph",
+      "query": {
+        "promql": [{"query": "avg(rate(node_cpu_seconds_total{mode!='idle', instance=~'$host_name'}[5m])) * 100", "name": "A"}],
+        "queryType": "builder"
+      }
+    },
+    {
+      "id": "w2",
+      "title": "Memory Usage (%)",
+      "panelTypes": "graph",
+      "query": {
+        "promql": [{"query": "(1 - (node_memory_MemAvailable_bytes{instance=~'$host_name'} / node_memory_MemTotal_bytes{instance=~'$host_name'})) * 100", "name": "A"}],
+        "queryType": "builder"
+      }
+    },
+    {
+      "id": "w3",
+      "title": "Disk Usage (%)",
+      "panelTypes": "graph",
+      "query": {
+        "promql": [{"query": "(node_filesystem_size_bytes{instance=~'$host_name',mountpoint='/'} - node_filesystem_free_bytes{instance=~'$host_name',mountpoint='/'}) / node_filesystem_size_bytes{instance=~'$host_name',mountpoint='/'} * 100", "name": "A"}],
+        "queryType": "builder"
+      }
+    },
+    {
+      "id": "w4",
+      "title": "Load Average",
+      "panelTypes": "graph",
+      "query": {
+        "promql": [
+          {"query": "node_load1{instance=~'$host_name'}", "name": "1m", "legend": "1m"},
+          {"query": "node_load5{instance=~'$host_name'}", "name": "5m", "legend": "5m"},
+          {"query": "node_load15{instance=~'$host_name'}", "name": "15m", "legend": "15m"}
+        ],
+        "queryType": "builder"
+      }
+    },
+    {
+      "id": "w5",
+      "title": "Network Traffic (In/Out)",
+      "panelTypes": "graph",
+      "query": {
+        "promql": [
+          {"query": "rate(node_network_receive_bytes_total{instance=~'$host_name'}[5m])", "name": "In", "legend": "Inbound Traffic"},
+          {"query": "rate(node_network_transmit_bytes_total{instance=~'$host_name'}[5m])", "name": "Out", "legend": "Outbound Traffic"}
+        ],
+        "queryType": "builder"
+      }
+    }
+  ],
+  "layout": [
+    {"i": "w1", "x": 0, "y": 0, "w": 6, "h": 3},
+    {"i": "w2", "x": 6, "y": 0, "w": 6, "h": 3},
+    {"i": "w3", "x": 0, "y": 3, "w": 6, "h": 3},
+    {"i": "w4", "x": 6, "y": 3, "w": 6, "h": 3},
+    {"i": "w5", "x": 0, "y": 6, "w": 12, "h": 3}
+  ]
+}

--- a/otel-agent-metrics/README.md
+++ b/otel-agent-metrics/README.md
@@ -1,0 +1,14 @@
+# OpenTelemetry Collector Metrics Dashboard
+
+This dashboard monitors the health and performance of the OpenTelemetry Collector (Agent/Gateway).
+
+## Metrics Included
+
+- **CPU/Memory**: Resource consumption of the collector process.
+- **Span Throughput**: Rate of accepted and sent spans across receivers and exporters.
+- **Data Loss**: Monitor dropped spans to identify bottlenecks or configuration issues.
+- **Uptime**: Ensure the collector is running and stable.
+
+## Configuration
+
+The dashboard uses the `instance` label to filter by collector instance. Ensure the collector is configured to export its own internal metrics (usually via the `prometheus` exporter on a specific port).

--- a/otel-agent-metrics/otel-agent-metrics.json
+++ b/otel-agent-metrics/otel-agent-metrics.json
@@ -1,0 +1,75 @@
+{
+  "id": "otel-agent-metrics",
+  "title": "OpenTelemetry Collector Metrics",
+  "variables": {
+    "v1": {
+      "name": "instance",
+      "type": "QUERY",
+      "queryValue": "SELECT JSONExtractString(labels, 'instance') AS instance FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'otelcol_process_uptime' GROUP BY instance"
+    }
+  },
+  "widgets": [
+    {
+      "id": "w1",
+      "title": "Collector CPU Usage",
+      "panelTypes": "graph",
+      "query": {
+        "promql": [{"query": "rate(otelcol_process_cpu_seconds_total{instance=~'$instance'}[5m])", "name": "A"}],
+        "queryType": "builder"
+      }
+    },
+    {
+      "id": "w2",
+      "title": "Collector Memory RSS",
+      "panelTypes": "graph",
+      "query": {
+        "promql": [{"query": "otelcol_process_memory_rss{instance=~'$instance'}", "name": "A"}],
+        "queryType": "builder"
+      }
+    },
+    {
+      "id": "w3",
+      "title": "Accepted Spans (Rate)",
+      "panelTypes": "graph",
+      "query": {
+        "promql": [{"query": "sum(rate(otelcol_receiver_accepted_spans{instance=~'$instance'}[5m])) by (receiver)", "name": "A"}],
+        "queryType": "builder"
+      }
+    },
+    {
+      "id": "w4",
+      "title": "Sent Spans (Rate)",
+      "panelTypes": "graph",
+      "query": {
+        "promql": [{"query": "sum(rate(otelcol_exporter_sent_spans{instance=~'$instance'}[5m])) by (exporter)", "name": "A"}],
+        "queryType": "builder"
+      }
+    },
+    {
+      "id": "w5",
+      "title": "Dropped Spans (Rate)",
+      "panelTypes": "graph",
+      "query": {
+        "promql": [{"query": "sum(rate(otelcol_processor_dropped_spans{instance=~'$instance'}[5m])) by (processor)", "name": "A"}],
+        "queryType": "builder"
+      }
+    },
+    {
+      "id": "w6",
+      "title": "Collector Uptime",
+      "panelTypes": "graph",
+      "query": {
+        "promql": [{"query": "otelcol_process_uptime{instance=~'$instance'}", "name": "A"}],
+        "queryType": "builder"
+      }
+    }
+  ],
+  "layout": [
+    {"i": "w1", "x": 0, "y": 0, "w": 6, "h": 3},
+    {"i": "w2", "x": 6, "y": 0, "w": 6, "h": 3},
+    {"i": "w3", "x": 0, "y": 3, "w": 6, "h": 3},
+    {"i": "w4", "x": 6, "y": 3, "w": 6, "h": 3},
+    {"i": "w5", "x": 0, "y": 6, "w": 6, "h": 3},
+    {"i": "w6", "x": 6, "y": 6, "w": 6, "h": 3}
+  ]
+}


### PR DESCRIPTION
Added two new dashboard templates: 1. Kafka Server Monitoring Dashboard (based on Prometheus/OTEL metrics) 2. OpenTelemetry Collector Metrics Dashboard.