### PR TITLE
Add ASP.NET Core Prometheus dashboard

### DIFF
--- a/aspnet-core/README.md
+++ b/aspnet-core/README.md
@@ -1,0 +1,111 @@
+# ASP.NET Core Dashboard - Prometheus
+
+Monitors ASP.NET Core applications using Prometheus metrics exposed via the `prometheus-net` or built-in OpenTelemetry Prometheus exporter. Covers HTTP request throughput and latency, exception tracking, memory/GC, thread pool health, and Kestrel connection metrics.
+
+## Metrics Ingestion
+
+### 1. Expose Prometheus metrics from your app
+
+Add the `prometheus-net.AspNetCore` NuGet package and wire it up in `Program.cs`:
+
+```csharp
+using Prometheus;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddOpenTelemetry()
+    .WithMetrics(metrics => metrics.AddAspNetCoreInstrumentation()
+                                   .AddRuntimeInstrumentation()
+                                   .AddPrometheusExporter());
+
+var app = builder.Build();
+app.MapPrometheusScrapingEndpoint(); // exposes /metrics
+app.Run();
+```
+
+Or with the legacy `prometheus-net` approach:
+
+```csharp
+app.UseHttpMetrics();
+app.MapMetrics(); // /metrics
+```
+
+### 2. Scrape with OpenTelemetry Collector
+
+Add a Prometheus receiver in your `otel-config.yaml` and forward to SigNoz:
+
+```yaml
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: aspnetcore
+          scrape_interval: 15s
+          static_configs:
+            - targets: ["localhost:5000"]
+
+exporters:
+  otlp:
+    endpoint: "<your-signoz-host>:4317"
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      exporters: [otlp]
+```
+
+## Variables
+
+This dashboard has no variables — it shows all ASP.NET Core instances together. To filter by service, add a `job` variable using the label values of the `http_server_request_duration_seconds_count` metric.
+
+## Dashboard Panels
+
+### Overview
+| Panel | Metric | Type |
+|---|---|---|
+| Active Requests | `http_server_active_requests` | Value |
+| Request Rate | `http_server_request_duration_seconds_count` | Graph |
+| Error Rate (5xx) | `http_server_request_duration_seconds_count{http_response_status_code=~"5.."}` | Graph |
+| Average Request Duration | `http_server_request_duration_seconds_sum/count` | Value |
+
+### HTTP Requests
+| Panel | Metric | Type |
+|---|---|---|
+| Request Rate by Endpoint | `http_server_request_duration_seconds_count` by `http_route` | Graph |
+| P99 Duration by Endpoint | `http_server_request_duration_seconds_bucket` histogram_quantile(0.99) | Graph |
+| P95 Duration by Endpoint | `http_server_request_duration_seconds_bucket` histogram_quantile(0.95) | Graph |
+| Requests by Status Code | `http_server_request_duration_seconds_count` by `http_response_status_code` | Graph (stacked) |
+
+### Exceptions
+| Panel | Metric | Type |
+|---|---|---|
+| Exception Rate | `aspnetcore_diagnostics_exceptions_total` | Graph |
+| Exceptions by Type | `aspnetcore_diagnostics_exceptions_total` by `exception_type` | Graph |
+
+### Memory
+| Panel | Metric | Type |
+|---|---|---|
+| Process Working Set | `process_working_set_bytes` | Graph |
+| GC Heap Size | `dotnet_gc_heap_size_bytes` | Graph |
+| GC Collections Rate | `dotnet_gc_collections_total` | Graph |
+
+### Threading
+| Panel | Metric | Type |
+|---|---|---|
+| Thread Pool Threads | `dotnet_threadpool_threads` | Graph |
+| Thread Pool Queue Length | `dotnet_threadpool_queue_length` | Graph |
+
+### Kestrel
+| Panel | Metric | Type |
+|---|---|---|
+| Active Connections | `kestrel_active_connections` | Graph |
+| Connection Duration (P95) | `kestrel_connection_duration_seconds_bucket` histogram_quantile(0.95) | Graph |
+| Queued Requests | `kestrel_queued_requests` | Graph |
+
+## Minimum .NET / SDK versions
+
+- .NET 8+ for `http_server_*` semantic convention metrics (OpenTelemetry)
+- `prometheus-net` 8+ for `kestrel_*` and `dotnet_*` metrics
+- For .NET 6/7, some metric names may differ — check your exporter docs

--- a/aspnet-core/aspnet-core-prometheus-v1.json
+++ b/aspnet-core/aspnet-core-prometheus-v1.json
@@ -1,0 +1,1809 @@
+{
+  "description": "ASP.NET Core metrics monitoring dashboard using Prometheus. Covers HTTP request throughput, latency percentiles, error rates, exceptions, GC memory, thread pool, and Kestrel connection metrics.",
+  "layout": [
+    {
+      "h": 1,
+      "i": "d3fb4cdb-89b0-4afc-9dc4-2e9ba14f437c",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 0,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 3,
+      "i": "9cb5f46a-0a71-484d-9bfe-b6b177d7d685",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 0,
+      "y": 1
+    },
+    {
+      "h": 6,
+      "i": "a492c692-946a-4ba8-b116-92d0ad2a33a9",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 3,
+      "y": 1
+    },
+    {
+      "h": 3,
+      "i": "ad15e07e-2583-4247-8e3d-f96fd89f381e",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 9,
+      "y": 1
+    },
+    {
+      "h": 3,
+      "i": "59f33387-d862-4d06-b325-0e5261732075",
+      "moved": false,
+      "static": false,
+      "w": 3,
+      "x": 0,
+      "y": 4
+    },
+    {
+      "h": 1,
+      "i": "1622e3fa-f14c-4373-a2d8-26c54322e91e",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 7,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 6,
+      "i": "8ee41801-7cb1-484a-9254-5e2e18af85ea",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 8
+    },
+    {
+      "h": 6,
+      "i": "afd305a7-f755-4655-afe3-42c19231ae84",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 8
+    },
+    {
+      "h": 6,
+      "i": "0214bc6c-ded7-401d-9a14-c3e6a7d16a00",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 14
+    },
+    {
+      "h": 6,
+      "i": "89cbdc62-410b-473d-a62e-d56f58bc162e",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 14
+    },
+    {
+      "h": 1,
+      "i": "a50458ad-2854-4f8b-b21f-954515144122",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 20,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 6,
+      "i": "dd9b5643-e571-4079-9a68-0d78d2a9c4cc",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 21
+    },
+    {
+      "h": 6,
+      "i": "9048ed83-c48a-4d3e-8c5c-852505481556",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 21
+    },
+    {
+      "h": 1,
+      "i": "77ea2fa5-5889-482a-aa2a-b443b31c1676",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 27,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 6,
+      "i": "20e7cc58-c9ad-4009-8893-0a4ac68ca860",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 28
+    },
+    {
+      "h": 6,
+      "i": "7beb4fba-04d2-4150-a076-065140abcfe7",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 28
+    },
+    {
+      "h": 6,
+      "i": "a2d2ddad-5a5c-469e-bb31-bebb443eeb4e",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 28
+    },
+    {
+      "h": 1,
+      "i": "c1b894e0-d953-47e1-a5fb-97a431fe7596",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 34,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 6,
+      "i": "ad0cf116-961a-42e2-9002-fcd9ee92b03b",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 35
+    },
+    {
+      "h": 6,
+      "i": "a7e5028b-7f3f-4acd-8b64-a12320c0b41e",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 35
+    },
+    {
+      "h": 1,
+      "i": "9b46e153-f36b-41b4-828a-c31905e3a39f",
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 41,
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12
+    },
+    {
+      "h": 6,
+      "i": "018e9a2e-3eee-4104-8db7-4a29987a4896",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 0,
+      "y": 42
+    },
+    {
+      "h": 6,
+      "i": "5033db60-50fe-40df-95dd-5c409360c750",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 4,
+      "y": 42
+    },
+    {
+      "h": 6,
+      "i": "11afffcf-b6fb-4dc3-ae35-18e3fa047ca5",
+      "moved": false,
+      "static": false,
+      "w": 4,
+      "x": 8,
+      "y": 42
+    }
+  ],
+  "panelMap": {
+    "d3fb4cdb-89b0-4afc-9dc4-2e9ba14f437c": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 3,
+          "i": "9cb5f46a-0a71-484d-9bfe-b6b177d7d685",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 0,
+          "y": 1
+        },
+        {
+          "h": 6,
+          "i": "a492c692-946a-4ba8-b116-92d0ad2a33a9",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 3,
+          "y": 1
+        },
+        {
+          "h": 3,
+          "i": "ad15e07e-2583-4247-8e3d-f96fd89f381e",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 9,
+          "y": 1
+        },
+        {
+          "h": 3,
+          "i": "59f33387-d862-4d06-b325-0e5261732075",
+          "moved": false,
+          "static": false,
+          "w": 3,
+          "x": 0,
+          "y": 4
+        }
+      ]
+    },
+    "1622e3fa-f14c-4373-a2d8-26c54322e91e": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "8ee41801-7cb1-484a-9254-5e2e18af85ea",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 8
+        },
+        {
+          "h": 6,
+          "i": "afd305a7-f755-4655-afe3-42c19231ae84",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 8
+        },
+        {
+          "h": 6,
+          "i": "0214bc6c-ded7-401d-9a14-c3e6a7d16a00",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 14
+        },
+        {
+          "h": 6,
+          "i": "89cbdc62-410b-473d-a62e-d56f58bc162e",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 14
+        }
+      ]
+    },
+    "a50458ad-2854-4f8b-b21f-954515144122": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "dd9b5643-e571-4079-9a68-0d78d2a9c4cc",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 21
+        },
+        {
+          "h": 6,
+          "i": "9048ed83-c48a-4d3e-8c5c-852505481556",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 21
+        }
+      ]
+    },
+    "77ea2fa5-5889-482a-aa2a-b443b31c1676": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "20e7cc58-c9ad-4009-8893-0a4ac68ca860",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 0,
+          "y": 28
+        },
+        {
+          "h": 6,
+          "i": "7beb4fba-04d2-4150-a076-065140abcfe7",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 4,
+          "y": 28
+        },
+        {
+          "h": 6,
+          "i": "a2d2ddad-5a5c-469e-bb31-bebb443eeb4e",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 8,
+          "y": 28
+        }
+      ]
+    },
+    "c1b894e0-d953-47e1-a5fb-97a431fe7596": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "ad0cf116-961a-42e2-9002-fcd9ee92b03b",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 0,
+          "y": 35
+        },
+        {
+          "h": 6,
+          "i": "a7e5028b-7f3f-4acd-8b64-a12320c0b41e",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 35
+        }
+      ]
+    },
+    "9b46e153-f36b-41b4-828a-c31905e3a39f": {
+      "collapsed": false,
+      "widgets": [
+        {
+          "h": 6,
+          "i": "018e9a2e-3eee-4104-8db7-4a29987a4896",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 0,
+          "y": 42
+        },
+        {
+          "h": 6,
+          "i": "5033db60-50fe-40df-95dd-5c409360c750",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 4,
+          "y": 42
+        },
+        {
+          "h": 6,
+          "i": "11afffcf-b6fb-4dc3-ae35-18e3fa047ca5",
+          "moved": false,
+          "static": false,
+          "w": 4,
+          "x": 8,
+          "y": 42
+        }
+      ]
+    }
+  },
+  "tags": [
+    "aspnet",
+    "dotnet",
+    "csharp",
+    "prometheus",
+    "microsoft",
+    "kestrel"
+  ],
+  "title": "ASP.NET Core Metrics",
+  "uploadedGrafana": false,
+  "variables": {},
+  "version": "v4",
+  "widgets": [
+    {
+      "description": "",
+      "id": "d3fb4cdb-89b0-4afc-9dc4-2e9ba14f437c",
+      "panelTypes": "row",
+      "query": {
+        "builder": {
+          "queryData": []
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "d3fb4cdb-89b0-4afc-9dc4-2e9ba14f437c",
+        "promql": [],
+        "queryType": "promql"
+      },
+      "title": "Overview"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Current number of active HTTP requests being processed",
+      "fillSpans": false,
+      "id": "9cb5f46a-0a71-484d-9bfe-b6b177d7d685",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "9cb5f46a-0a71-484d-9bfe-b6b177d7d685",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{job}}",
+            "name": "A",
+            "query": "http_server_active_requests"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active Requests",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "HTTP requests per second (all endpoints)",
+      "fillSpans": false,
+      "id": "a492c692-946a-4ba8-b116-92d0ad2a33a9",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "a492c692-946a-4ba8-b116-92d0ad2a33a9",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{job}}",
+            "name": "A",
+            "query": "sum(rate(http_server_request_duration_seconds_count[1m]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Rate",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "HTTP 5xx error requests per second",
+      "fillSpans": false,
+      "id": "ad15e07e-2583-4247-8e3d-f96fd89f381e",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "ad15e07e-2583-4247-8e3d-f96fd89f381e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{job}}",
+            "name": "A",
+            "query": "sum(rate(http_server_request_duration_seconds_count{http_response_status_code=~\"5..\"}[1m]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Error Rate (5xx)",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Average HTTP request duration in milliseconds",
+      "fillSpans": false,
+      "id": "59f33387-d862-4d06-b325-0e5261732075",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "value",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "59f33387-d862-4d06-b325-0e5261732075",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "avg",
+            "name": "A",
+            "query": "1000 * sum(rate(http_server_request_duration_seconds_sum[5m])) / sum(rate(http_server_request_duration_seconds_count[5m]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Average Request Duration",
+      "yAxisUnit": "ms"
+    },
+    {
+      "description": "",
+      "id": "1622e3fa-f14c-4373-a2d8-26c54322e91e",
+      "panelTypes": "row",
+      "query": {
+        "builder": {
+          "queryData": []
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "1622e3fa-f14c-4373-a2d8-26c54322e91e",
+        "promql": [],
+        "queryType": "promql"
+      },
+      "title": "HTTP Requests"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "HTTP requests per second broken down by route",
+      "fillSpans": false,
+      "id": "8ee41801-7cb1-484a-9254-5e2e18af85ea",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "8ee41801-7cb1-484a-9254-5e2e18af85ea",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{http_route}}",
+            "name": "A",
+            "query": "sum by (http_route) (rate(http_server_request_duration_seconds_count[1m]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Rate by Endpoint",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "99th percentile request duration per route",
+      "fillSpans": false,
+      "id": "afd305a7-f755-4655-afe3-42c19231ae84",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "afd305a7-f755-4655-afe3-42c19231ae84",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{http_route}}",
+            "name": "A",
+            "query": "histogram_quantile(0.99, sum by (http_route, le) (rate(http_server_request_duration_seconds_bucket[5m])))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "P99 Request Duration by Endpoint",
+      "yAxisUnit": "s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "95th percentile request duration per route",
+      "fillSpans": false,
+      "id": "0214bc6c-ded7-401d-9a14-c3e6a7d16a00",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "0214bc6c-ded7-401d-9a14-c3e6a7d16a00",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{http_route}}",
+            "name": "A",
+            "query": "histogram_quantile(0.95, sum by (http_route, le) (rate(http_server_request_duration_seconds_bucket[5m])))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "P95 Request Duration by Endpoint",
+      "yAxisUnit": "s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "HTTP requests per second grouped by status code",
+      "fillSpans": false,
+      "id": "89cbdc62-410b-473d-a62e-d56f58bc162e",
+      "isStacked": true,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "89cbdc62-410b-473d-a62e-d56f58bc162e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{http_response_status_code}}",
+            "name": "A",
+            "query": "sum by (http_response_status_code) (rate(http_server_request_duration_seconds_count[1m]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Requests by Status Code",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "a50458ad-2854-4f8b-b21f-954515144122",
+      "panelTypes": "row",
+      "query": {
+        "builder": {
+          "queryData": []
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "a50458ad-2854-4f8b-b21f-954515144122",
+        "promql": [],
+        "queryType": "promql"
+      },
+      "title": "Exceptions"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total application exceptions per second",
+      "fillSpans": false,
+      "id": "dd9b5643-e571-4079-9a68-0d78d2a9c4cc",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "dd9b5643-e571-4079-9a68-0d78d2a9c4cc",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{job}}",
+            "name": "A",
+            "query": "sum(rate(aspnetcore_diagnostics_exceptions_total[1m]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Exception Rate",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Exception rate broken down by exception type",
+      "fillSpans": false,
+      "id": "9048ed83-c48a-4d3e-8c5c-852505481556",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "9048ed83-c48a-4d3e-8c5c-852505481556",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{exception_type}}",
+            "name": "A",
+            "query": "sum by (exception_type) (rate(aspnetcore_diagnostics_exceptions_total[1m]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Exceptions by Type",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "",
+      "id": "77ea2fa5-5889-482a-aa2a-b443b31c1676",
+      "panelTypes": "row",
+      "query": {
+        "builder": {
+          "queryData": []
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "77ea2fa5-5889-482a-aa2a-b443b31c1676",
+        "promql": [],
+        "queryType": "promql"
+      },
+      "title": "Memory"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Memory working set of the process",
+      "fillSpans": false,
+      "id": "20e7cc58-c9ad-4009-8893-0a4ac68ca860",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "20e7cc58-c9ad-4009-8893-0a4ac68ca860",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{job}}",
+            "name": "A",
+            "query": "process_working_set_bytes"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Process Working Set",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Total .NET GC heap size in bytes",
+      "fillSpans": false,
+      "id": "7beb4fba-04d2-4150-a076-065140abcfe7",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "7beb4fba-04d2-4150-a076-065140abcfe7",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{generation}}",
+            "name": "A",
+            "query": "dotnet_gc_heap_size_bytes"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "GC Heap Size",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": ".NET GC collection rate per generation",
+      "fillSpans": false,
+      "id": "a2d2ddad-5a5c-469e-bb31-bebb443eeb4e",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "a2d2ddad-5a5c-469e-bb31-bebb443eeb4e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "gen {{generation}}",
+            "name": "A",
+            "query": "sum by (generation) (rate(dotnet_gc_collections_total[1m]))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "GC Collections Rate",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "",
+      "id": "c1b894e0-d953-47e1-a5fb-97a431fe7596",
+      "panelTypes": "row",
+      "query": {
+        "builder": {
+          "queryData": []
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "c1b894e0-d953-47e1-a5fb-97a431fe7596",
+        "promql": [],
+        "queryType": "promql"
+      },
+      "title": "Threading"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of active threads in the .NET thread pool",
+      "fillSpans": false,
+      "id": "ad0cf116-961a-42e2-9002-fcd9ee92b03b",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "ad0cf116-961a-42e2-9002-fcd9ee92b03b",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{job}}",
+            "name": "A",
+            "query": "dotnet_threadpool_threads"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Thread Pool Threads",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of work items queued to the .NET thread pool",
+      "fillSpans": false,
+      "id": "a7e5028b-7f3f-4acd-8b64-a12320c0b41e",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "a7e5028b-7f3f-4acd-8b64-a12320c0b41e",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{job}}",
+            "name": "A",
+            "query": "dotnet_threadpool_queue_length"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Thread Pool Queue Length",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "",
+      "id": "9b46e153-f36b-41b4-828a-c31905e3a39f",
+      "panelTypes": "row",
+      "query": {
+        "builder": {
+          "queryData": []
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "9b46e153-f36b-41b4-828a-c31905e3a39f",
+        "promql": [],
+        "queryType": "promql"
+      },
+      "title": "Kestrel"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of active connections to Kestrel",
+      "fillSpans": false,
+      "id": "018e9a2e-3eee-4104-8db7-4a29987a4896",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "018e9a2e-3eee-4104-8db7-4a29987a4896",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{job}}",
+            "name": "A",
+            "query": "kestrel_active_connections"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Kestrel Active Connections",
+      "yAxisUnit": "short"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "95th percentile connection duration for Kestrel",
+      "fillSpans": false,
+      "id": "5033db60-50fe-40df-95dd-5c409360c750",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "5033db60-50fe-40df-95dd-5c409360c750",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "p95",
+            "name": "A",
+            "query": "histogram_quantile(0.95, sum by (le) (rate(kestrel_connection_duration_seconds_bucket[5m])))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Kestrel Connection Duration (P95)",
+      "yAxisUnit": "s"
+    },
+    {
+      "bucketCount": 30,
+      "bucketWidth": 0,
+      "columnUnits": {},
+      "description": "Number of requests queued waiting for a connection",
+      "fillSpans": false,
+      "id": "11afffcf-b6fb-4dc3-ae35-18e3fa047ca5",
+      "isStacked": false,
+      "mergeAllActiveQueries": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "count",
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "pageSize": 10,
+              "reduceTo": "avg",
+              "spaceAggregation": "avg",
+              "stepInterval": 60
+            }
+          ]
+        },
+        "clickhouse_sql": {
+          "disabled": false,
+          "legend": "",
+          "name": "A",
+          "query": ""
+        },
+        "id": "11afffcf-b6fb-4dc3-ae35-18e3fa047ca5",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{job}}",
+            "name": "A",
+            "query": "kestrel_queued_requests"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "softMax": 0,
+      "softMin": 0,
+      "thresholds": [],
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Kestrel Queued Requests",
+      "yAxisUnit": "short"
+    }
+  ]
+}


### PR DESCRIPTION
Closes SigNoz/signoz#5996

/claim SigNoz/signoz#5996

## Dashboard: ASP.NET Core Metrics

Adds ASP.NET Core Prometheus monitoring dashboard with 18 panels across 6 sections.

### Sections:
- **Overview**: Active requests, request rate, 5xx error rate, avg duration
- **HTTP Requests**: Rate by endpoint, P99/P95 duration, status codes
- **Exceptions**: Exception rate, breakdown by type
- **Memory**: Working set, GC heap size, GC collections rate
- **Threading**: Thread pool threads, queue length
- **Kestrel**: Active connections, connection duration P95, queued requests