### PR TITLE
feat(k8s): add distro-agnostic Kubernetes system and CronJob dashboards

### DIFF
--- a/k8s-infra-metrics/kubernetes-cronjobs.json
+++ b/k8s-infra-metrics/kubernetes-cronjobs.json
@@ -1,0 +1,1461 @@
+{
+  "title": "Kubernetes CronJobs: Current State and Recent Runs",
+  "description": "Current state shows the Jobs Kubernetes still keeps. Recent runs shows the Job runs SigNoz observed in the selected time range.",
+  "tags": [
+    "kubernetes",
+    "cronjobs",
+    "jobs",
+    "batch",
+    "k8s-infra",
+    "opentelemetry"
+  ],
+  "uploadedGrafana": false,
+  "uuid": "28e49ddd-c868-4975-ad7c-69dad693d632",
+  "version": "v5",
+  "panelMap": {},
+  "variables": {
+    "k8s.cluster.name": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Cluster label selector for CronJob metrics.",
+      "id": "k8s.cluster.name",
+      "key": "k8s.cluster.name",
+      "modificationUUID": "31427bdc-3d7b-4ebd-b52e-9541c59aef2c",
+      "multiSelect": true,
+      "name": "k8s.cluster.name",
+      "order": 0,
+      "queryValue": "SELECT JSONExtractString(labels, 'k8s.cluster.name') AS `k8s.cluster.name` FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'k8s.job.max_parallel_pods' GROUP BY `k8s.cluster.name`",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "k8s.namespace.name": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Namespace selector for CronJob-backed Jobs.",
+      "id": "k8s.namespace.name",
+      "key": "k8s.namespace.name",
+      "modificationUUID": "3ef2487f-0cbf-4fe8-9228-4a11e15f3966",
+      "multiSelect": true,
+      "name": "k8s.namespace.name",
+      "order": 1,
+      "queryValue": "SELECT JSONExtractString(labels, 'k8s.namespace.name') AS `k8s.namespace.name` FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'k8s.job.max_parallel_pods' AND JSONExtractString(labels, 'k8s.cluster.name') IN $k8s.cluster.name GROUP BY `k8s.namespace.name`",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "k8s.job.name": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Job executions created by the selected CronJobs.",
+      "id": "k8s.job.name",
+      "key": "k8s.job.name",
+      "modificationUUID": "7ba4f6dc-6d89-494b-a0eb-d3ed72d61dbf",
+      "multiSelect": true,
+      "name": "k8s.job.name",
+      "order": 2,
+      "queryValue": "SELECT JSONExtractString(labels, 'k8s.job.name') AS `k8s.job.name` FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'k8s.job.max_parallel_pods' AND JSONExtractString(labels, 'k8s.cluster.name') IN $k8s.cluster.name AND JSONExtractString(labels, 'k8s.namespace.name') IN $k8s.namespace.name GROUP BY `k8s.job.name`",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "k8s.cronjob.name": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "CronJob resources emitting active job counts.",
+      "id": "k8s.cronjob.name",
+      "key": "k8s.cronjob.name",
+      "modificationUUID": "cd008fd6-f60b-471b-a2c0-a31008e549f5",
+      "multiSelect": true,
+      "name": "k8s.cronjob.name",
+      "order": 3,
+      "queryValue": "SELECT JSONExtractString(labels, 'k8s.cronjob.name') AS `k8s.cronjob.name` FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'k8s.cronjob.active_jobs' AND JSONExtractString(labels, 'k8s.cluster.name') IN $k8s.cluster.name AND JSONExtractString(labels, 'k8s.namespace.name') IN $k8s.namespace.name GROUP BY `k8s.cronjob.name`",
+      "showALLOption": true,
+      "sort": "ASC",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "widgets": [
+    {
+      "description": "CronJobs that appear to be running right now.",
+      "id": "cronjob-active-pods-current",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "k8s.cronjob.active_jobs",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "max"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "active cronjobs",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "(k8s.cluster.name IN $k8s.cluster.name AND k8s.namespace.name IN $k8s.namespace.name AND k8s.cronjob.name IN $k8s.cronjob.name)"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Current Active CronJob Count",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "Successful Jobs that Kubernetes still keeps right now.",
+      "id": "cronjob-successful-pods-current",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "k8s.job.successful_pods",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "max"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "successful pods",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "(k8s.cluster.name IN $k8s.cluster.name AND k8s.namespace.name IN $k8s.namespace.name AND k8s.job.name IN $k8s.job.name)"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Current Successful Job Count",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "Failed Jobs that Kubernetes still keeps right now.",
+      "id": "cronjob-failed-pods-current",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "k8s.job.failed_pods",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "max"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "failed pods",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "(k8s.cluster.name IN $k8s.cluster.name AND k8s.namespace.name IN $k8s.namespace.name AND k8s.job.name IN $k8s.job.name)"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Current Failed Job Count",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "Expected successful pod count for Jobs Kubernetes still keeps right now.",
+      "id": "cronjob-desired-success-current",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "k8s.job.desired_successful_pods",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "max"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "desired successful pods",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "(k8s.cluster.name IN $k8s.cluster.name AND k8s.namespace.name IN $k8s.namespace.name AND k8s.job.name IN $k8s.job.name)"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Current Desired Success Count",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "Maximum parallel pod limit for Jobs Kubernetes still keeps right now.",
+      "id": "cronjob-max-parallel-current",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "k8s.job.max_parallel_pods",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "max"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "max parallel pods",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "(k8s.cluster.name IN $k8s.cluster.name AND k8s.namespace.name IN $k8s.namespace.name AND k8s.job.name IN $k8s.job.name)"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Current Max Parallel Pod Count",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Job runs SigNoz observed during the selected time range.",
+      "fillSpans": false,
+      "id": "cronjob-observed-job-runs-selected-range",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "SELECT count() FROM ( SELECT fingerprint FROM signoz_metrics.distributed_samples_v4 WHERE metric_name = 'k8s.job.max_parallel_pods' AND unix_milli >= $start_timestamp_ms AND unix_milli < $end_timestamp_ms AND fingerprint GLOBAL IN ( SELECT DISTINCT fingerprint FROM signoz_metrics.time_series_v4_1day WHERE metric_name = 'k8s.job.max_parallel_pods' AND JSONExtractString(labels, 'k8s.cluster.name') IN $k8s.cluster.name AND JSONExtractString(labels, 'k8s.namespace.name') IN $k8s.namespace.name AND JSONExtractString(labels, 'k8s.job.name') IN $k8s.job.name ) GROUP BY fingerprint HAVING max(value) > 0 )"
+          }
+        ],
+        "id": "86de8dfe-c8f8-4a99-96d2-d8335918f899",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "clickhouse_sql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Job Run Count",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Successful Job runs SigNoz observed during the selected time range.",
+      "fillSpans": false,
+      "id": "cronjob-observed-successful-runs-selected-range",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "SELECT count() FROM ( SELECT fingerprint FROM signoz_metrics.distributed_samples_v4 WHERE metric_name = 'k8s.job.successful_pods' AND unix_milli >= $start_timestamp_ms AND unix_milli < $end_timestamp_ms AND fingerprint GLOBAL IN ( SELECT DISTINCT fingerprint FROM signoz_metrics.time_series_v4_1day WHERE metric_name = 'k8s.job.successful_pods' AND JSONExtractString(labels, 'k8s.cluster.name') IN $k8s.cluster.name AND JSONExtractString(labels, 'k8s.namespace.name') IN $k8s.namespace.name AND JSONExtractString(labels, 'k8s.job.name') IN $k8s.job.name ) GROUP BY fingerprint HAVING max(value) > 0 )"
+          }
+        ],
+        "id": "ae14cc85-f338-41f5-bd91-c632d2fb6e30",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "clickhouse_sql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Successful Job Run Count",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Failed Job runs SigNoz observed during the selected time range.",
+      "fillSpans": false,
+      "id": "cronjob-observed-failed-runs-selected-range",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "SELECT count() FROM ( SELECT fingerprint FROM signoz_metrics.distributed_samples_v4 WHERE metric_name = 'k8s.job.failed_pods' AND unix_milli >= $start_timestamp_ms AND unix_milli < $end_timestamp_ms AND fingerprint GLOBAL IN ( SELECT DISTINCT fingerprint FROM signoz_metrics.time_series_v4_1day WHERE metric_name = 'k8s.job.failed_pods' AND JSONExtractString(labels, 'k8s.cluster.name') IN $k8s.cluster.name AND JSONExtractString(labels, 'k8s.namespace.name') IN $k8s.namespace.name AND JSONExtractString(labels, 'k8s.job.name') IN $k8s.job.name ) GROUP BY fingerprint HAVING max(value) > 0 )"
+          }
+        ],
+        "id": "b2104fc1-1179-4f81-bb29-bd1d58bf5f43",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "clickhouse_sql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Failed Job Run Count",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Highest number of CronJob runs seen at the same time during the selected time range.",
+      "fillSpans": false,
+      "id": "cronjob-observed-peak-active-selected-range",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "SELECT ifNull(max(value), 0) FROM signoz_metrics.distributed_samples_v4 WHERE metric_name = 'k8s.cronjob.active_jobs' AND unix_milli >= $start_timestamp_ms AND unix_milli < $end_timestamp_ms AND fingerprint GLOBAL IN ( SELECT DISTINCT fingerprint FROM signoz_metrics.time_series_v4_1day WHERE metric_name = 'k8s.cronjob.active_jobs' AND JSONExtractString(labels, 'k8s.cluster.name') IN $k8s.cluster.name AND JSONExtractString(labels, 'k8s.namespace.name') IN $k8s.namespace.name AND JSONExtractString(labels, 'k8s.cronjob.name') IN $k8s.cronjob.name )"
+          }
+        ],
+        "id": "9e7421c7-fd8f-4d2f-aa44-34bcfca85434",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "clickhouse_sql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Peak Concurrent Job Count",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "Success, failure, and active run status for what Kubernetes still keeps right now.",
+      "id": "cronjob-execution-state-trends",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "k8s.cronjob.active_jobs",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "max"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "active cronjobs",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "(k8s.cluster.name IN $k8s.cluster.name AND k8s.namespace.name IN $k8s.namespace.name AND k8s.cronjob.name IN $k8s.cronjob.name)"
+              }
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "k8s.job.successful_pods",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "max"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "successful",
+              "queryName": "B",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "(k8s.cluster.name IN $k8s.cluster.name AND k8s.namespace.name IN $k8s.namespace.name AND k8s.job.name IN $k8s.job.name)"
+              }
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "k8s.job.failed_pods",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "max"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "C",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "failed",
+              "queryName": "C",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "(k8s.cluster.name IN $k8s.cluster.name AND k8s.namespace.name IN $k8s.namespace.name AND k8s.job.name IN $k8s.job.name)"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Current Job Status",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "Expected successful pods compared with parallel pod limits for what Kubernetes still keeps right now.",
+      "id": "cronjob-scheduling-constraints-trends",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "k8s.job.desired_successful_pods",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "max"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "desired successful",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "(k8s.cluster.name IN $k8s.cluster.name AND k8s.namespace.name IN $k8s.namespace.name AND k8s.job.name IN $k8s.job.name)"
+              }
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "k8s.job.max_parallel_pods",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "max"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "max parallel",
+              "queryName": "B",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "(k8s.cluster.name IN $k8s.cluster.name AND k8s.namespace.name IN $k8s.namespace.name AND k8s.job.name IN $k8s.job.name)"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Current Desired Success vs Parallel Limit",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "Active pod count by Job for what Kubernetes still keeps right now.",
+      "id": "cronjob-active-pods-by-job",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "k8s.job.active_pods",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "max"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "k8s.job.name",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{k8s.job.name}}",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "(k8s.cluster.name IN $k8s.cluster.name AND k8s.namespace.name IN $k8s.namespace.name AND k8s.job.name IN $k8s.job.name)"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Current Active Pods by Job",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "Successful pod count by Job for what Kubernetes still keeps right now.",
+      "id": "cronjob-successful-pods-by-job",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "k8s.job.successful_pods",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "max"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "k8s.job.name",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{k8s.job.name}}",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "(k8s.cluster.name IN $k8s.cluster.name AND k8s.namespace.name IN $k8s.namespace.name AND k8s.job.name IN $k8s.job.name)"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Current Successful Jobs by Name",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "Failed pod count by Job for what Kubernetes still keeps right now.",
+      "id": "cronjob-failed-pods-by-job",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "k8s.job.failed_pods",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "max"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "k8s.job.name",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{k8s.job.name}}",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "(k8s.cluster.name IN $k8s.cluster.name AND k8s.namespace.name IN $k8s.namespace.name AND k8s.job.name IN $k8s.job.name)"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Current Failed Jobs by Name",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "Expected successful pods and parallel limits by Job for what Kubernetes still keeps right now.",
+      "id": "cronjob-desired-vs-parallel-by-job",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "k8s.job.desired_successful_pods",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "max"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "k8s.job.name",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "desired {{k8s.job.name}}",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "(k8s.cluster.name IN $k8s.cluster.name AND k8s.namespace.name IN $k8s.namespace.name AND k8s.job.name IN $k8s.job.name)"
+              }
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "k8s.job.max_parallel_pods",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "max"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "k8s.job.name",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "max parallel {{k8s.job.name}}",
+              "queryName": "B",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "(k8s.cluster.name IN $k8s.cluster.name AND k8s.namespace.name IN $k8s.namespace.name AND k8s.job.name IN $k8s.job.name)"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Current Desired Success vs Parallel Limit by Job",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {
+      "Desired Successful Pods": "",
+      "Failed Pods": "",
+      "Max Parallel Pods": "",
+      "Successful Pods": ""
+      },
+      "columnWidths": {
+        "Desired Successful Pods": 145,
+        "Failed Pods": 145,
+        "Job Name": 220,
+        "Latest Sample (UTC)": 200,
+        "Max Parallel Pods": 145,
+        "Successful Pods": 145
+      },
+      "contextLinks": {
+        "linksData": []
+      },
+      "customLegendColors": {},
+      "decimalPrecision": 2,
+      "description": "Job-by-job details for the runs SigNoz observed during the selected time range.",
+      "fillSpans": false,
+      "id": "cronjob-selected-range-job-run-details",
+      "isLogScale": false,
+      "isStacked": false,
+      "legendPosition": "bottom",
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "table",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "functions": [],
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum",
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": "SELECT toString(JSONExtractString(ts.labels, 'k8s.job.name')) AS `Job Name`, toUInt64(maxIf(s.value, s.metric_name = 'k8s.job.successful_pods')) AS `Successful Pods`, toUInt64(maxIf(s.value, s.metric_name = 'k8s.job.failed_pods')) AS `Failed Pods`, toUInt64(maxIf(s.value, s.metric_name = 'k8s.job.desired_successful_pods')) AS `Desired Successful Pods`, toUInt64(maxIf(s.value, s.metric_name = 'k8s.job.max_parallel_pods')) AS `Max Parallel Pods`, formatDateTime(max(fromUnixTimestamp64Milli(s.unix_milli)), '%Y-%m-%d %H:%i:%s') AS `Latest Sample (UTC)` FROM signoz_metrics.distributed_samples_v4 AS s INNER JOIN ( SELECT DISTINCT fingerprint, labels FROM signoz_metrics.time_series_v4_1day WHERE metric_name IN ('k8s.job.successful_pods','k8s.job.failed_pods','k8s.job.desired_successful_pods','k8s.job.max_parallel_pods') AND JSONExtractString(labels, 'k8s.cluster.name') IN $k8s.cluster.name AND JSONExtractString(labels, 'k8s.namespace.name') IN $k8s.namespace.name AND JSONExtractString(labels, 'k8s.job.name') IN $k8s.job.name ) AS ts USING fingerprint WHERE s.metric_name IN ('k8s.job.successful_pods','k8s.job.failed_pods','k8s.job.desired_successful_pods','k8s.job.max_parallel_pods') AND s.unix_milli >= $start_timestamp_ms AND s.unix_milli < $end_timestamp_ms GROUP BY `Job Name` ORDER BY max(s.unix_milli) DESC LIMIT 100"
+          }
+        ],
+        "id": "61a5dcdc-5998-4d41-8bb4-c74d009e8a9a",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "queryType": "clickhouse_sql"
+      },
+      "selectedLogFields": [
+        {
+          "dataType": "string",
+          "name": "body",
+          "type": ""
+        },
+        {
+          "dataType": "string",
+          "name": "timestamp",
+          "type": ""
+        }
+      ],
+      "selectedTracesFields": [
+        {
+          "dataType": "string",
+          "id": "serviceName--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "serviceName",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "name--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "name",
+          "type": "tag"
+        },
+        {
+          "dataType": "float64",
+          "id": "durationNano--float64--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "durationNano",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "httpMethod--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "httpMethod",
+          "type": "tag"
+        },
+        {
+          "dataType": "string",
+          "id": "responseStatusCode--string--tag--true",
+          "isColumn": true,
+          "isJSON": false,
+          "key": "responseStatusCode",
+          "type": "tag"
+        }
+      ],
+      "softMax": 0,
+      "softMin": 0,
+      "stackedBarChart": false,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Recent Job Run Details",
+      "yAxisUnit": "short"
+    }
+  ],
+  "layout": [
+    {
+      "x": 0,
+      "y": 0,
+      "w": 2,
+      "h": 2,
+      "i": "cronjob-active-pods-current",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 2,
+      "y": 0,
+      "w": 2,
+      "h": 2,
+      "i": "cronjob-successful-pods-current",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 4,
+      "y": 0,
+      "w": 2,
+      "h": 2,
+      "i": "cronjob-failed-pods-current",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 6,
+      "y": 0,
+      "w": 3,
+      "h": 2,
+      "i": "cronjob-desired-success-current",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 9,
+      "y": 0,
+      "w": 3,
+      "h": 2,
+      "i": "cronjob-max-parallel-current",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 0,
+      "y": 2,
+      "w": 3,
+      "h": 2,
+      "i": "cronjob-observed-job-runs-selected-range",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 3,
+      "y": 2,
+      "w": 3,
+      "h": 2,
+      "i": "cronjob-observed-successful-runs-selected-range",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 6,
+      "y": 2,
+      "w": 3,
+      "h": 2,
+      "i": "cronjob-observed-failed-runs-selected-range",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 9,
+      "y": 2,
+      "w": 3,
+      "h": 2,
+      "i": "cronjob-observed-peak-active-selected-range",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 0,
+      "y": 4,
+      "w": 6,
+      "h": 4,
+      "i": "cronjob-execution-state-trends",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 6,
+      "y": 4,
+      "w": 6,
+      "h": 4,
+      "i": "cronjob-scheduling-constraints-trends",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 0,
+      "y": 8,
+      "w": 4,
+      "h": 5,
+      "i": "cronjob-active-pods-by-job",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 4,
+      "y": 8,
+      "w": 4,
+      "h": 5,
+      "i": "cronjob-successful-pods-by-job",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 8,
+      "y": 8,
+      "w": 4,
+      "h": 5,
+      "i": "cronjob-failed-pods-by-job",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 0,
+      "y": 13,
+      "w": 6,
+      "h": 5,
+      "i": "cronjob-desired-vs-parallel-by-job",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 6,
+      "y": 13,
+      "w": 6,
+      "h": 5,
+      "i": "cronjob-selected-range-job-run-details",
+      "moved": false,
+      "static": false
+    }
+  ]
+}

--- a/k8s-system-monitoring/kubernetes-apiserver.json
+++ b/k8s-system-monitoring/kubernetes-apiserver.json
@@ -1,0 +1,576 @@
+{
+  "description": "Standard control-plane view for kube-apiserver using Prometheus/OpenTelemetry metrics.",
+  "layout": [
+    {
+      "x": 0,
+      "y": 0,
+      "w": 3,
+      "h": 2,
+      "i": "apiserver-discovery",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 3,
+      "y": 0,
+      "w": 3,
+      "h": 2,
+      "i": "req-rate",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 6,
+      "y": 0,
+      "w": 3,
+      "h": 2,
+      "i": "inflight",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 9,
+      "y": 0,
+      "w": 3,
+      "h": 2,
+      "i": "longrunning",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 0,
+      "y": 2,
+      "w": 6,
+      "h": 5,
+      "i": "goroutines",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 6,
+      "y": 2,
+      "w": 6,
+      "h": 5,
+      "i": "req-verb",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 0,
+      "y": 7,
+      "w": 6,
+      "h": 5,
+      "i": "req-code",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 6,
+      "y": 7,
+      "w": 6,
+      "h": 5,
+      "i": "req-lat-buckets",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 0,
+      "y": 12,
+      "w": 6,
+      "h": 5,
+      "i": "workqueue-depth",
+      "moved": false,
+      "static": false
+    }
+  ],
+  "panelMap": {},
+  "tags": [
+    "kubernetes",
+    "control-plane",
+    "apiserver",
+    "prometheus"
+  ],
+  "title": "Kubernetes API Server",
+  "uploadedGrafana": false,
+  "uuid": "d6a4a386-c887-4237-8c42-dfb7ded01068",
+  "variables": {
+    "service_name": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Auto-discovered services (from metric labels).",
+      "dynamicVariablesAttribute": "service.name",
+      "dynamicVariablesSource": "Metrics",
+      "haveCustomValuesSelected": false,
+      "id": "service_name",
+      "key": "service_name",
+      "modificationUUID": "2467d8ee-845d-47b3-95d5-1e5a059b107b",
+      "multiSelect": true,
+      "name": "service_name",
+      "order": 0,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    },
+    "k8s_cluster_name": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Optional cluster label selector.",
+      "dynamicVariablesAttribute": "k8s.cluster.name",
+      "dynamicVariablesSource": "Metrics",
+      "haveCustomValuesSelected": false,
+      "id": "k8s_cluster_name",
+      "key": "k8s_cluster_name",
+      "modificationUUID": "35b3ec30-8060-4260-b9a5-f9de490fcf49",
+      "multiSelect": true,
+      "name": "k8s_cluster_name",
+      "order": 1,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    },
+    "deployment_environment_name": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Optional OTel environment label selector.",
+      "dynamicVariablesAttribute": "deployment.environment.name",
+      "dynamicVariablesSource": "Metrics",
+      "haveCustomValuesSelected": false,
+      "id": "deployment_environment_name",
+      "key": "deployment_environment_name",
+      "modificationUUID": "8c8553da-16ce-42b0-a7d0-6f02cfef1266",
+      "multiSelect": true,
+      "name": "deployment_environment_name",
+      "order": 2,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    },
+    "deployment_environment": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Optional legacy environment label selector.",
+      "dynamicVariablesAttribute": "deployment.environment",
+      "dynamicVariablesSource": "Metrics",
+      "haveCustomValuesSelected": false,
+      "id": "deployment_environment",
+      "key": "deployment_environment",
+      "modificationUUID": "e2895253-5e5b-4d9c-8844-d2aff99d8520",
+      "multiSelect": true,
+      "name": "deployment_environment",
+      "order": 3,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    }
+  },
+  "version": "v5",
+  "widgets": [
+    {
+      "description": "",
+      "id": "apiserver-discovery",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "apiserver_request_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "service.name",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{service.name}}",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Auto-Discovered API Services",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "req-rate",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "apiserver_request_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "req/s",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "API Requests / s",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "inflight",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "apiserver_current_inflight_requests",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "inflight",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Inflight Requests",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "",
+      "id": "longrunning",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "apiserver_longrunning_requests",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "long-running",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Long Running Requests",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "",
+      "id": "goroutines",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "go_goroutines",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "goroutines",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Go Routines",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "",
+      "id": "req-verb",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "apiserver_request_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "verb",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{verb}}",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Rate By Verb",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "req-code",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "apiserver_request_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "code",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{code}}",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Rate By Status Code",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "req-lat-buckets",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "apiserver_request_sli_duration_seconds.bucket",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "le",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "<={{le}}s",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request SLI Duration Buckets",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "workqueue-depth",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "workqueue_depth",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "name",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{name}}",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Workqueue Depth",
+      "yAxisUnit": "short"
+    }
+  ]
+}

--- a/k8s-system-monitoring/kubernetes-controller-manager.json
+++ b/k8s-system-monitoring/kubernetes-controller-manager.json
@@ -1,0 +1,576 @@
+{
+  "description": "Standard control-plane view for kube-controller-manager workqueues, retries, and client request pressure.",
+  "layout": [
+    {
+      "x": 0,
+      "y": 0,
+      "w": 3,
+      "h": 2,
+      "i": "controller-discovery",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 3,
+      "y": 0,
+      "w": 3,
+      "h": 2,
+      "i": "workqueue-adds",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 6,
+      "y": 0,
+      "w": 3,
+      "h": 2,
+      "i": "workqueue-retries",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 9,
+      "y": 0,
+      "w": 3,
+      "h": 2,
+      "i": "cm-goroutines",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 0,
+      "y": 2,
+      "w": 6,
+      "h": 5,
+      "i": "cm-rss",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 6,
+      "y": 2,
+      "w": 6,
+      "h": 5,
+      "i": "cm-queue-depth",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 0,
+      "y": 7,
+      "w": 6,
+      "h": 5,
+      "i": "cm-queue-duration",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 6,
+      "y": 7,
+      "w": 6,
+      "h": 5,
+      "i": "cm-work-duration",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 0,
+      "y": 12,
+      "w": 6,
+      "h": 5,
+      "i": "cm-rest-client",
+      "moved": false,
+      "static": false
+    }
+  ],
+  "panelMap": {},
+  "tags": [
+    "kubernetes",
+    "control-plane",
+    "controller-manager",
+    "prometheus"
+  ],
+  "title": "Kubernetes Controller Manager",
+  "uploadedGrafana": false,
+  "uuid": "c1590a90-75e1-450f-a6eb-63f54f12f724",
+  "variables": {
+    "service_name": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Auto-discovered services (from metric labels).",
+      "dynamicVariablesAttribute": "service.name",
+      "dynamicVariablesSource": "Metrics",
+      "haveCustomValuesSelected": false,
+      "id": "service_name",
+      "key": "service_name",
+      "modificationUUID": "b3bf8532-923d-4dc7-a1d5-c8bf1902f88c",
+      "multiSelect": true,
+      "name": "service_name",
+      "order": 0,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    },
+    "k8s_cluster_name": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Optional cluster label selector.",
+      "dynamicVariablesAttribute": "k8s.cluster.name",
+      "dynamicVariablesSource": "Metrics",
+      "haveCustomValuesSelected": false,
+      "id": "k8s_cluster_name",
+      "key": "k8s_cluster_name",
+      "modificationUUID": "abebdef2-14b0-452f-8600-b8d2b12e0d5e",
+      "multiSelect": true,
+      "name": "k8s_cluster_name",
+      "order": 1,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    },
+    "deployment_environment_name": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Optional OTel environment label selector.",
+      "dynamicVariablesAttribute": "deployment.environment.name",
+      "dynamicVariablesSource": "Metrics",
+      "haveCustomValuesSelected": false,
+      "id": "deployment_environment_name",
+      "key": "deployment_environment_name",
+      "modificationUUID": "b59eaae9-b674-482c-94a0-f9cadd026b1a",
+      "multiSelect": true,
+      "name": "deployment_environment_name",
+      "order": 2,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    },
+    "deployment_environment": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Optional legacy environment label selector.",
+      "dynamicVariablesAttribute": "deployment.environment",
+      "dynamicVariablesSource": "Metrics",
+      "haveCustomValuesSelected": false,
+      "id": "deployment_environment",
+      "key": "deployment_environment",
+      "modificationUUID": "3fd46406-4b9e-484a-8ff8-aa55228e4056",
+      "multiSelect": true,
+      "name": "deployment_environment",
+      "order": 3,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    }
+  },
+  "version": "v5",
+  "widgets": [
+    {
+      "description": "",
+      "id": "controller-discovery",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "workqueue_adds_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "service.name",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{service.name}}",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Auto-Discovered Controller Services",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "workqueue-adds",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "workqueue_adds_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "adds/s",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Workqueue Adds / s",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "workqueue-retries",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "workqueue_retries_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "retries/s",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Workqueue Retries / s",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "cm-goroutines",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "go_goroutines",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "goroutines",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Go Routines",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "",
+      "id": "cm-rss",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "process_resident_memory_bytes",
+                  "reduceTo": "last",
+                  "spaceAggregation": "avg",
+                  "temporality": null,
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "rss",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Process RSS",
+      "yAxisUnit": "By"
+    },
+    {
+      "description": "",
+      "id": "cm-queue-depth",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "workqueue_depth",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "name",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{name}}",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Workqueue Depth By Queue",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "",
+      "id": "cm-queue-duration",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "workqueue_queue_duration_seconds.bucket",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "le",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "<={{le}}s",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Workqueue Queue Duration Buckets",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "cm-work-duration",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "workqueue_work_duration_seconds.bucket",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "le",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "<={{le}}s",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Workqueue Work Duration Buckets",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "cm-rest-client",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "rest_client_requests_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "code",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{code}}",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "REST Client Requests By Code",
+      "yAxisUnit": "reqps"
+    }
+  ]
+}

--- a/k8s-system-monitoring/kubernetes-coredns.json
+++ b/k8s-system-monitoring/kubernetes-coredns.json
@@ -1,0 +1,607 @@
+{
+  "description": "Cluster DNS view for request volume, cache efficiency signals, and request duration buckets.",
+  "layout": [
+    {
+      "x": 0,
+      "y": 0,
+      "w": 3,
+      "h": 2,
+      "i": "coredns-discovery",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 3,
+      "y": 0,
+      "w": 3,
+      "h": 2,
+      "i": "dns-requests-rate",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 6,
+      "y": 0,
+      "w": 3,
+      "h": 2,
+      "i": "cache-hits-rate",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 9,
+      "y": 0,
+      "w": 3,
+      "h": 2,
+      "i": "cache-misses-rate",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 0,
+      "y": 2,
+      "w": 6,
+      "h": 5,
+      "i": "dns-panics-rate",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 6,
+      "y": 2,
+      "w": 6,
+      "h": 5,
+      "i": "dns-requests-rcode",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 0,
+      "y": 7,
+      "w": 6,
+      "h": 5,
+      "i": "dns-requests-type",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 6,
+      "y": 7,
+      "w": 6,
+      "h": 5,
+      "i": "dns-duration-buckets",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 0,
+      "y": 12,
+      "w": 6,
+      "h": 5,
+      "i": "dns-goroutines",
+      "moved": false,
+      "static": false
+    }
+  ],
+  "panelMap": {},
+  "tags": [
+    "kubernetes",
+    "dns",
+    "coredns",
+    "prometheus"
+  ],
+  "title": "Kubernetes CoreDNS",
+  "uploadedGrafana": false,
+  "uuid": "887743a8-186e-45ec-b437-05bcfd3ab0ce",
+  "variables": {
+    "service_name": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Auto-discovered services (from metric labels).",
+      "dynamicVariablesAttribute": "service.name",
+      "dynamicVariablesSource": "Metrics",
+      "haveCustomValuesSelected": false,
+      "id": "service_name",
+      "key": "service_name",
+      "modificationUUID": "8cf9ec49-9138-4003-ba41-0c769322c666",
+      "multiSelect": true,
+      "name": "service_name",
+      "order": 0,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    },
+    "k8s_cluster_name": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Optional cluster label selector.",
+      "dynamicVariablesAttribute": "k8s.cluster.name",
+      "dynamicVariablesSource": "Metrics",
+      "haveCustomValuesSelected": false,
+      "id": "k8s_cluster_name",
+      "key": "k8s_cluster_name",
+      "modificationUUID": "ed1d5340-77af-46a9-9eb5-b9b1fd8aab74",
+      "multiSelect": true,
+      "name": "k8s_cluster_name",
+      "order": 1,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    },
+    "deployment_environment_name": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Optional OTel environment label selector.",
+      "dynamicVariablesAttribute": "deployment.environment.name",
+      "dynamicVariablesSource": "Metrics",
+      "haveCustomValuesSelected": false,
+      "id": "deployment_environment_name",
+      "key": "deployment_environment_name",
+      "modificationUUID": "bb0b6234-7900-4b02-a60f-ac5c7f1009f2",
+      "multiSelect": true,
+      "name": "deployment_environment_name",
+      "order": 2,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    },
+    "deployment_environment": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Optional legacy environment label selector.",
+      "dynamicVariablesAttribute": "deployment.environment",
+      "dynamicVariablesSource": "Metrics",
+      "haveCustomValuesSelected": false,
+      "id": "deployment_environment",
+      "key": "deployment_environment",
+      "modificationUUID": "333de612-6529-4caf-9e46-1370409f9700",
+      "multiSelect": true,
+      "name": "deployment_environment",
+      "order": 3,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    }
+  },
+  "version": "v5",
+  "widgets": [
+    {
+      "description": "",
+      "id": "coredns-discovery",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "coredns_dns_requests_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "service.name",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{service.name}}",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Auto-Discovered CoreDNS Services",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "dns-requests-rate",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "coredns_dns_requests_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "requests/s",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "DNS Requests / s",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "cache-hits-rate",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "coredns_cache_requests_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "requests/s",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "coredns_cache_misses_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": true,
+              "expression": "B",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "misses/s",
+              "queryName": "B",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": [
+            {
+              "disabled": false,
+              "expression": "A - B",
+              "legend": "hits/s",
+              "queryName": "F1"
+            }
+          ]
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Cache Hits / s",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "cache-misses-rate",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "coredns_cache_misses_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "misses/s",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Cache Misses / s",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "dns-panics-rate",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "coredns_panics_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "panics/s",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Panics / s",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "dns-requests-rcode",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "coredns_dns_requests_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "rcode",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{rcode}}",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "DNS Requests By Rcode",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "dns-requests-type",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "coredns_dns_requests_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "type",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{type}}",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "DNS Requests By Record Type",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "dns-duration-buckets",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "coredns_dns_request_duration_seconds.bucket",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "le",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "<={{le}}s",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "DNS Request Duration Buckets",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "dns-goroutines",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "go_goroutines",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "service.instance.id",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{service.instance.id}}",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Go Routines By Instance",
+      "yAxisUnit": "short"
+    }
+  ]
+}

--- a/k8s-system-monitoring/kubernetes-etcd.json
+++ b/k8s-system-monitoring/kubernetes-etcd.json
@@ -1,0 +1,576 @@
+{
+  "description": "Standard etcd view using native etcd server metrics (leadership, proposals, client request traffic, and storage latency).",
+  "layout": [
+    {
+      "x": 0,
+      "y": 0,
+      "w": 3,
+      "h": 2,
+      "i": "etcd-discovery",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 3,
+      "y": 0,
+      "w": 3,
+      "h": 2,
+      "i": "etcd-client-requests-rate",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 6,
+      "y": 0,
+      "w": 3,
+      "h": 2,
+      "i": "etcd-has-leader",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 9,
+      "y": 0,
+      "w": 3,
+      "h": 2,
+      "i": "etcd-proposals-pending",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 0,
+      "y": 2,
+      "w": 6,
+      "h": 5,
+      "i": "etcd-db-size",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 6,
+      "y": 2,
+      "w": 6,
+      "h": 5,
+      "i": "etcd-client-requests-type",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 0,
+      "y": 7,
+      "w": 6,
+      "h": 5,
+      "i": "etcd-apply-duration-buckets",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 6,
+      "y": 7,
+      "w": 6,
+      "h": 5,
+      "i": "etcd-range-duration-buckets",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 0,
+      "y": 12,
+      "w": 6,
+      "h": 5,
+      "i": "etcd-wal-fsync-buckets",
+      "moved": false,
+      "static": false
+    }
+  ],
+  "panelMap": {},
+  "tags": [
+    "kubernetes",
+    "control-plane",
+    "etcd",
+    "prometheus"
+  ],
+  "title": "Kubernetes Etcd",
+  "uploadedGrafana": false,
+  "uuid": "47fc1cf0-3d7c-4ed3-a6e6-f0b7fa3fa355",
+  "variables": {
+    "service_name": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Auto-discovered services (from metric labels).",
+      "dynamicVariablesAttribute": "service.name",
+      "dynamicVariablesSource": "Metrics",
+      "haveCustomValuesSelected": false,
+      "id": "service_name",
+      "key": "service_name",
+      "modificationUUID": "0c6f8306-86fb-418d-aa05-36703c8e212f",
+      "multiSelect": true,
+      "name": "service_name",
+      "order": 0,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    },
+    "k8s_cluster_name": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Optional cluster label selector.",
+      "dynamicVariablesAttribute": "k8s.cluster.name",
+      "dynamicVariablesSource": "Metrics",
+      "haveCustomValuesSelected": false,
+      "id": "k8s_cluster_name",
+      "key": "k8s_cluster_name",
+      "modificationUUID": "3a3ee930-c756-44e1-9ca7-038d0ef70b27",
+      "multiSelect": true,
+      "name": "k8s_cluster_name",
+      "order": 1,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    },
+    "deployment_environment_name": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Optional OTel environment label selector.",
+      "dynamicVariablesAttribute": "deployment.environment.name",
+      "dynamicVariablesSource": "Metrics",
+      "haveCustomValuesSelected": false,
+      "id": "deployment_environment_name",
+      "key": "deployment_environment_name",
+      "modificationUUID": "1d4cf3ee-de31-405a-81c6-ad5f766822a5",
+      "multiSelect": true,
+      "name": "deployment_environment_name",
+      "order": 2,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    },
+    "deployment_environment": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Optional legacy environment label selector.",
+      "dynamicVariablesAttribute": "deployment.environment",
+      "dynamicVariablesSource": "Metrics",
+      "haveCustomValuesSelected": false,
+      "id": "deployment_environment",
+      "key": "deployment_environment",
+      "modificationUUID": "08642e62-ac6f-4e30-8a85-bf5ac4f5244c",
+      "multiSelect": true,
+      "name": "deployment_environment",
+      "order": 3,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    }
+  },
+  "version": "v5",
+  "widgets": [
+    {
+      "description": "",
+      "id": "etcd-discovery",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "etcd_server_client_requests_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "service.name",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{service.name}}",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Auto-Discovered Etcd Services",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "etcd-client-requests-rate",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "etcd_server_client_requests_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "client req/s",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Client Requests / s",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "etcd-has-leader",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "etcd_server_has_leader",
+                  "reduceTo": "last",
+                  "spaceAggregation": "max",
+                  "temporality": null,
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "leader=1",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Has Leader",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "",
+      "id": "etcd-proposals-pending",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "etcd_server_proposals_pending",
+                  "reduceTo": "last",
+                  "spaceAggregation": "max",
+                  "temporality": null,
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "pending",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Proposals Pending",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "",
+      "id": "etcd-db-size",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "etcd_mvcc_db_total_size_in_bytes",
+                  "reduceTo": "last",
+                  "spaceAggregation": "max",
+                  "temporality": null,
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "db size",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "DB Size",
+      "yAxisUnit": "By"
+    },
+    {
+      "description": "",
+      "id": "etcd-client-requests-type",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "etcd_server_client_requests_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "type",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{type}}",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Client Requests By Type",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "etcd-apply-duration-buckets",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "etcd_server_apply_duration_seconds.bucket",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "le",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "<={{le}}s",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Apply Duration Buckets",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "etcd-range-duration-buckets",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "etcd_server_range_duration_seconds.bucket",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "le",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "<={{le}}s",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Range Duration Buckets",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "etcd-wal-fsync-buckets",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "etcd_disk_wal_fsync_duration_seconds.bucket",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "le",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "<={{le}}s",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "WAL Fsync Duration Buckets",
+      "yAxisUnit": "reqps"
+    }
+  ]
+}

--- a/k8s-system-monitoring/kubernetes-kube-proxy.json
+++ b/k8s-system-monitoring/kubernetes-kube-proxy.json
@@ -1,0 +1,576 @@
+{
+  "description": "Network-agent view for kube-proxy sync loops, network programming durations, and client request rates.",
+  "layout": [
+    {
+      "x": 0,
+      "y": 0,
+      "w": 3,
+      "h": 2,
+      "i": "proxy-discovery",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 3,
+      "y": 0,
+      "w": 3,
+      "h": 2,
+      "i": "proxy-sync-rate",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 6,
+      "y": 0,
+      "w": 3,
+      "h": 2,
+      "i": "proxy-netprog-rate",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 9,
+      "y": 0,
+      "w": 3,
+      "h": 2,
+      "i": "proxy-goroutines",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 0,
+      "y": 2,
+      "w": 6,
+      "h": 5,
+      "i": "proxy-rss",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 6,
+      "y": 2,
+      "w": 6,
+      "h": 5,
+      "i": "proxy-sync-buckets",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 0,
+      "y": 7,
+      "w": 6,
+      "h": 5,
+      "i": "proxy-netprog-buckets",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 6,
+      "y": 7,
+      "w": 6,
+      "h": 5,
+      "i": "proxy-rest-client",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 0,
+      "y": 12,
+      "w": 6,
+      "h": 5,
+      "i": "proxy-sync-last-ts",
+      "moved": false,
+      "static": false
+    }
+  ],
+  "panelMap": {},
+  "tags": [
+    "kubernetes",
+    "node",
+    "kube-proxy",
+    "prometheus"
+  ],
+  "title": "Kubernetes Kube Proxy",
+  "uploadedGrafana": false,
+  "uuid": "1fd5d5c6-9bb6-4dc6-bc0c-4eebb8bb367c",
+  "variables": {
+    "service_name": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Auto-discovered services (from metric labels).",
+      "dynamicVariablesAttribute": "service.name",
+      "dynamicVariablesSource": "Metrics",
+      "haveCustomValuesSelected": false,
+      "id": "service_name",
+      "key": "service_name",
+      "modificationUUID": "df83b99b-0524-46b1-addd-459a7aea11a6",
+      "multiSelect": true,
+      "name": "service_name",
+      "order": 0,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    },
+    "k8s_cluster_name": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Optional cluster label selector.",
+      "dynamicVariablesAttribute": "k8s.cluster.name",
+      "dynamicVariablesSource": "Metrics",
+      "haveCustomValuesSelected": false,
+      "id": "k8s_cluster_name",
+      "key": "k8s_cluster_name",
+      "modificationUUID": "03e49ad1-3a32-4677-8e73-a1e54e650a40",
+      "multiSelect": true,
+      "name": "k8s_cluster_name",
+      "order": 1,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    },
+    "deployment_environment_name": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Optional OTel environment label selector.",
+      "dynamicVariablesAttribute": "deployment.environment.name",
+      "dynamicVariablesSource": "Metrics",
+      "haveCustomValuesSelected": false,
+      "id": "deployment_environment_name",
+      "key": "deployment_environment_name",
+      "modificationUUID": "b3a11086-9179-4b9d-9400-47f8e5a529d4",
+      "multiSelect": true,
+      "name": "deployment_environment_name",
+      "order": 2,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    },
+    "deployment_environment": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Optional legacy environment label selector.",
+      "dynamicVariablesAttribute": "deployment.environment",
+      "dynamicVariablesSource": "Metrics",
+      "haveCustomValuesSelected": false,
+      "id": "deployment_environment",
+      "key": "deployment_environment",
+      "modificationUUID": "688a724a-4062-4c89-bb9c-7b4d707396cc",
+      "multiSelect": true,
+      "name": "deployment_environment",
+      "order": 3,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    }
+  },
+  "version": "v5",
+  "widgets": [
+    {
+      "description": "",
+      "id": "proxy-discovery",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "kubeproxy_sync_proxy_rules_duration_seconds.count",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "service.name",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{service.name}}",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Auto-Discovered Kube-Proxy Services",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "proxy-sync-rate",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "kubeproxy_sync_proxy_rules_duration_seconds.count",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "sync/s",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Sync Proxy Rules / s",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "proxy-netprog-rate",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "kubeproxy_network_programming_duration_seconds.count",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "events/s",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Network Programming / s",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "proxy-goroutines",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "go_goroutines",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "goroutines",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Go Routines",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "",
+      "id": "proxy-rss",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "process_resident_memory_bytes",
+                  "reduceTo": "last",
+                  "spaceAggregation": "avg",
+                  "temporality": null,
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "rss",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Process RSS",
+      "yAxisUnit": "By"
+    },
+    {
+      "description": "",
+      "id": "proxy-sync-buckets",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "kubeproxy_sync_proxy_rules_duration_seconds.bucket",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "le",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "<={{le}}s",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Sync Proxy Rules Duration Buckets",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "proxy-netprog-buckets",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "kubeproxy_network_programming_duration_seconds.bucket",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "le",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "<={{le}}s",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Network Programming Duration Buckets",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "proxy-rest-client",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "rest_client_requests_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "code",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{code}}",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "REST Client Requests By Code",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "proxy-sync-last-ts",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "kubeproxy_sync_proxy_rules_last_timestamp_seconds",
+                  "reduceTo": "last",
+                  "spaceAggregation": "max",
+                  "temporality": null,
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "service.instance.id",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{service.instance.id}}",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Last Sync Timestamp",
+      "yAxisUnit": "seconds"
+    }
+  ]
+}

--- a/k8s-system-monitoring/kubernetes-kubelet.json
+++ b/k8s-system-monitoring/kubernetes-kubelet.json
@@ -1,0 +1,582 @@
+{
+  "description": "Node-agent view for kubelet runtime operations, pod lifecycle, and storage operation latencies.",
+  "layout": [
+    {
+      "x": 0,
+      "y": 0,
+      "w": 3,
+      "h": 2,
+      "i": "kubelet-discovery",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 3,
+      "y": 0,
+      "w": 3,
+      "h": 2,
+      "i": "kubelet-running-pods",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 6,
+      "y": 0,
+      "w": 3,
+      "h": 2,
+      "i": "kubelet-running-containers",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 9,
+      "y": 0,
+      "w": 3,
+      "h": 2,
+      "i": "kubelet-runtime-errors",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 0,
+      "y": 2,
+      "w": 6,
+      "h": 5,
+      "i": "kubelet-goroutines",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 6,
+      "y": 2,
+      "w": 6,
+      "h": 5,
+      "i": "kubelet-runtime-ops-type",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 0,
+      "y": 7,
+      "w": 6,
+      "h": 5,
+      "i": "kubelet-runtime-errors-type",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 6,
+      "y": 7,
+      "w": 6,
+      "h": 5,
+      "i": "kubelet-pod-start-buckets",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 0,
+      "y": 12,
+      "w": 6,
+      "h": 5,
+      "i": "kubelet-storage-buckets",
+      "moved": false,
+      "static": false
+    }
+  ],
+  "panelMap": {},
+  "tags": [
+    "kubernetes",
+    "node",
+    "kubelet",
+    "prometheus"
+  ],
+  "title": "Kubernetes Kubelet",
+  "uploadedGrafana": false,
+  "uuid": "7533ad63-0093-478e-8a43-dfac263b4868",
+  "variables": {
+    "service_name": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Auto-discovered services (from metric labels).",
+      "dynamicVariablesAttribute": "service.name",
+      "dynamicVariablesSource": "Metrics",
+      "haveCustomValuesSelected": false,
+      "id": "service_name",
+      "key": "service_name",
+      "modificationUUID": "ed5ecbc8-eedf-4b13-8d7b-9dc72ac4d82b",
+      "multiSelect": true,
+      "name": "service_name",
+      "order": 0,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    },
+    "k8s_cluster_name": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Optional cluster label selector.",
+      "dynamicVariablesAttribute": "k8s.cluster.name",
+      "dynamicVariablesSource": "Metrics",
+      "haveCustomValuesSelected": false,
+      "id": "k8s_cluster_name",
+      "key": "k8s_cluster_name",
+      "modificationUUID": "df36bd5e-7830-47c0-8dae-e05672814b09",
+      "multiSelect": true,
+      "name": "k8s_cluster_name",
+      "order": 1,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    },
+    "deployment_environment_name": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Optional OTel environment label selector.",
+      "dynamicVariablesAttribute": "deployment.environment.name",
+      "dynamicVariablesSource": "Metrics",
+      "haveCustomValuesSelected": false,
+      "id": "deployment_environment_name",
+      "key": "deployment_environment_name",
+      "modificationUUID": "a4ebef75-d74b-4040-bb7c-a1e3c1813ca2",
+      "multiSelect": true,
+      "name": "deployment_environment_name",
+      "order": 2,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    },
+    "deployment_environment": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Optional legacy environment label selector.",
+      "dynamicVariablesAttribute": "deployment.environment",
+      "dynamicVariablesSource": "Metrics",
+      "haveCustomValuesSelected": false,
+      "id": "deployment_environment",
+      "key": "deployment_environment",
+      "modificationUUID": "b5d4285b-13d3-47fb-b3be-36eba476bef4",
+      "multiSelect": true,
+      "name": "deployment_environment",
+      "order": 3,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    }
+  },
+  "version": "v5",
+  "widgets": [
+    {
+      "description": "",
+      "id": "kubelet-discovery",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "kubelet_running_pods",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "service.name",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{service.name}}",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Auto-Discovered Kubelet Services",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "",
+      "id": "kubelet-running-pods",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "kubelet_running_pods",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "pods",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Running Pods",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "",
+      "id": "kubelet-running-containers",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "kubelet_running_containers",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "containers",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Running Containers",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "",
+      "id": "kubelet-runtime-errors",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "kubelet_started_pods_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "started/s",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Started Pods / s",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "kubelet-goroutines",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "go_goroutines",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "goroutines",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Go Routines",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "",
+      "id": "kubelet-runtime-ops-type",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "kubelet_runtime_operations_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "operation_type",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{operation_type}}",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Runtime Operations / s By Type",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "kubelet-runtime-errors-type",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "kubelet_runtime_operations_duration_seconds.bucket",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "operation_type",
+                  "type": "tag"
+                },
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "le",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{operation_type}} <= {{le}}s",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Runtime Operation Duration Buckets",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "kubelet-pod-start-buckets",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "kubelet_pod_start_duration_seconds.bucket",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "le",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "<={{le}}s",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Pod Start Duration Buckets",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "kubelet-storage-buckets",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "storage_operation_duration_seconds.bucket",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "le",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "<={{le}}s",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Storage Operation Duration Buckets",
+      "yAxisUnit": "reqps"
+    }
+  ]
+}

--- a/k8s-system-monitoring/kubernetes-scheduler.json
+++ b/k8s-system-monitoring/kubernetes-scheduler.json
@@ -1,0 +1,576 @@
+{
+  "description": "Standard control-plane view for kube-scheduler queue pressure, scheduling throughput, and duration buckets.",
+  "layout": [
+    {
+      "x": 0,
+      "y": 0,
+      "w": 3,
+      "h": 2,
+      "i": "scheduler-discovery",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 3,
+      "y": 0,
+      "w": 3,
+      "h": 2,
+      "i": "attempts-rate",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 6,
+      "y": 0,
+      "w": 3,
+      "h": 2,
+      "i": "pending-pods",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 9,
+      "y": 0,
+      "w": 3,
+      "h": 2,
+      "i": "scheduler-goroutines",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 0,
+      "y": 2,
+      "w": 6,
+      "h": 5,
+      "i": "scheduler-rss",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 6,
+      "y": 2,
+      "w": 6,
+      "h": 5,
+      "i": "attempts-result",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 0,
+      "y": 7,
+      "w": 6,
+      "h": 5,
+      "i": "e2e-buckets",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 6,
+      "y": 7,
+      "w": 6,
+      "h": 5,
+      "i": "framework-buckets",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 0,
+      "y": 12,
+      "w": 6,
+      "h": 5,
+      "i": "scheduler-workqueue-depth",
+      "moved": false,
+      "static": false
+    }
+  ],
+  "panelMap": {},
+  "tags": [
+    "kubernetes",
+    "control-plane",
+    "scheduler",
+    "prometheus"
+  ],
+  "title": "Kubernetes Scheduler",
+  "uploadedGrafana": false,
+  "uuid": "57211d32-6ec0-4d0e-8d31-c3b1e7bc39b9",
+  "variables": {
+    "service_name": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Auto-discovered services (from metric labels).",
+      "dynamicVariablesAttribute": "service.name",
+      "dynamicVariablesSource": "Metrics",
+      "haveCustomValuesSelected": false,
+      "id": "service_name",
+      "key": "service_name",
+      "modificationUUID": "d5b1e5bc-3865-4243-a6e1-60cd9a94ee66",
+      "multiSelect": true,
+      "name": "service_name",
+      "order": 0,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    },
+    "k8s_cluster_name": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Optional cluster label selector.",
+      "dynamicVariablesAttribute": "k8s.cluster.name",
+      "dynamicVariablesSource": "Metrics",
+      "haveCustomValuesSelected": false,
+      "id": "k8s_cluster_name",
+      "key": "k8s_cluster_name",
+      "modificationUUID": "5b3d5925-3348-4e25-9992-a1ec4ce546ec",
+      "multiSelect": true,
+      "name": "k8s_cluster_name",
+      "order": 1,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    },
+    "deployment_environment_name": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Optional OTel environment label selector.",
+      "dynamicVariablesAttribute": "deployment.environment.name",
+      "dynamicVariablesSource": "Metrics",
+      "haveCustomValuesSelected": false,
+      "id": "deployment_environment_name",
+      "key": "deployment_environment_name",
+      "modificationUUID": "d35c6992-7cf7-4d51-bc6d-5785931f2813",
+      "multiSelect": true,
+      "name": "deployment_environment_name",
+      "order": 2,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    },
+    "deployment_environment": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Optional legacy environment label selector.",
+      "dynamicVariablesAttribute": "deployment.environment",
+      "dynamicVariablesSource": "Metrics",
+      "haveCustomValuesSelected": false,
+      "id": "deployment_environment",
+      "key": "deployment_environment",
+      "modificationUUID": "03ca36f5-95c3-4834-9015-31ce76b77def",
+      "multiSelect": true,
+      "name": "deployment_environment",
+      "order": 3,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    }
+  },
+  "version": "v5",
+  "widgets": [
+    {
+      "description": "",
+      "id": "scheduler-discovery",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "scheduler_schedule_attempts_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "service.name",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{service.name}}",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Auto-Discovered Scheduler Services",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "attempts-rate",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "scheduler_schedule_attempts_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "attempts/s",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Scheduling Attempts / s",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "pending-pods",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "scheduler_pending_pods",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "pending",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Pending Pods",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "",
+      "id": "scheduler-goroutines",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "go_goroutines",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "goroutines",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Go Routines",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "",
+      "id": "scheduler-rss",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "process_resident_memory_bytes",
+                  "reduceTo": "last",
+                  "spaceAggregation": "avg",
+                  "temporality": null,
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "rss",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Process RSS",
+      "yAxisUnit": "By"
+    },
+    {
+      "description": "",
+      "id": "attempts-result",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "scheduler_schedule_attempts_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "result",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{result}}",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Scheduling Attempts By Result",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "e2e-buckets",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "scheduler_scheduling_attempt_duration_seconds.bucket",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "le",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "<={{le}}s",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "E2E Scheduling Duration Buckets",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "framework-buckets",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "scheduler_framework_extension_point_duration_seconds.bucket",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "extension_point",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{extension_point}}",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Framework Extension Duration Buckets",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "scheduler-workqueue-depth",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "workqueue_depth",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "name",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{name}}",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Workqueue Depth",
+      "yAxisUnit": "short"
+    }
+  ]
+}

--- a/k8s-system-monitoring/kubernetes-system-overview.json
+++ b/k8s-system-monitoring/kubernetes-system-overview.json
@@ -1,0 +1,1079 @@
+{
+  "description": "Combined view across control-plane, node, networking, and DNS components with distro-neutral service scoping.",
+  "layout": [
+    {
+      "x": 0,
+      "y": 0,
+      "w": 3,
+      "h": 2,
+      "i": "overview-apiserver-rate",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 3,
+      "y": 0,
+      "w": 3,
+      "h": 2,
+      "i": "overview-scheduler-rate",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 6,
+      "y": 0,
+      "w": 3,
+      "h": 2,
+      "i": "overview-controller-rate",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 9,
+      "y": 0,
+      "w": 3,
+      "h": 2,
+      "i": "overview-etcd-rate",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 0,
+      "y": 2,
+      "w": 3,
+      "h": 2,
+      "i": "overview-kubelet-running-pods",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 3,
+      "y": 2,
+      "w": 3,
+      "h": 2,
+      "i": "overview-kubeproxy-rate",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 6,
+      "y": 2,
+      "w": 3,
+      "h": 2,
+      "i": "overview-coredns-rate",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 9,
+      "y": 2,
+      "w": 3,
+      "h": 2,
+      "i": "overview-etcd-leader",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 0,
+      "y": 4,
+      "w": 6,
+      "h": 5,
+      "i": "overview-component-rates",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 6,
+      "y": 4,
+      "w": 6,
+      "h": 5,
+      "i": "overview-apiserver-codes",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 0,
+      "y": 9,
+      "w": 6,
+      "h": 5,
+      "i": "overview-scheduler-result",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 6,
+      "y": 9,
+      "w": 6,
+      "h": 5,
+      "i": "overview-controller-depth",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 0,
+      "y": 14,
+      "w": 6,
+      "h": 5,
+      "i": "overview-etcd-apply-buckets",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 6,
+      "y": 14,
+      "w": 6,
+      "h": 5,
+      "i": "overview-kubelet-runtime-ops",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 0,
+      "y": 19,
+      "w": 6,
+      "h": 5,
+      "i": "overview-kubeproxy-netprog-buckets",
+      "moved": false,
+      "static": false
+    },
+    {
+      "x": 6,
+      "y": 19,
+      "w": 6,
+      "h": 5,
+      "i": "overview-coredns-rcode",
+      "moved": false,
+      "static": false
+    }
+  ],
+  "panelMap": {},
+  "tags": [
+    "kubernetes",
+    "overview",
+    "control-plane",
+    "node",
+    "dns",
+    "prometheus"
+  ],
+  "title": "Kubernetes System Overview",
+  "uploadedGrafana": false,
+  "uuid": "969d6e27-d252-4a11-9a79-920fd1ac52ba",
+  "variables": {
+    "service_name": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Auto-discovered services (from metric labels).",
+      "dynamicVariablesAttribute": "service.name",
+      "dynamicVariablesSource": "Metrics",
+      "haveCustomValuesSelected": false,
+      "id": "service_name",
+      "key": "service_name",
+      "modificationUUID": "02332f8c-17a4-4cec-9bfe-68a88221588d",
+      "multiSelect": true,
+      "name": "service_name",
+      "order": 0,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    },
+    "k8s_cluster_name": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Optional cluster label selector.",
+      "dynamicVariablesAttribute": "k8s.cluster.name",
+      "dynamicVariablesSource": "Metrics",
+      "haveCustomValuesSelected": false,
+      "id": "k8s_cluster_name",
+      "key": "k8s_cluster_name",
+      "modificationUUID": "591efb06-ae66-4347-a1c0-991fdc85ff86",
+      "multiSelect": true,
+      "name": "k8s_cluster_name",
+      "order": 1,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    },
+    "deployment_environment_name": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Optional OTel environment label selector.",
+      "dynamicVariablesAttribute": "deployment.environment.name",
+      "dynamicVariablesSource": "Metrics",
+      "haveCustomValuesSelected": false,
+      "id": "deployment_environment_name",
+      "key": "deployment_environment_name",
+      "modificationUUID": "7d624750-8053-4abb-a37c-df14fc26d519",
+      "multiSelect": true,
+      "name": "deployment_environment_name",
+      "order": 2,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    },
+    "deployment_environment": {
+      "allSelected": true,
+      "customValue": "",
+      "defaultValue": "",
+      "description": "Optional legacy environment label selector.",
+      "dynamicVariablesAttribute": "deployment.environment",
+      "dynamicVariablesSource": "Metrics",
+      "haveCustomValuesSelected": false,
+      "id": "deployment_environment",
+      "key": "deployment_environment",
+      "modificationUUID": "315f7647-ff03-451e-8d99-a9e243c8c6e1",
+      "multiSelect": true,
+      "name": "deployment_environment",
+      "order": 3,
+      "queryValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "DYNAMIC"
+    }
+  },
+  "version": "v5",
+  "widgets": [
+    {
+      "description": "",
+      "id": "overview-apiserver-rate",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "apiserver_request_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "apiserver req/s",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "API Requests / s",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "overview-scheduler-rate",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "scheduler_schedule_attempts_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "scheduler attempts/s",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Scheduling Attempts / s",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "overview-controller-rate",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "workqueue_adds_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "controller adds/s",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Controller Workqueue Adds / s",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "overview-etcd-rate",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "etcd_server_client_requests_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "etcd req/s",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Etcd Client Requests / s",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "overview-kubelet-running-pods",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "kubelet_running_pods",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "running pods",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Kubelet Running Pods",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "",
+      "id": "overview-kubeproxy-rate",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "kubeproxy_sync_proxy_rules_duration_seconds.count",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "proxy sync/s",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Proxy Sync / s",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "overview-coredns-rate",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "coredns_dns_requests_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "dns req/s",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "CoreDNS Requests / s",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "overview-etcd-leader",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "etcd_server_has_leader",
+                  "reduceTo": "last",
+                  "spaceAggregation": "max",
+                  "temporality": null,
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "leader=1",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Etcd Has Leader",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "",
+      "id": "overview-component-rates",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "apiserver_request_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "kube-apiserver",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "scheduler_schedule_attempts_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "B",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "kube-scheduler",
+              "queryName": "B",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "workqueue_adds_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "C",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "kube-controller-manager",
+              "queryName": "C",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "etcd_server_client_requests_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "D",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "etcd",
+              "queryName": "D",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "kubelet_started_pods_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "E",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "kubelet",
+              "queryName": "E",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "kubeproxy_sync_proxy_rules_duration_seconds.count",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "F",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "kube-proxy",
+              "queryName": "F",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "coredns_dns_requests_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "G",
+              "groupBy": [],
+              "having": {
+                "expression": ""
+              },
+              "legend": "coredns",
+              "queryName": "G",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Component Throughput Trends",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "overview-apiserver-codes",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "apiserver_request_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "code",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{code}}",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "API Request Rate By Code",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "overview-scheduler-result",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "scheduler_schedule_attempts_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "result",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{result}}",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Scheduling Attempts By Result",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "overview-controller-depth",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "workqueue_depth",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "name",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{name}}",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Controller Workqueue Depth",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "",
+      "id": "overview-etcd-apply-buckets",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "etcd_server_apply_duration_seconds.bucket",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "le",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "<={{le}}s",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Etcd Apply Duration Buckets",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "overview-kubelet-runtime-ops",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "kubelet_runtime_operations_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "operation_type",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{operation_type}}",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Kubelet Runtime Ops / s By Type",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "overview-kubeproxy-netprog-buckets",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "kubeproxy_network_programming_duration_seconds.bucket",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "le",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "<={{le}}s",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Proxy Network Programming Duration Buckets",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "overview-coredns-rcode",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregations": [
+                {
+                  "metricName": "coredns_dns_requests_total",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": null,
+                  "timeAggregation": "rate"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "isColumn": false,
+                  "key": "rcode",
+                  "type": "tag"
+                }
+              ],
+              "having": {
+                "expression": ""
+              },
+              "legend": "{{rcode}}",
+              "queryName": "A",
+              "stepInterval": 60,
+              "filter": {
+                "expression": "service.name IN $service_name"
+              }
+            }
+          ],
+          "queryFormulas": []
+        },
+        "queryType": "builder"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "CoreDNS Requests By Rcode",
+      "yAxisUnit": "reqps"
+    }
+  ]
+}


### PR DESCRIPTION
  Introduce a generic dashboard set that works across self-managed
  Kubernetes distributions (k3s, minikube, RKE2, Rancher/RKE2, kubeadm)
  without per-distro forks.

  System component dashboards (k8s-system-monitoring/):
  - kubernetes-system-overview.json: combined health view across components
  - kubernetes-apiserver.json
  - kubernetes-scheduler.json
  - kubernetes-controller-manager.json
  - kubernetes-etcd.json
  - kubernetes-kubelet.json
  - kubernetes-kube-proxy.json
  - kubernetes-coredns.json

  Workload dashboard (k8s-infra-metrics/):
  - kubernetes-cronjobs.json: current state and recent runs for CronJobs and the Jobs they create, using k8sclusterreceiver metrics (k8s.cronjob.active_jobs, k8s.job.{active,successful,failed, desired_successful,max_parallel}_pods)

  Why agnostic:
  - Dashboards key off generic OpenTelemetry metric names and the standard k8s.* / deployment.environment.* resource attributes, not distro-specific labels or endpoints.
  - Optional scope variables (k8s_cluster_name, deployment_environment_name, deployment_environment) support multi-cluster and multi-env reuse.

  Validation:
  - Real-cluster, non-mock runs on k3s, minikube, and Rancher/RKE2 all pass. kubeadm/kind path is tracked separately (kind bootstrap issue on the test host).
  - CronJob dashboard end-to-end verified: metrics flow from an OrbStack cluster through k8s-infra into the target SigNoz instance, and every variable query and panel metric resolves against real k8s.cronjob.* / k8s.job.* samples.