### PR TITLE
feat: add Istio service mesh dashboard (Prometheus)

### DIFF
--- a/istio-prometheus/README.md
+++ b/istio-prometheus/README.md
@@ -1,0 +1,151 @@
+# Istio Service Mesh Dashboard - Prometheus
+
+Monitor an Istio service mesh in SigNoz using the standard Istio Prometheus telemetry exposed by every Envoy sidecar (`istio_requests_total`, `istio_request_duration_milliseconds`, `istio_request_bytes`, `istio_response_bytes`, `istio_tcp_*_total`).
+
+The dashboard ships 17 panels across five sections — General Overview, Traffic Management, Performance, Error Metrics, and TCP Data Plane — and three filter variables for namespace / workload / source selection.
+
+## Metrics Ingestion
+
+Istio's data plane (Envoy sidecar) exposes Prometheus metrics on each pod at `:15090/stats/prometheus`. The control plane (`istiod`) exposes its metrics on `:15014/metrics`. Scrape both with the OpenTelemetry Collector Prometheus receiver and forward to SigNoz.
+
+### Option A — Annotate-and-scrape (recommended for in-cluster sidecars)
+
+Istio injection adds the `prometheus.io/scrape: "true"`, `prometheus.io/path: "/stats/prometheus"`, and `prometheus.io/port: "15090"` annotations to every meshed pod. The Prometheus receiver can pick these up via Kubernetes service discovery.
+
+Add this job to the `prometheus` receiver in your `otel-config.yaml`:
+
+```yaml
+receivers:
+  prometheus:
+    config:
+      global:
+        scrape_interval: 30s
+      scrape_configs:
+        # Istio sidecars (Envoy)
+        - job_name: 'envoy-stats'
+          metrics_path: /stats/prometheus
+          kubernetes_sd_configs:
+            - role: pod
+          relabel_configs:
+            - source_labels: [__meta_kubernetes_pod_container_port_name]
+              action: keep
+              regex: '.*-envoy-prom'
+            - source_labels: [__meta_kubernetes_pod_label_app]
+              action: replace
+              target_label: app
+            - source_labels: [__meta_kubernetes_namespace]
+              action: replace
+              target_label: namespace
+
+        # Istio control plane (istiod)
+        - job_name: 'istiod'
+          kubernetes_sd_configs:
+            - role: endpoints
+              namespaces:
+                names:
+                  - istio-system
+          relabel_configs:
+            - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+              action: keep
+              regex: 'istiod;http-monitoring'
+```
+
+### Option B — Static targets
+
+If you do not run the OpenTelemetry Collector inside the cluster, port-forward (or expose) the proxies and scrape statically:
+
+```yaml
+receivers:
+  prometheus:
+    config:
+      global:
+        scrape_interval: 30s
+      scrape_configs:
+        - job_name: istio-mesh
+          metrics_path: /stats/prometheus
+          static_configs:
+            - targets: ['<pod-ip>:15090']
+```
+
+### Pipeline
+
+Wire the `prometheus` receiver into your metrics pipeline alongside the SigNoz exporter:
+
+```yaml
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp, prometheus]
+      processors: [batch]
+      exporters: [otlp/signoz]
+```
+
+The dashboard expects the metrics under their stock Istio names — no metric renaming is required at the collector. The standard label set (`reporter`, `destination_workload`, `destination_workload_namespace`, `source_workload`, `response_code`, `response_flags`, `request_protocol`, `connection_security_policy`) is preserved by Istio's default telemetry config.
+
+### Reporter filter — why every panel pins `reporter=destination`
+
+Istio's telemetry pipeline emits the same request twice — once from the source proxy (`reporter=source`) and once from the destination proxy (`reporter=destination`). Counting both would double every count. All counter and histogram queries in this dashboard pin `reporter=destination` so totals match reality. This matches the official Istio recommendation for monitoring server-side traffic.
+
+If you want to monitor outgoing traffic from a specific source workload's perspective instead, edit the panel's filter and switch to `reporter=source`.
+
+## Variables
+
+| Variable | Description |
+|---|---|
+| `{{destination_workload_namespace}}` | Filter by destination workload namespace. Multi-select, includes "ALL". |
+| `{{destination_workload}}` | Filter by destination workload. Multi-select, cascades from namespace. |
+| `{{source_workload}}` | Filter by source workload. Multi-select, useful for service-to-service drill-down. |
+
+## Dashboard Panels
+
+### General Overview (4 value tiles)
+
+| Panel | Metric / Computation |
+|---|---|
+| **Total Request Rate** | `sum_rate(istio_requests_total)` |
+| **Active Destination Workloads** | `sum_rate(istio_requests_total)` grouped by `destination_workload`, merged active count |
+| **Average Request Latency** | Formula `A/B` where A = `sum_rate(istio_request_duration_milliseconds_sum)`, B = `sum_rate(istio_request_duration_milliseconds_count)` (repo precedent: `apm/apm-metrics.json` "Database Calls Avg Duration") |
+| **Error Rate (5xx %)** | Formula `(A/B)*100` where A = 5xx-only request rate, B = total request rate |
+
+### Traffic Management
+
+| Panel | Metric |
+|---|---|
+| **Request Rate by Destination Workload** | `istio_requests_total` grouped by `destination_workload` |
+| **Request Rate by Response Code** | `istio_requests_total` grouped by `response_code` (stacked) |
+| **Request Protocol Distribution** | `istio_requests_total` grouped by `request_protocol` (stacked) |
+| **Connection Security Policy (mTLS coverage)** | `istio_requests_total` grouped by `connection_security_policy` (stacked) |
+
+### Performance
+
+| Panel | Metric |
+|---|---|
+| **Average Request Latency Over Time** | `A/B` over `istio_request_duration_milliseconds_{sum,count}` (mesh-wide) |
+| **Average Latency by Destination Workload** | Same formula, grouped by `destination_workload` |
+| **Throughput by Destination Workload** | `istio_requests_total` rate grouped by `destination_workload` (stacked) |
+| **Average Request / Response Body Sizes** | Two formulas: `A/B` for request bytes, `C/D` for response bytes |
+
+> **Note on percentile latency.** This first version reports averages (rate-of-sum / rate-of-count) rather than p50/p95/p99, because SigNoz Query Builder's `Histogram + p99` aggregator pattern is established for traces-source metrics, not for Prometheus-source histograms in this repo. An average latency panel is the conservative choice that is guaranteed to render against any Prometheus histogram. Future versions can extend with bucket-based percentile panels once a Prometheus-source p99 example is established in the repo.
+
+### Error Metrics
+
+| Panel | Metric |
+|---|---|
+| **HTTP Error Rates (4xx / 5xx)** | `istio_requests_total` filtered to 4xx/5xx code list, grouped by `response_code` (stacked) |
+| **Failed Requests by Destination Workload (5xx)** | 5xx-only rate grouped by `destination_workload` |
+| **Envoy Response Flags** | `istio_requests_total` grouped by `response_flags` (excluding `-`). Surfaces UH/UF/NR/UR proxy events. |
+
+> **Note on filter syntax.** SigNoz Query Builder filters use explicit lists (`op: in`) rather than range comparisons because `response_code` is a string-typed Prometheus label. The 4xx and 5xx code lists are enumerated explicitly inside each affected panel.
+
+### TCP Data Plane
+
+| Panel | Metric |
+|---|---|
+| **TCP Connection Rate (Opened / Closed)** | Rate of `istio_tcp_connections_opened_total` and `istio_tcp_connections_closed_total` |
+| **TCP Throughput (Sent / Received)** | Rate of `istio_tcp_sent_bytes_total` and `istio_tcp_received_bytes_total` |
+
+## References
+
+- [Istio Standard Metrics](https://istio.io/latest/docs/reference/config/metrics/) — canonical list of mesh metrics and their labels.
+- [Istio Observability — Querying Metrics from Prometheus](https://istio.io/latest/docs/tasks/observability/metrics/querying-metrics/) — scrape configuration guidance.
+- [SigNoz Prometheus Receiver setup](https://signoz.io/docs/userguide/send-metrics/) — wiring the OpenTelemetry Collector Prometheus receiver into a SigNoz pipeline.

--- a/istio-prometheus/istio-prometheus-v1.json
+++ b/istio-prometheus/istio-prometheus-v1.json
@@ -1,0 +1,3571 @@
+{
+  "description": "Istio service-mesh monitoring dashboard powered by the standard Istio Prometheus telemetry (`istio_requests_total`, `istio_request_duration_milliseconds`, `istio_request_bytes`, `istio_response_bytes`, `istio_tcp_*_total`). Provides general overview, traffic management, performance averages, error metrics, and TCP data-plane visibility. All counter and histogram queries pin `reporter=destination` to avoid double-counting (Istio emits identical telemetry from both source and destination proxies). Filter by destination namespace / destination workload / source workload via the variables at the top.",
+  "image": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxOCIgaGVpZ2h0PSIxOCIgdmlld0JveD0iMCAwIDQwIDQwIj48cGF0aCBkPSJNMjAgMyBMNCAzNyBMMzYgMzcgWiIgZmlsbD0iIzQ2NkJCMCIvPjxwYXRoIGQ9Ik0yMCAxMyBMMTIgMzMgTDI4IDMzIFoiIGZpbGw9IndoaXRlIi8+PC9zdmc+",
+  "layout": [
+    {
+      "h": 4,
+      "i": "08030d22-5a6b-4d07-b198-0c1fab4aaf65",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 4,
+      "i": "0314f7a0-fde8-484a-9679-e212474bba59",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 3,
+      "y": 0
+    },
+    {
+      "h": 4,
+      "i": "25aa42ab-0c22-4800-b568-04c395a930b2",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 6,
+      "y": 0
+    },
+    {
+      "h": 4,
+      "i": "726ec5e2-3ccd-4e5c-94b1-75213fbd2950",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 9,
+      "y": 0
+    },
+    {
+      "h": 6,
+      "i": "b4fefd5e-d121-4f9b-ad14-117cda14d885",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 4
+    },
+    {
+      "h": 6,
+      "i": "15d5cd0b-8535-4a41-ba6b-766dde95bb53",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 4
+    },
+    {
+      "h": 6,
+      "i": "bd4eeef7-280a-4730-9505-22ec172463c4",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 10
+    },
+    {
+      "h": 6,
+      "i": "2eaa87a0-3504-4e0f-a70c-1d29b0e82d74",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 10
+    },
+    {
+      "h": 6,
+      "i": "a6205259-f083-42d2-8790-c992901ac8ae",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 16
+    },
+    {
+      "h": 6,
+      "i": "21bf3d2b-cf2c-4249-bcf6-98f0bd249ec2",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 16
+    },
+    {
+      "h": 6,
+      "i": "3c3e39db-fec2-45a1-981b-a55aaaa3815a",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 22
+    },
+    {
+      "h": 6,
+      "i": "8719c714-72d2-4c21-80fe-0a25d9942b52",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 22
+    },
+    {
+      "h": 6,
+      "i": "12a200f8-2991-4327-a916-06f93a5f8e2a",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 28
+    },
+    {
+      "h": 6,
+      "i": "b9ccdaac-7f19-456f-9d7a-c7dd32d75778",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 28
+    },
+    {
+      "h": 6,
+      "i": "7a97d748-9383-4ee8-8eea-5f643324ded2",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 34
+    },
+    {
+      "h": 6,
+      "i": "97edcde0-96fb-43e8-8d81-052eafaa6fa5",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 34
+    },
+    {
+      "h": 6,
+      "i": "6cba7982-0fd3-485f-97b8-ef54073d1e17",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 40
+    }
+  ],
+  "panelMap": {},
+  "tags": [
+    "Istio",
+    "Service Mesh",
+    "Prometheus",
+    "Kubernetes"
+  ],
+  "title": "Istio Service Mesh - Prometheus",
+  "uploadedGrafana": false,
+  "variables": {
+    "703f9e9b-4083-4a5e-ad50-32a2afbe0432": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Filter by destination workload namespace",
+      "id": "703f9e9b-4083-4a5e-ad50-32a2afbe0432",
+      "key": "703f9e9b-4083-4a5e-ad50-32a2afbe0432",
+      "modificationUUID": "05a6b2ed-f957-4021-a928-c619043c2613",
+      "multiSelect": true,
+      "name": "destination_workload_namespace",
+      "order": 0,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'destination_workload_namespace'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name = 'istio_requests_total'",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "11890556-b5bb-4d37-9616-7eee90d3f453": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Filter by destination workload (cascades from namespace)",
+      "id": "11890556-b5bb-4d37-9616-7eee90d3f453",
+      "key": "11890556-b5bb-4d37-9616-7eee90d3f453",
+      "modificationUUID": "0bf2a8ae-baa2-4f13-98dd-c2872a800718",
+      "multiSelect": true,
+      "name": "destination_workload",
+      "order": 1,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'destination_workload'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name = 'istio_requests_total'\n  AND JSONExtractString(labels, 'destination_workload_namespace') IN $destination_workload_namespace",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "5821878d-9390-4e0c-96a1-20235a8fe69c": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Filter by source workload (optional)",
+      "id": "5821878d-9390-4e0c-96a1-20235a8fe69c",
+      "key": "5821878d-9390-4e0c-96a1-20235a8fe69c",
+      "modificationUUID": "9119b8c9-673c-48e1-8c53-c5a085ab8d74",
+      "multiSelect": true,
+      "name": "source_workload",
+      "order": 2,
+      "queryValue": "SELECT DISTINCT(JSONExtractString(labels, 'source_workload'))\nFROM signoz_metrics.time_series_v4\nWHERE metric_name = 'istio_requests_total'",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "version": "v4",
+  "widgets": [
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total request rate across the mesh (requests/sec). Source: rate(istio_requests_total). Filtered to reporter=destination to avoid double-counting.",
+      "fillSpans": false,
+      "id": "08030d22-5a6b-4d07-b198-0c1fab4aaf65",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "aa25b82e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload_namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload_namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload_namespace"
+                    ]
+                  },
+                  {
+                    "id": "84b317c3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload"
+                    ]
+                  },
+                  {
+                    "id": "13eacafe",
+                    "key": {
+                      "dataType": "string",
+                      "id": "source_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "source_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$source_workload"
+                    ]
+                  },
+                  {
+                    "id": "9480cb31",
+                    "key": {
+                      "dataType": "string",
+                      "id": "reporter--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "reporter",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "destination"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "last",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "46faa398-e6c5-483d-8dee-00eb8d0b03f2",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": null,
+      "selectedTracesFields": null,
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Request Rate",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Count of distinct destination workloads emitting telemetry in the selected window. Uses aggregateOperator='count' grouped by destination_workload \u2014 repo precedent: gcp/compute-engine 'Total Active GCE Instances'.",
+      "fillSpans": false,
+      "id": "0314f7a0-fde8-484a-9679-e212474bba59",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "7bff2adb",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload_namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload_namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload_namespace"
+                    ]
+                  },
+                  {
+                    "id": "ca75ecd8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload"
+                    ]
+                  },
+                  {
+                    "id": "0989bd8b",
+                    "key": {
+                      "dataType": "string",
+                      "id": "source_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "source_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$source_workload"
+                    ]
+                  },
+                  {
+                    "id": "61ea2fb4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "reporter--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "reporter",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "destination"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "destination_workload--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "destination_workload",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ed4a46b6-bbb7-4f94-b541-abc2c758b413",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": null,
+      "selectedTracesFields": null,
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Destination Workloads",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Average request duration computed as rate(istio_request_duration_milliseconds_sum) / rate(istio_request_duration_milliseconds_count). Repo precedent: apm/apm-metrics.json 'Database Calls Avg Duration'.",
+      "fillSpans": false,
+      "id": "25aa42ab-0c22-4800-b568-04c395a930b2",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_request_duration_milliseconds_sum--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_request_duration_milliseconds_sum",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "5e780ead",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload_namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload_namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload_namespace"
+                    ]
+                  },
+                  {
+                    "id": "faed7cfe",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload"
+                    ]
+                  },
+                  {
+                    "id": "c69b09f9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "source_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "source_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$source_workload"
+                    ]
+                  },
+                  {
+                    "id": "192349d4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "reporter--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "reporter",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "destination"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "sum",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_request_duration_milliseconds_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_request_duration_milliseconds_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "15bffcc9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload_namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload_namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload_namespace"
+                    ]
+                  },
+                  {
+                    "id": "1392447b",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload"
+                    ]
+                  },
+                  {
+                    "id": "df9cee41",
+                    "key": {
+                      "dataType": "string",
+                      "id": "source_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "source_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$source_workload"
+                    ]
+                  },
+                  {
+                    "id": "49b8e610",
+                    "key": {
+                      "dataType": "string",
+                      "id": "reporter--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "reporter",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "destination"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "count",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "A/B",
+              "legend": "avg ms",
+              "name": "F1",
+              "queryName": "F1"
+            }
+          ]
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "b8d53e13-7b66-4337-a63c-84ea70bc8bdc",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": null,
+      "selectedTracesFields": null,
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Average Request Latency",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Percentage of 5xx responses out of total. Computed as (A/B)*100 where A = rate of 5xx responses and B = total request rate.",
+      "fillSpans": false,
+      "id": "726ec5e2-3ccd-4e5c-94b1-75213fbd2950",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "c4d31602",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload_namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload_namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload_namespace"
+                    ]
+                  },
+                  {
+                    "id": "6355679f",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload"
+                    ]
+                  },
+                  {
+                    "id": "d3ab96ce",
+                    "key": {
+                      "dataType": "string",
+                      "id": "source_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "source_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$source_workload"
+                    ]
+                  },
+                  {
+                    "id": "0e1d6994",
+                    "key": {
+                      "dataType": "string",
+                      "id": "reporter--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "reporter",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "destination"
+                  },
+                  {
+                    "id": "67e4ea02",
+                    "key": {
+                      "dataType": "string",
+                      "id": "response_code--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "response_code",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "500",
+                      "501",
+                      "502",
+                      "503",
+                      "504",
+                      "505",
+                      "506",
+                      "507",
+                      "508",
+                      "510",
+                      "511"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "errors",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "516f1f6d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload_namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload_namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload_namespace"
+                    ]
+                  },
+                  {
+                    "id": "a1582361",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload"
+                    ]
+                  },
+                  {
+                    "id": "147b7947",
+                    "key": {
+                      "dataType": "string",
+                      "id": "source_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "source_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$source_workload"
+                    ]
+                  },
+                  {
+                    "id": "0c35e9b8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "reporter--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "reporter",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "destination"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "total",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "(A/B)*100",
+              "legend": "error %",
+              "name": "F1",
+              "queryName": "F1"
+            }
+          ]
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "8e8aa8c4-defd-40bc-8299-8bf011b45904",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": null,
+      "selectedTracesFields": null,
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Error Rate (5xx %)",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of istio_requests_total grouped by destination_workload. Identifies which services receive the most traffic.",
+      "fillSpans": false,
+      "id": "b4fefd5e-d121-4f9b-ad14-117cda14d885",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "aa19bf26",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload_namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload_namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload_namespace"
+                    ]
+                  },
+                  {
+                    "id": "adcb2f12",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload"
+                    ]
+                  },
+                  {
+                    "id": "e1737326",
+                    "key": {
+                      "dataType": "string",
+                      "id": "source_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "source_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$source_workload"
+                    ]
+                  },
+                  {
+                    "id": "8b070ee4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "reporter--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "reporter",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "destination"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "destination_workload--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "destination_workload",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{destination_workload}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d7ee4f66-5f5e-4d67-abb1-1fd95e2a0c2e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": null,
+      "selectedTracesFields": null,
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Rate by Destination Workload",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Stacked rate of istio_requests_total by HTTP response_code. Shows the 2xx/3xx/4xx/5xx mix over time.",
+      "fillSpans": false,
+      "id": "15d5cd0b-8535-4a41-ba6b-766dde95bb53",
+      "isStacked": true,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "63ed77ea",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload_namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload_namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload_namespace"
+                    ]
+                  },
+                  {
+                    "id": "47af7e47",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload"
+                    ]
+                  },
+                  {
+                    "id": "76ca3659",
+                    "key": {
+                      "dataType": "string",
+                      "id": "source_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "source_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$source_workload"
+                    ]
+                  },
+                  {
+                    "id": "f4f9cccd",
+                    "key": {
+                      "dataType": "string",
+                      "id": "reporter--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "reporter",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "destination"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "response_code--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "response_code",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "HTTP {{response_code}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "aba63bbe-6037-4503-b937-beef4857f366",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": null,
+      "selectedTracesFields": null,
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Rate by Response Code",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Stacked rate by request_protocol (http, grpc, tcp).",
+      "fillSpans": false,
+      "id": "bd4eeef7-280a-4730-9505-22ec172463c4",
+      "isStacked": true,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "f5948ad7",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload_namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload_namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload_namespace"
+                    ]
+                  },
+                  {
+                    "id": "901a30f4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload"
+                    ]
+                  },
+                  {
+                    "id": "698f25bb",
+                    "key": {
+                      "dataType": "string",
+                      "id": "source_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "source_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$source_workload"
+                    ]
+                  },
+                  {
+                    "id": "76ce63d4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "reporter--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "reporter",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "destination"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "request_protocol--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "request_protocol",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{request_protocol}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "606fdfd2-c05e-475a-934d-6701a995f7c1",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": null,
+      "selectedTracesFields": null,
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Protocol Distribution",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate split by connection_security_policy (mutual_tls vs none). Useful to verify that mTLS is in effect for in-mesh traffic.",
+      "fillSpans": false,
+      "id": "2eaa87a0-3504-4e0f-a70c-1d29b0e82d74",
+      "isStacked": true,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "3bd87eb3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload_namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload_namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload_namespace"
+                    ]
+                  },
+                  {
+                    "id": "226feef6",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload"
+                    ]
+                  },
+                  {
+                    "id": "9aed57b4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "source_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "source_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$source_workload"
+                    ]
+                  },
+                  {
+                    "id": "a263bdc5",
+                    "key": {
+                      "dataType": "string",
+                      "id": "reporter--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "reporter",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "destination"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "connection_security_policy--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "connection_security_policy",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{connection_security_policy}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "27b27dc1-ef61-4e2b-8b89-0d2f3bbee36c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": null,
+      "selectedTracesFields": null,
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Connection Security Policy (mTLS coverage)",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Mesh-wide average request duration over time. Computed as rate(istio_request_duration_milliseconds_sum) / rate(istio_request_duration_milliseconds_count).",
+      "fillSpans": false,
+      "id": "a6205259-f083-42d2-8790-c992901ac8ae",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_request_duration_milliseconds_sum--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_request_duration_milliseconds_sum",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "78b78733",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload_namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload_namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload_namespace"
+                    ]
+                  },
+                  {
+                    "id": "fcf3a6ff",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload"
+                    ]
+                  },
+                  {
+                    "id": "6bd273f2",
+                    "key": {
+                      "dataType": "string",
+                      "id": "source_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "source_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$source_workload"
+                    ]
+                  },
+                  {
+                    "id": "eb707da7",
+                    "key": {
+                      "dataType": "string",
+                      "id": "reporter--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "reporter",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "destination"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "sum",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_request_duration_milliseconds_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_request_duration_milliseconds_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "4248799c",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload_namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload_namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload_namespace"
+                    ]
+                  },
+                  {
+                    "id": "a13d85b7",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload"
+                    ]
+                  },
+                  {
+                    "id": "0dcf4f7e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "source_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "source_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$source_workload"
+                    ]
+                  },
+                  {
+                    "id": "2888b944",
+                    "key": {
+                      "dataType": "string",
+                      "id": "reporter--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "reporter",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "destination"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "count",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "A/B",
+              "legend": "avg ms",
+              "name": "F1",
+              "queryName": "F1"
+            }
+          ]
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "d0b432c0-cd77-4578-b729-2057e816968e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": null,
+      "selectedTracesFields": null,
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Average Request Latency Over Time",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Per-service average latency = rate(<metric>_sum) / rate(<metric>_count) grouped by destination_workload. Surfaces slow services.",
+      "fillSpans": false,
+      "id": "21bf3d2b-cf2c-4249-bcf6-98f0bd249ec2",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_request_duration_milliseconds_sum--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_request_duration_milliseconds_sum",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "5b5e2442",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload_namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload_namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload_namespace"
+                    ]
+                  },
+                  {
+                    "id": "bd5da5ec",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload"
+                    ]
+                  },
+                  {
+                    "id": "2235ae62",
+                    "key": {
+                      "dataType": "string",
+                      "id": "source_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "source_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$source_workload"
+                    ]
+                  },
+                  {
+                    "id": "5107c97c",
+                    "key": {
+                      "dataType": "string",
+                      "id": "reporter--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "reporter",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "destination"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "destination_workload--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "destination_workload",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{destination_workload}} sum",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_request_duration_milliseconds_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_request_duration_milliseconds_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "30f12be0",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload_namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload_namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload_namespace"
+                    ]
+                  },
+                  {
+                    "id": "6c20afdb",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload"
+                    ]
+                  },
+                  {
+                    "id": "8585f1fc",
+                    "key": {
+                      "dataType": "string",
+                      "id": "source_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "source_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$source_workload"
+                    ]
+                  },
+                  {
+                    "id": "b4428599",
+                    "key": {
+                      "dataType": "string",
+                      "id": "reporter--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "reporter",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "destination"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "destination_workload--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "destination_workload",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{destination_workload}} count",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "A/B",
+              "legend": "{{destination_workload}}",
+              "name": "F1",
+              "queryName": "F1"
+            }
+          ]
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c6989380-e26d-4c67-9100-aa5d67128de0",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": null,
+      "selectedTracesFields": null,
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Average Latency by Destination Workload",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Request rate grouped by destination_workload (proxy for per-service throughput).",
+      "fillSpans": false,
+      "id": "3c3e39db-fec2-45a1-981b-a55aaaa3815a",
+      "isStacked": true,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "20604f0f",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload_namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload_namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload_namespace"
+                    ]
+                  },
+                  {
+                    "id": "57e798fb",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload"
+                    ]
+                  },
+                  {
+                    "id": "ae164db1",
+                    "key": {
+                      "dataType": "string",
+                      "id": "source_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "source_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$source_workload"
+                    ]
+                  },
+                  {
+                    "id": "ab461cc3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "reporter--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "reporter",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "destination"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "destination_workload--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "destination_workload",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{destination_workload}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "449601ac-adb0-4ae4-959e-b7a0c01aa490",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": null,
+      "selectedTracesFields": null,
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Throughput by Destination Workload",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Average request body size = rate(istio_request_bytes_sum)/rate(istio_request_bytes_count). Same shape for response. Per-formula computed series.",
+      "fillSpans": false,
+      "id": "8719c714-72d2-4c21-80fe-0a25d9942b52",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_request_bytes_sum--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_request_bytes_sum",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "72e261ce",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload_namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload_namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload_namespace"
+                    ]
+                  },
+                  {
+                    "id": "ead6a67e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload"
+                    ]
+                  },
+                  {
+                    "id": "74fc887a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "source_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "source_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$source_workload"
+                    ]
+                  },
+                  {
+                    "id": "0639ed98",
+                    "key": {
+                      "dataType": "string",
+                      "id": "reporter--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "reporter",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "destination"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "req-sum",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_request_bytes_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_request_bytes_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "ae8c8156",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload_namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload_namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload_namespace"
+                    ]
+                  },
+                  {
+                    "id": "38ff9c9d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload"
+                    ]
+                  },
+                  {
+                    "id": "cfa08e0a",
+                    "key": {
+                      "dataType": "string",
+                      "id": "source_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "source_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$source_workload"
+                    ]
+                  },
+                  {
+                    "id": "5c77d12b",
+                    "key": {
+                      "dataType": "string",
+                      "id": "reporter--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "reporter",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "destination"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "req-count",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_response_bytes_sum--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_response_bytes_sum",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "C",
+              "filters": {
+                "items": [
+                  {
+                    "id": "cec482b6",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload_namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload_namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload_namespace"
+                    ]
+                  },
+                  {
+                    "id": "31e15fe8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload"
+                    ]
+                  },
+                  {
+                    "id": "3a09a2db",
+                    "key": {
+                      "dataType": "string",
+                      "id": "source_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "source_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$source_workload"
+                    ]
+                  },
+                  {
+                    "id": "d05860b6",
+                    "key": {
+                      "dataType": "string",
+                      "id": "reporter--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "reporter",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "destination"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "resp-sum",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "C",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_response_bytes_count--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_response_bytes_count",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "D",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b024e240",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload_namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload_namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload_namespace"
+                    ]
+                  },
+                  {
+                    "id": "f27a653e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload"
+                    ]
+                  },
+                  {
+                    "id": "fd5a4dc4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "source_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "source_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$source_workload"
+                    ]
+                  },
+                  {
+                    "id": "ec601214",
+                    "key": {
+                      "dataType": "string",
+                      "id": "reporter--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "reporter",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "destination"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "resp-count",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "D",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "A/B",
+              "legend": "request avg",
+              "name": "F1",
+              "queryName": "F1"
+            },
+            {
+              "disabled": false,
+              "expression": "C/D",
+              "legend": "response avg",
+              "name": "F2",
+              "queryName": "F2"
+            }
+          ]
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "7212cfc5-ca4b-40a1-9afc-b27a73921e9d",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": null,
+      "selectedTracesFields": null,
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Average Request / Response Body Sizes",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of error responses (response_code in 4xx/5xx code list), stacked by code. Uses explicit code lists rather than range comparison since response_code is a string label in Prometheus.",
+      "fillSpans": false,
+      "id": "12a200f8-2991-4327-a916-06f93a5f8e2a",
+      "isStacked": true,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "0357452e",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload_namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload_namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload_namespace"
+                    ]
+                  },
+                  {
+                    "id": "9f564129",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload"
+                    ]
+                  },
+                  {
+                    "id": "38070d10",
+                    "key": {
+                      "dataType": "string",
+                      "id": "source_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "source_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$source_workload"
+                    ]
+                  },
+                  {
+                    "id": "d7a22bfc",
+                    "key": {
+                      "dataType": "string",
+                      "id": "reporter--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "reporter",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "destination"
+                  },
+                  {
+                    "id": "596fedb3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "response_code--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "response_code",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "400",
+                      "401",
+                      "402",
+                      "403",
+                      "404",
+                      "405",
+                      "406",
+                      "407",
+                      "408",
+                      "409",
+                      "410",
+                      "411",
+                      "412",
+                      "413",
+                      "414",
+                      "415",
+                      "416",
+                      "417",
+                      "418",
+                      "421",
+                      "422",
+                      "423",
+                      "424",
+                      "425",
+                      "426",
+                      "428",
+                      "429",
+                      "431",
+                      "451",
+                      "500",
+                      "501",
+                      "502",
+                      "503",
+                      "504",
+                      "505",
+                      "506",
+                      "507",
+                      "508",
+                      "510",
+                      "511"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "response_code--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "response_code",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "HTTP {{response_code}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "390dc3b0-d936-4701-8281-08902c281eb9",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": null,
+      "selectedTracesFields": null,
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "HTTP Error Rates (4xx / 5xx)",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of 5xx responses by destination workload \u2014 identifies failing services.",
+      "fillSpans": false,
+      "id": "b9ccdaac-7f19-456f-9d7a-c7dd32d75778",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "102ef5e3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload_namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload_namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload_namespace"
+                    ]
+                  },
+                  {
+                    "id": "72fbc700",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload"
+                    ]
+                  },
+                  {
+                    "id": "1bf4a432",
+                    "key": {
+                      "dataType": "string",
+                      "id": "source_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "source_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$source_workload"
+                    ]
+                  },
+                  {
+                    "id": "d4a6dfd9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "reporter--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "reporter",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "destination"
+                  },
+                  {
+                    "id": "5a56f0ca",
+                    "key": {
+                      "dataType": "string",
+                      "id": "response_code--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "response_code",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "500",
+                      "501",
+                      "502",
+                      "503",
+                      "504",
+                      "505",
+                      "506",
+                      "507",
+                      "508",
+                      "510",
+                      "511"
+                    ]
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "destination_workload--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "destination_workload",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{destination_workload}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "27452e1c-b338-4926-b7ed-159462aad4d8",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": null,
+      "selectedTracesFields": null,
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Failed Requests by Destination Workload (5xx)",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of requests by Envoy response_flags (excluding `-`). Surfaces proxy-level conditions: UH=upstream host, UF=upstream connection failure, NR=no route, UR=upstream retry.",
+      "fillSpans": false,
+      "id": "7a97d748-9383-4ee8-8eea-5f643324ded2",
+      "isStacked": true,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_requests_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_requests_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "48124b48",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload_namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload_namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload_namespace"
+                    ]
+                  },
+                  {
+                    "id": "f13f256c",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload"
+                    ]
+                  },
+                  {
+                    "id": "2b6ba718",
+                    "key": {
+                      "dataType": "string",
+                      "id": "source_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "source_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$source_workload"
+                    ]
+                  },
+                  {
+                    "id": "48559c2d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "reporter--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "reporter",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "destination"
+                  },
+                  {
+                    "id": "151729dd",
+                    "key": {
+                      "dataType": "string",
+                      "id": "response_flags--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "response_flags",
+                      "type": "tag"
+                    },
+                    "op": "!=",
+                    "value": "-"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "response_flags--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "response_flags",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "flags={{response_flags}}",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "12081464-436e-427d-a107-801c96a617dc",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": null,
+      "selectedTracesFields": null,
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Envoy Response Flags",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of TCP connections opened and closed across the mesh, reporter=destination.",
+      "fillSpans": false,
+      "id": "97edcde0-96fb-43e8-8d81-052eafaa6fa5",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_tcp_connections_opened_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_tcp_connections_opened_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "63d6c797",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload_namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload_namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload_namespace"
+                    ]
+                  },
+                  {
+                    "id": "89d405d7",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload"
+                    ]
+                  },
+                  {
+                    "id": "47581934",
+                    "key": {
+                      "dataType": "string",
+                      "id": "source_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "source_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$source_workload"
+                    ]
+                  },
+                  {
+                    "id": "27900525",
+                    "key": {
+                      "dataType": "string",
+                      "id": "reporter--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "reporter",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "destination"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "opened",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_tcp_connections_closed_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_tcp_connections_closed_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "86b20e74",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload_namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload_namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload_namespace"
+                    ]
+                  },
+                  {
+                    "id": "b04d142d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload"
+                    ]
+                  },
+                  {
+                    "id": "811e8ac0",
+                    "key": {
+                      "dataType": "string",
+                      "id": "source_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "source_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$source_workload"
+                    ]
+                  },
+                  {
+                    "id": "5fd2f823",
+                    "key": {
+                      "dataType": "string",
+                      "id": "reporter--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "reporter",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "destination"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "closed",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "c2989618-91ef-486a-9c01-5975e7524d26",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": null,
+      "selectedTracesFields": null,
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "TCP Connection Rate (Opened / Closed)",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of TCP bytes sent and received across data-plane sidecars.",
+      "fillSpans": false,
+      "id": "6cba7982-0fd3-485f-97b8-ef54073d1e17",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_tcp_sent_bytes_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_tcp_sent_bytes_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [
+                  {
+                    "id": "dbf45ee4",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload_namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload_namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload_namespace"
+                    ]
+                  },
+                  {
+                    "id": "1ed9ced7",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload"
+                    ]
+                  },
+                  {
+                    "id": "b7bd28e9",
+                    "key": {
+                      "dataType": "string",
+                      "id": "source_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "source_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$source_workload"
+                    ]
+                  },
+                  {
+                    "id": "38ba4abb",
+                    "key": {
+                      "dataType": "string",
+                      "id": "reporter--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "reporter",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "destination"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "sent",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            },
+            {
+              "aggregateAttribute": {
+                "dataType": "float64",
+                "id": "istio_tcp_received_bytes_total--float64--Sum--true",
+                "isColumn": true,
+                "isJSON": false,
+                "key": "istio_tcp_received_bytes_total",
+                "type": "Sum"
+              },
+              "aggregateOperator": "sum_rate",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "filters": {
+                "items": [
+                  {
+                    "id": "b677934b",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload_namespace--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload_namespace",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload_namespace"
+                    ]
+                  },
+                  {
+                    "id": "1b59492d",
+                    "key": {
+                      "dataType": "string",
+                      "id": "destination_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "destination_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$destination_workload"
+                    ]
+                  },
+                  {
+                    "id": "7fb861d8",
+                    "key": {
+                      "dataType": "string",
+                      "id": "source_workload--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "source_workload",
+                      "type": "tag"
+                    },
+                    "op": "in",
+                    "value": [
+                      "$source_workload"
+                    ]
+                  },
+                  {
+                    "id": "33e844c3",
+                    "key": {
+                      "dataType": "string",
+                      "id": "reporter--string--tag--false",
+                      "isColumn": false,
+                      "isJSON": false,
+                      "key": "reporter",
+                      "type": "tag"
+                    },
+                    "op": "=",
+                    "value": "destination"
+                  }
+                ],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "received",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "B",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "ead0b37b-8142-4bd5-992f-0ad9cf891c28",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "builder"
+      },
+      "selectedLogFields": null,
+      "selectedTracesFields": null,
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "TCP Throughput (Sent / Received)",
+      "yAxisUnit": "Bps"
+    }
+  ]
+}


### PR DESCRIPTION
Adds an Istio Prometheus dashboard fulfilling [SigNoz/signoz#6025](https://github.com/SigNoz/signoz/issues/6025).

## What's in this PR

`istio-prometheus/istio-prometheus-v1.json` — 17 panels across 5 sections:

- **General Overview** (4 value tiles): Total Request Rate, Active Destination Workloads, Average Request Latency, Error Rate (5xx %)
- **Traffic Management** (4 graphs): Request Rate by Destination Workload / by Response Code / by Request Protocol / by Connection Security Policy (mTLS coverage)
- **Performance** (4 graphs): Average Request Latency Over Time, Average Latency by Destination Workload, Throughput by Destination Workload, Average Request/Response Body Sizes
- **Error Metrics** (3 graphs): HTTP Error Rates (4xx/5xx), Failed Requests by Destination Workload (5xx), Envoy Response Flags
- **TCP Data Plane** (2 graphs): TCP Connection Rate (Opened/Closed), TCP Throughput (Sent/Received)

`istio-prometheus/README.md` — documents both annotate-and-scrape and static-target collector configurations, the reporter filter rationale, and the per-panel metric mapping.

## Implementation notes

Three filter variables — \`destination_workload_namespace\` cascading to \`destination_workload\`, plus optional \`source_workload\`.

**Reporter filter (no double-counting).** Istio emits identical telemetry from both source and destination proxies. Every counter / histogram query in this dashboard pins \`reporter=destination\` so totals reflect reality. Documented in the README; users can flip to \`reporter=source\` to monitor outgoing traffic from a specific source workload.

**Latency averages via formula.** Latency / body-size panels use \`rate(<metric>_sum) / rate(<metric>_count)\` with a query formula \`A/B\`, matching the precedent in \`apm/apm-metrics.json\` "Database Calls Avg Duration". This is the conservative choice that renders against any Prometheus histogram.

**Response code filtering.** 4xx / 5xx filters use explicit IN-lists (\`op: in\`) rather than range comparison since \`response_code\` is a string-typed Prometheus label.

**Counter convention.** All counter widgets use \`aggregateOperator: sum_rate\` to match the postgresql / aws-rds / clickhouse precedent in this repo.

Closes SigNoz/signoz#6025