### PR TITLE
feat: add AWS MSK Prometheus monitoring dashboard

### DIFF
--- a/aws-msk-prometheus/README.md
+++ b/aws-msk-prometheus/README.md
@@ -1,0 +1,128 @@
+# AWS MSK Cluster Monitoring - Prometheus
+
+Comprehensive monitoring dashboard for **AWS Managed Streaming for Apache Kafka (MSK)** clusters using Prometheus metrics collected via `kafka_exporter` (Daniel Czerwonk) and the JMX Prometheus exporter, with optional CloudWatch metrics sourced through `prometheus-cloudwatch-exporter`.
+
+---
+
+## Metrics Ingestion
+
+### Option A: kafka_exporter (recommended)
+
+Deploy [kafka_exporter](https://github.com/danielqsj/kafka_exporter) pointing at your MSK bootstrap brokers:
+
+```bash
+docker run -d \
+  --name kafka-exporter \
+  -p 9308:9308 \
+  danielqsj/kafka-exporter \
+  --kafka.server=<MSK_BOOTSTRAP_BROKER>:9092
+```
+
+Then add the following scrape config to your OpenTelemetry Collector:
+
+```yaml
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: kafka-exporter
+          scrape_interval: 30s
+          static_configs:
+            - targets: ["kafka-exporter:9308"]
+              labels:
+                cluster_name: my-msk-cluster
+
+exporters:
+  otlp:
+    endpoint: "<signoz-endpoint>:4317"
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      exporters: [otlp]
+```
+
+### Option B: JMX Prometheus Exporter (for JVM metrics)
+
+Enable JMX on each MSK broker and deploy the [jmx_prometheus_javaagent](https://github.com/prometheus/jmx_exporter) to expose `jvm_memory_bytes_used`, `jvm_gc_collection_seconds_sum`, and Kafka server metrics.
+
+### Option C: CloudWatch via prometheus-cloudwatch-exporter (optional)
+
+To populate the CloudWatch-backed panels (`aws_msk_bytes_in_per_sec_average`, `aws_msk_cpu_user_average`, `aws_msk_consumer_lag_offsets_maximum`), deploy [yet-another-cloudwatch-exporter](https://github.com/nerdswords/yet-another-cloudwatch-exporter) with a config targeting MSK metrics from the `AWS/Kafka` namespace.
+
+---
+
+## Variables
+
+This dashboard uses no template variables by default. All panels work with metric labels for grouping. You can optionally add a SigNoz variable for `cluster_name` or `broker_id` to filter panels to a specific cluster.
+
+---
+
+## Dashboard Panels
+
+### Cluster Overview (4 value panels)
+
+| Panel | Metric | Notes |
+|---|---|---|
+| Active Brokers | `kafka_brokers` | Count of reachable brokers |
+| Active Controllers | `kafka_controller_kafkacontroller_activecontrollercount` | Should always be exactly 1 |
+| Offline Partitions | `kafka_controller_kafkacontroller_offlinepartitionscount` | Should always be 0 |
+| Total Topics | `count(count by (topic)(kafka_topic_partitions))` | Distinct topic count |
+
+### Throughput (3 graph panels)
+
+- **Bytes In per Second** — `kafka_server_broker_metrics_bytes_in_per_sec` + `aws_msk_bytes_in_per_sec_average`
+- **Bytes Out per Second** — `kafka_server_broker_metrics_bytes_out_per_sec` + `aws_msk_bytes_out_per_sec_average`
+- **Messages In per Second** — `kafka_server_broker_metrics_messages_in_per_sec`
+
+### Consumer Groups (3 graph panels)
+
+- **Consumer Group Lag** — `kafka_consumergroup_lag` + `aws_msk_consumer_lag_offsets_maximum` (critical SLA metric)
+- **Consumer Group Lag Sum** — `kafka_consumergroup_lag_sum` aggregated per group
+- **Consumer Offset Commit Rate** — derived from `kafka_consumergroup_current_offset`
+
+### Partitions (3 graph panels)
+
+- **Partition Count by Topic** — `kafka_topic_partitions`
+- **Under-Replicated Partitions** — `kafka_topic_partition_replicas - kafka_topic_partition_in_sync_replica`
+- **In-Sync Replicas** — `kafka_topic_partition_in_sync_replica`
+
+### Performance (4 graph panels)
+
+- **Request Latency P99** — `histogram_quantile(0.99, ...)` over `kafka_network_request_metrics_total_time_ms_bucket`
+- **Broker CPU Utilization** — `aws_msk_cpu_user_average`
+- **JVM Heap Memory Used** — `jvm_memory_bytes_used{area="heap"}`
+- **JVM GC Pause Time** — `rate(jvm_gc_collection_seconds_sum[5m])`
+
+### Storage (3 graph panels)
+
+- **Log Size by Topic** — `kafka_log_log_size`
+- **Current Offset by Topic** — `kafka_topic_partition_current_offset`
+- **Oldest Offset by Topic** — `kafka_topic_partition_oldest_offset`
+
+### Replication & Stability (3 graph panels)
+
+- **Replica Count by Topic** — `kafka_topic_partition_replicas`
+- **Leader Election Rate** — `kafka_controller_kafkacontroller_leaderelectionrateandtimems_count`
+- **Unclean Leader Election Rate** — should be 0; any non-zero value indicates potential data loss
+
+---
+
+## Key Alerts to Configure
+
+| Condition | Threshold | Severity |
+|---|---|---|
+| `kafka_controller_kafkacontroller_offlinepartitionscount > 0` | Immediate | Critical |
+| `kafka_controller_kafkacontroller_activecontrollercount != 1` | Immediate | Critical |
+| `kafka_consumergroup_lag_sum > <threshold>` | SLA-dependent | Warning |
+| `kafka_topic_partition_replicas - kafka_topic_partition_in_sync_replica > 0` | Sustained >5m | Warning |
+| Unclean leader elections > 0 | Any occurrence | Critical |
+
+---
+
+## Related Issue
+
+Requested in [signoz/signoz#6036](https://github.com/signoz/signoz/issues/6036).

--- a/aws-msk-prometheus/aws-msk-prometheus-v2.json
+++ b/aws-msk-prometheus/aws-msk-prometheus-v2.json
@@ -1,0 +1,1833 @@
+{
+  "description": "Comprehensive AWS MSK (Managed Streaming for Kafka) cluster monitoring using Prometheus metrics from kafka_exporter and JMX exporter, with optional CloudWatch metrics via prometheus-cloudwatch-exporter.",
+  "layout": [
+    {
+      "h": 6,
+      "i": "68c46ac9-0b2e-4e77-8ddb-59fc0e08e2f6",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 6,
+      "i": "925ae2b5-5070-493e-bf7c-7d0f08069def",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 3,
+      "y": 0
+    },
+    {
+      "h": 6,
+      "i": "2564f04d-9ff8-44c8-a63a-e41b1d11ee1d",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 6,
+      "y": 0
+    },
+    {
+      "h": 6,
+      "i": "dac48004-3170-45fe-8ad2-d6e0d541004b",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 9,
+      "y": 0
+    },
+    {
+      "h": 7,
+      "i": "8c1d39c6-03ce-46e7-828b-682936024637",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 6
+    },
+    {
+      "h": 7,
+      "i": "e5d333fb-71ca-44d0-95e7-3a7c4f1de854",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 6
+    },
+    {
+      "h": 7,
+      "i": "dc047996-0511-4160-9e66-aa9d1cf54ebb",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 13
+    },
+    {
+      "h": 7,
+      "i": "854dd132-4b04-4800-adc6-eff6f5a43f86",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 20
+    },
+    {
+      "h": 7,
+      "i": "7f845389-d86e-41a2-ba61-30bbd27887fc",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 20
+    },
+    {
+      "h": 7,
+      "i": "bc203275-3501-4146-bf07-8453bcbaff9c",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 27
+    },
+    {
+      "h": 7,
+      "i": "425981d5-7aa0-464b-a903-5bf2a8556110",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 34
+    },
+    {
+      "h": 7,
+      "i": "09242a03-aa9b-4ccd-9532-6f6d6c6574e8",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 34
+    },
+    {
+      "h": 7,
+      "i": "f49902e8-ffd9-4e9c-aa14-8261f70f5a67",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 34
+    },
+    {
+      "h": 7,
+      "i": "7fa8202c-8604-4a65-be04-9f984aadafe2",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 41
+    },
+    {
+      "h": 7,
+      "i": "6e9c47aa-8a32-4508-b5ef-96985cd65f3b",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 41
+    },
+    {
+      "h": 7,
+      "i": "4108c60e-66ef-443b-bbca-4ba61efe8f14",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 48
+    },
+    {
+      "h": 7,
+      "i": "c7d7f21d-abb5-4deb-807c-eb12450ccccf",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 48
+    },
+    {
+      "h": 7,
+      "i": "0b05f615-3f9e-4309-a30d-8bd396011602",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 55
+    },
+    {
+      "h": 7,
+      "i": "43ec5415-77a8-4a31-8904-c98f6a8910d4",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 55
+    },
+    {
+      "h": 7,
+      "i": "2dc03f3c-b7c7-416e-b1b6-1de601e07887",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 55
+    },
+    {
+      "h": 7,
+      "i": "18c33216-2c40-48c0-b210-317850da2f16",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 62
+    },
+    {
+      "h": 7,
+      "i": "bd17a69f-6bbd-49b5-8fa7-ac6d4514d941",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 62
+    },
+    {
+      "h": 7,
+      "i": "b43a5851-f2b9-44c2-83ba-24d90d06ee4a",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 62
+    }
+  ],
+  "panelMap": {},
+  "tags": [
+    "aws",
+    "msk",
+    "kafka",
+    "prometheus",
+    "streaming",
+    "kafka-exporter",
+    "jmx"
+  ],
+  "title": "AWS MSK Cluster Monitoring",
+  "uploadedGrafana": false,
+  "variables": {},
+  "version": "v4",
+  "widgets": [
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of active Kafka brokers in the MSK cluster",
+      "fillSpans": false,
+      "id": "68c46ac9-0b2e-4e77-8ddb-59fc0e08e2f6",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "68c46ac9-0b2e-4e77-8ddb-59fc0e08e2f6",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{job}}",
+            "name": "A",
+            "query": "kafka_brokers"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Brokers",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of active Kafka controllers (should always be 1)",
+      "fillSpans": false,
+      "id": "925ae2b5-5070-493e-bf7c-7d0f08069def",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "925ae2b5-5070-493e-bf7c-7d0f08069def",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{cluster_name}}",
+            "name": "A",
+            "query": "kafka_controller_kafkacontroller_activecontrollercount"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Controllers",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of offline partitions \u2014 should be 0; any value above indicates data unavailability",
+      "fillSpans": false,
+      "id": "2564f04d-9ff8-44c8-a63a-e41b1d11ee1d",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "2564f04d-9ff8-44c8-a63a-e41b1d11ee1d",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{cluster_name}}",
+            "name": "A",
+            "query": "kafka_controller_kafkacontroller_offlinepartitionscount"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Offline Partitions",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total number of distinct Kafka topics across the cluster",
+      "fillSpans": false,
+      "id": "dac48004-3170-45fe-8ad2-d6e0d541004b",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "dac48004-3170-45fe-8ad2-d6e0d541004b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{job}}",
+            "name": "A",
+            "query": "count(count by (topic)(kafka_topic_partitions))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Total Topics",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Ingress throughput in bytes/s per broker (JMX) and via CloudWatch exporter",
+      "fillSpans": false,
+      "id": "8c1d39c6-03ce-46e7-828b-682936024637",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "8c1d39c6-03ce-46e7-828b-682936024637",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Broker {{broker_id}} (JMX)",
+            "name": "A",
+            "query": "sum(rate(kafka_server_broker_metrics_bytes_in_per_sec[5m])) by (broker_id)"
+          },
+          {
+            "disabled": false,
+            "legend": "{{broker_id}} (CW)",
+            "name": "B",
+            "query": "aws_msk_bytes_in_per_sec_average"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Bytes In per Second",
+      "yAxisUnit": "binBps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Egress throughput in bytes/s per broker (JMX) and via CloudWatch exporter",
+      "fillSpans": false,
+      "id": "e5d333fb-71ca-44d0-95e7-3a7c4f1de854",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "e5d333fb-71ca-44d0-95e7-3a7c4f1de854",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Broker {{broker_id}} (JMX)",
+            "name": "A",
+            "query": "sum(rate(kafka_server_broker_metrics_bytes_out_per_sec[5m])) by (broker_id)"
+          },
+          {
+            "disabled": false,
+            "legend": "{{broker_id}} (CW)",
+            "name": "B",
+            "query": "aws_msk_bytes_out_per_sec_average"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Bytes Out per Second",
+      "yAxisUnit": "binBps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Message ingestion rate per broker",
+      "fillSpans": false,
+      "id": "dc047996-0511-4160-9e66-aa9d1cf54ebb",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "dc047996-0511-4160-9e66-aa9d1cf54ebb",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Broker {{broker_id}}",
+            "name": "A",
+            "query": "sum(rate(kafka_server_broker_metrics_messages_in_per_sec[5m])) by (broker_id)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Messages In per Second",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Per-partition consumer group lag. High lag means consumers are falling behind producers.",
+      "fillSpans": false,
+      "id": "854dd132-4b04-4800-adc6-eff6f5a43f86",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "854dd132-4b04-4800-adc6-eff6f5a43f86",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{consumergroup}} / {{topic}} / p{{partition}}",
+            "name": "A",
+            "query": "kafka_consumergroup_lag"
+          },
+          {
+            "disabled": false,
+            "legend": "{{consumergroup}} (CW max)",
+            "name": "B",
+            "query": "aws_msk_consumer_lag_offsets_maximum"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Consumer Group Lag",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total lag per consumer group summed across all partitions",
+      "fillSpans": false,
+      "id": "7f845389-d86e-41a2-ba61-30bbd27887fc",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "7f845389-d86e-41a2-ba61-30bbd27887fc",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{consumergroup}}",
+            "name": "A",
+            "query": "sum by (consumergroup)(kafka_consumergroup_lag_sum)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Consumer Group Lag Sum",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of consumer offset commits per consumer group (approximate messages consumed/s)",
+      "fillSpans": false,
+      "id": "bc203275-3501-4146-bf07-8453bcbaff9c",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "bc203275-3501-4146-bf07-8453bcbaff9c",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{consumergroup}} / {{topic}}",
+            "name": "A",
+            "query": "sum(rate(kafka_consumergroup_current_offset[5m])) by (consumergroup, topic)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Consumer Offset Commit Rate",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of partitions per Kafka topic",
+      "fillSpans": false,
+      "id": "425981d5-7aa0-464b-a903-5bf2a8556110",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "425981d5-7aa0-464b-a903-5bf2a8556110",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{topic}}",
+            "name": "A",
+            "query": "kafka_topic_partitions"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Partition Count by Topic",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Partitions where ISR count is less than the configured replication factor",
+      "fillSpans": false,
+      "id": "09242a03-aa9b-4ccd-9532-6f6d6c6574e8",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "09242a03-aa9b-4ccd-9532-6f6d6c6574e8",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{topic}} / p{{partition}}",
+            "name": "A",
+            "query": "kafka_topic_partition_replicas - kafka_topic_partition_in_sync_replica"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Under-Replicated Partitions",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "In-sync replica count per partition. Should equal the replication factor.",
+      "fillSpans": false,
+      "id": "f49902e8-ffd9-4e9c-aa14-8261f70f5a67",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "f49902e8-ffd9-4e9c-aa14-8261f70f5a67",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{topic}} / p{{partition}}",
+            "name": "A",
+            "query": "kafka_topic_partition_in_sync_replica"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "In-Sync Replicas",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "99th percentile end-to-end broker request latency in milliseconds by request type",
+      "fillSpans": false,
+      "id": "7fa8202c-8604-4a65-be04-9f984aadafe2",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "7fa8202c-8604-4a65-be04-9f984aadafe2",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{request}} P99",
+            "name": "A",
+            "query": "histogram_quantile(0.99, sum by (request, le)(rate(kafka_network_request_metrics_total_time_ms_bucket[5m])))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Latency P99 (ms)",
+      "yAxisUnit": "ms"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "CPU user-space utilization per broker node (CloudWatch metric)",
+      "fillSpans": false,
+      "id": "6e9c47aa-8a32-4508-b5ef-96985cd65f3b",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "6e9c47aa-8a32-4508-b5ef-96985cd65f3b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{broker_id}}",
+            "name": "A",
+            "query": "aws_msk_cpu_user_average"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Broker CPU Utilization",
+      "yAxisUnit": "percent"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "JVM heap memory consumed in bytes per broker instance",
+      "fillSpans": false,
+      "id": "4108c60e-66ef-443b-bbca-4ba61efe8f14",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "4108c60e-66ef-443b-bbca-4ba61efe8f14",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{instance}}",
+            "name": "A",
+            "query": "jvm_memory_bytes_used{area='heap'}"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "JVM Heap Memory Used",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of GC pause time in seconds/s per broker \u2014 elevated values degrade consumer throughput",
+      "fillSpans": false,
+      "id": "c7d7f21d-abb5-4deb-807c-eb12450ccccf",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "c7d7f21d-abb5-4deb-807c-eb12450ccccf",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{instance}} {{gc}}",
+            "name": "A",
+            "query": "rate(jvm_gc_collection_seconds_sum[5m])"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "JVM GC Pause Time",
+      "yAxisUnit": "s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "On-disk log storage consumed per topic (sum of all partitions)",
+      "fillSpans": false,
+      "id": "0b05f615-3f9e-4309-a30d-8bd396011602",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "0b05f615-3f9e-4309-a30d-8bd396011602",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{topic}}",
+            "name": "A",
+            "query": "sum by (topic)(kafka_log_log_size)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Log Size by Topic",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Latest log-end offset per topic \u2014 proxy for total messages ever produced",
+      "fillSpans": false,
+      "id": "43ec5415-77a8-4a31-8904-c98f6a8910d4",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "43ec5415-77a8-4a31-8904-c98f6a8910d4",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{topic}}",
+            "name": "A",
+            "query": "sum by (topic)(kafka_topic_partition_current_offset)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Current Offset by Topic",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Oldest available offset per topic \u2014 indicates the log retention boundary",
+      "fillSpans": false,
+      "id": "2dc03f3c-b7c7-416e-b1b6-1de601e07887",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "2dc03f3c-b7c7-416e-b1b6-1de601e07887",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{topic}}",
+            "name": "A",
+            "query": "sum by (topic)(kafka_topic_partition_oldest_offset)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Oldest Offset by Topic",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total configured replicas per topic",
+      "fillSpans": false,
+      "id": "18c33216-2c40-48c0-b210-317850da2f16",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "18c33216-2c40-48c0-b210-317850da2f16",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{topic}}",
+            "name": "A",
+            "query": "sum by (topic)(kafka_topic_partition_replicas)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Replica Count by Topic",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of partition leader elections per second. Frequent elections indicate instability.",
+      "fillSpans": false,
+      "id": "bd17a69f-6bbd-49b5-8fa7-ac6d4514d941",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "bd17a69f-6bbd-49b5-8fa7-ac6d4514d941",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{cluster_name}}",
+            "name": "A",
+            "query": "rate(kafka_controller_kafkacontroller_leaderelectionrateandtimems_count[5m])"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Leader Election Rate",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Rate of unclean leader elections (out-of-sync replica elected). Should be 0 \u2014 indicates potential data loss.",
+      "fillSpans": false,
+      "id": "b43a5851-f2b9-44c2-83ba-24d90d06ee4a",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "b43a5851-f2b9-44c2-83ba-24d90d06ee4a",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{cluster_name}}",
+            "name": "A",
+            "query": "rate(kafka_controller_kafkacontroller_uncleanleaderelectionsenablerateandtimems_count[5m])"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Unclean Leader Election Rate",
+      "yAxisUnit": "short"
+    }
+  ]
+}


### PR DESCRIPTION
Closes SigNoz/signoz#6036

/claim SigNoz/signoz#6036

## Dashboard: AWS MSK Cluster Monitoring

Adds comprehensive AWS MSK cluster Prometheus dashboard with 23 panels across 6 sections.

### Sections:
- **Cluster Overview**: Active brokers, controllers, offline partitions, total topics
- **Throughput**: Bytes in/out, messages in/s (JMX + CloudWatch dual-source)
- **Consumer Groups**: Per-partition lag, lag sum, offset commit rate
- **Partitions**: Partition count, under-replicated, in-sync replicas
- **Performance**: Request latency P99, CPU, JVM heap, GC pause
- **Storage & Replication**: Log size, offsets, replica count, leader elections