### PR TITLE
feat: add Istio service mesh dashboard (Prometheus)

### DIFF
--- a/istio/README.md
+++ b/istio/README.md
@@ -1,0 +1,151 @@
+# Istio Service Mesh Dashboard - Prometheus
+
+SigNoz dashboard for monitoring Istio service mesh traffic, latency, error rates, and control plane (Istiod) health using Prometheus metrics.
+
+## Prerequisites
+
+- Kubernetes cluster with Istio installed (v1.13+)
+- Istio telemetry v2 enabled (default since Istio 1.7)
+- SigNoz with Prometheus remote write configured, or OpenTelemetry Collector forwarding Prometheus metrics to SigNoz
+
+## Metrics Ingestion
+
+Istio exposes Prometheus metrics from the Envoy sidecar proxies and Istiod. To forward them to SigNoz, use the OpenTelemetry Collector with the `prometheus` receiver pointing at the Istio Prometheus instance, or scrape the sidecars directly.
+
+### Option 1: Scrape Istio's Prometheus via OTel Collector
+
+Deploy an OTel Collector that scrapes the existing Istio Prometheus and forwards to SigNoz:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-collector-config
+  namespace: istio-system
+data:
+  config.yaml: |
+    receivers:
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: 'istio-mesh'
+              kubernetes_sd_configs:
+                - role: pod
+                  namespaces:
+                    names: []
+              relabel_configs:
+                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+                  action: keep
+                  regex: 'true'
+                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+                  action: replace
+                  target_label: __metrics_path__
+                  regex: (.+)
+                - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+                  action: replace
+                  regex: ([^:]+)(?::\d+)?;(\d+)
+                  replacement: $1:$2
+                  target_label: __address__
+            - job_name: 'istiod'
+              kubernetes_sd_configs:
+                - role: endpoints
+                  namespaces:
+                    names:
+                      - istio-system
+              relabel_configs:
+                - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+                  action: keep
+                  regex: istiod;http-monitoring
+
+    processors:
+      batch:
+        timeout: 10s
+        send_batch_size: 1024
+
+    exporters:
+      otlp:
+        endpoint: "ingest.<region>.signoz.cloud:443"
+        tls:
+          insecure: false
+        headers:
+          signoz-ingestion-key: "<your-ingestion-key>"
+
+    service:
+      pipelines:
+        metrics:
+          receivers: [prometheus]
+          processors: [batch]
+          exporters: [otlp]
+```
+
+Replace:
+- `<region>`: Your SigNoz Cloud [region](https://signoz.io/docs/ingestion/signoz-cloud/overview/#endpoint)
+- `<your-ingestion-key>`: Your [ingestion key](https://signoz.io/docs/ingestion/signoz-cloud/keys/)
+
+### Option 2: Prometheus Remote Write to SigNoz
+
+Configure your existing Istio Prometheus to remote-write to SigNoz:
+
+```yaml
+# In your Prometheus configuration (prometheus.yml)
+remote_write:
+  - url: "https://ingest.<region>.signoz.cloud/api/prometheus/remote/write"
+    headers:
+      signoz-ingestion-key: "<your-ingestion-key>"
+    write_relabel_configs:
+      - source_labels: [__name__]
+        regex: "istio_.*|pilot_.*"
+        action: keep
+```
+
+## Variables
+
+| Variable | Description |
+|---|---|
+| `$namespace` | Kubernetes namespace to filter by (supports multi-select) |
+| `$destination_service` | Destination service name to filter by (supports multi-select) |
+
+## Dashboard Sections
+
+### Traffic Overview
+- **Incoming Request Rate (RPS)** — `istio_requests_total` rate by destination service
+- **5xx Error Rate** — Ratio of 5xx responses to total requests
+- **Average Request Size** — Mean request body size in bytes
+- **Average Response Size** — Mean response body size in bytes
+
+### Latency
+- **Request Latency p50** — Median request latency via `istio_request_duration_milliseconds_bucket`
+- **Request Latency p95** — 95th percentile request latency
+- **Request Latency p99** — 99th percentile request latency
+- **Latency Percentiles (All Services)** — p50/p95/p99 overlaid on one panel
+
+### Service Mesh Traffic
+- **Incoming Requests by Source Workload** — Traffic breakdown by `source_workload`
+- **Outgoing Requests by Destination** — Outbound traffic from the source reporter side
+- **HTTP Response Status Codes** — Distribution of all HTTP status codes
+- **gRPC Response Status Codes** — gRPC-specific status code distribution
+
+### Control Plane (Istiod / Pilot)
+- **Pilot xDS Push Rate by Type** — Rate of CDS/EDS/LDS/RDS pushes from Istiod (`pilot_xds_pushes`)
+- **Active xDS Connections** — Number of live Envoy proxy connections to Istiod (`pilot_xds`)
+- **Pilot xDS Push Errors** — Configuration delivery failures (`pilot_xds_push_errors`)
+- **Pilot Known Services** — Total services discovered by Istiod (`pilot_services`)
+
+### TCP Traffic
+- **TCP Bytes Sent** — `istio_tcp_sent_bytes_total` rate by destination service
+- **TCP Bytes Received** — `istio_tcp_received_bytes_total` rate by destination service
+
+## Key Istio Metrics Used
+
+| Metric | Description |
+|---|---|
+| `istio_requests_total` | Total HTTP/gRPC requests (counter) |
+| `istio_request_duration_milliseconds_bucket` | Request duration histogram |
+| `istio_request_bytes_sum` / `_count` | Request body size |
+| `istio_response_bytes_sum` / `_count` | Response body size |
+| `istio_tcp_sent_bytes_total` | TCP bytes sent |
+| `istio_tcp_received_bytes_total` | TCP bytes received |
+| `pilot_xds_pushes` | xDS configuration pushes from Istiod |
+| `pilot_xds` | Active xDS connections |
+| `pilot_xds_push_errors` | xDS push errors |
+| `pilot_services` | Services known to Istiod |

--- a/istio/istio-prometheus-v1.json
+++ b/istio/istio-prometheus-v1.json
@@ -1,0 +1,1467 @@
+{
+  "description": "Istio Service Mesh dashboard using Prometheus metrics. Covers traffic, latency, error rates, and control plane health.",
+  "layout": [
+    {
+      "h": 1,
+      "i": "row-traffic-overview",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 0
+    },
+    {
+      "h": 6,
+      "i": "w-request-rate",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 1
+    },
+    {
+      "h": 6,
+      "i": "w-error-rate",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 1
+    },
+    {
+      "h": 6,
+      "i": "w-request-size",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 7
+    },
+    {
+      "h": 6,
+      "i": "w-response-size",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 7
+    },
+    {
+      "h": 1,
+      "i": "row-latency",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 13
+    },
+    {
+      "h": 6,
+      "i": "w-latency-p50",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 14
+    },
+    {
+      "h": 6,
+      "i": "w-latency-p95",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 14
+    },
+    {
+      "h": 6,
+      "i": "w-latency-p99",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 20
+    },
+    {
+      "h": 6,
+      "i": "w-latency-by-service",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 20
+    },
+    {
+      "h": 1,
+      "i": "row-service-mesh",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 26
+    },
+    {
+      "h": 6,
+      "i": "w-incoming-requests-by-source",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 27
+    },
+    {
+      "h": 6,
+      "i": "w-outgoing-requests-by-dest",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 27
+    },
+    {
+      "h": 6,
+      "i": "w-http-status-codes",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 33
+    },
+    {
+      "h": 6,
+      "i": "w-grpc-status-codes",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 33
+    },
+    {
+      "h": 1,
+      "i": "row-control-plane",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 39
+    },
+    {
+      "h": 6,
+      "i": "w-pilot-xds-pushes",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 40
+    },
+    {
+      "h": 6,
+      "i": "w-pilot-xds-connections",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 40
+    },
+    {
+      "h": 6,
+      "i": "w-pilot-push-errors",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 46
+    },
+    {
+      "h": 6,
+      "i": "w-pilot-known-services",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 46
+    },
+    {
+      "h": 1,
+      "i": "row-tcp",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 52
+    },
+    {
+      "h": 6,
+      "i": "w-tcp-sent-bytes",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 53
+    },
+    {
+      "h": 6,
+      "i": "w-tcp-received-bytes",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 53
+    }
+  ],
+  "panelMap": {},
+  "tags": [
+    "istio",
+    "prometheus",
+    "service-mesh",
+    "kubernetes"
+  ],
+  "title": "Istio Service Mesh (Prometheus)",
+  "uploadedGrafana": false,
+  "variables": {
+    "namespace": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Kubernetes namespace",
+      "modificationUUID": "e1a2b3c4-d5e6-7890-abcd-ef1234567890",
+      "multiSelect": true,
+      "name": "namespace",
+      "queryValue": "label_values(istio_requests_total, destination_service_namespace)",
+      "selectedValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "QUERY"
+    },
+    "destination_service": {
+      "allSelected": true,
+      "customValue": "",
+      "description": "Destination service name",
+      "modificationUUID": "f2b3c4d5-e6f7-8901-bcde-f12345678901",
+      "multiSelect": true,
+      "name": "destination_service",
+      "queryValue": "label_values(istio_requests_total{destination_service_namespace=~\"$namespace\"}, destination_service_name)",
+      "selectedValue": "",
+      "showALLOption": true,
+      "sort": "DISABLED",
+      "textboxValue": "",
+      "type": "QUERY"
+    }
+  },
+  "version": "v4",
+  "widgets": [
+    {
+      "description": "",
+      "id": "row-traffic-overview",
+      "panelTypes": "row",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "id": "",
+        "queryType": "builder"
+      },
+      "title": "Traffic Overview"
+    },
+    {
+      "description": "Rate of incoming HTTP/gRPC requests per second, grouped by destination service.",
+      "id": "w-request-rate",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a1b2c3d4-e5f6-7890-abcd-000000000001",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{destination_service_name}}",
+            "name": "A",
+            "query": "sum(rate(istio_requests_total{reporter=\"destination\",destination_service_namespace=~\"$namespace\",destination_service_name=~\"$destination_service\"}[5m])) by (destination_service_name)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Incoming Request Rate (RPS)",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "Percentage of requests returning 5xx status codes, grouped by destination service.",
+      "id": "w-error-rate",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a1b2c3d4-e5f6-7890-abcd-000000000002",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{destination_service_name}}",
+            "name": "A",
+            "query": "sum(rate(istio_requests_total{reporter=\"destination\",destination_service_namespace=~\"$namespace\",destination_service_name=~\"$destination_service\",response_code=~\"5.*\"}[5m])) by (destination_service_name) / sum(rate(istio_requests_total{reporter=\"destination\",destination_service_namespace=~\"$namespace\",destination_service_name=~\"$destination_service\"}[5m])) by (destination_service_name)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "5xx Error Rate",
+      "yAxisUnit": "percentunit"
+    },
+    {
+      "description": "Average request body size in bytes for incoming requests.",
+      "id": "w-request-size",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a1b2c3d4-e5f6-7890-abcd-000000000003",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{destination_service_name}}",
+            "name": "A",
+            "query": "sum(rate(istio_request_bytes_sum{reporter=\"destination\",destination_service_namespace=~\"$namespace\",destination_service_name=~\"$destination_service\"}[5m])) by (destination_service_name) / sum(rate(istio_request_bytes_count{reporter=\"destination\",destination_service_namespace=~\"$namespace\",destination_service_name=~\"$destination_service\"}[5m])) by (destination_service_name)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Average Request Size",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "Average response body size in bytes for outgoing responses.",
+      "id": "w-response-size",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a1b2c3d4-e5f6-7890-abcd-000000000004",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{destination_service_name}}",
+            "name": "A",
+            "query": "sum(rate(istio_response_bytes_sum{reporter=\"destination\",destination_service_namespace=~\"$namespace\",destination_service_name=~\"$destination_service\"}[5m])) by (destination_service_name) / sum(rate(istio_response_bytes_count{reporter=\"destination\",destination_service_namespace=~\"$namespace\",destination_service_name=~\"$destination_service\"}[5m])) by (destination_service_name)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Average Response Size",
+      "yAxisUnit": "bytes"
+    },
+    {
+      "description": "",
+      "id": "row-latency",
+      "panelTypes": "row",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "id": "",
+        "queryType": "builder"
+      },
+      "title": "Latency"
+    },
+    {
+      "description": "50th percentile request latency (median), grouped by destination service.",
+      "id": "w-latency-p50",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a1b2c3d4-e5f6-7890-abcd-000000000005",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{destination_service_name}}",
+            "name": "A",
+            "query": "histogram_quantile(0.50, sum(rate(istio_request_duration_milliseconds_bucket{reporter=\"destination\",destination_service_namespace=~\"$namespace\",destination_service_name=~\"$destination_service\"}[5m])) by (le, destination_service_name))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Latency p50",
+      "yAxisUnit": "ms"
+    },
+    {
+      "description": "95th percentile request latency, grouped by destination service.",
+      "id": "w-latency-p95",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a1b2c3d4-e5f6-7890-abcd-000000000006",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{destination_service_name}}",
+            "name": "A",
+            "query": "histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{reporter=\"destination\",destination_service_namespace=~\"$namespace\",destination_service_name=~\"$destination_service\"}[5m])) by (le, destination_service_name))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Latency p95",
+      "yAxisUnit": "ms"
+    },
+    {
+      "description": "99th percentile request latency, grouped by destination service.",
+      "id": "w-latency-p99",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a1b2c3d4-e5f6-7890-abcd-000000000007",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{destination_service_name}}",
+            "name": "A",
+            "query": "histogram_quantile(0.99, sum(rate(istio_request_duration_milliseconds_bucket{reporter=\"destination\",destination_service_namespace=~\"$namespace\",destination_service_name=~\"$destination_service\"}[5m])) by (le, destination_service_name))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Request Latency p99",
+      "yAxisUnit": "ms"
+    },
+    {
+      "description": "p50/p95/p99 latency percentiles for a specific service over time.",
+      "id": "w-latency-by-service",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a1b2c3d4-e5f6-7890-abcd-000000000008",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "p50",
+            "name": "A",
+            "query": "histogram_quantile(0.50, sum(rate(istio_request_duration_milliseconds_bucket{reporter=\"destination\",destination_service_namespace=~\"$namespace\",destination_service_name=~\"$destination_service\"}[5m])) by (le))"
+          },
+          {
+            "disabled": false,
+            "legend": "p95",
+            "name": "B",
+            "query": "histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{reporter=\"destination\",destination_service_namespace=~\"$namespace\",destination_service_name=~\"$destination_service\"}[5m])) by (le))"
+          },
+          {
+            "disabled": false,
+            "legend": "p99",
+            "name": "C",
+            "query": "histogram_quantile(0.99, sum(rate(istio_request_duration_milliseconds_bucket{reporter=\"destination\",destination_service_namespace=~\"$namespace\",destination_service_name=~\"$destination_service\"}[5m])) by (le))"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Latency Percentiles (All Services)",
+      "yAxisUnit": "ms"
+    },
+    {
+      "description": "",
+      "id": "row-service-mesh",
+      "panelTypes": "row",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "id": "",
+        "queryType": "builder"
+      },
+      "title": "Service Mesh Traffic"
+    },
+    {
+      "description": "Incoming request rate grouped by source workload and destination service.",
+      "id": "w-incoming-requests-by-source",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a1b2c3d4-e5f6-7890-abcd-000000000009",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{source_workload}} -> {{destination_service_name}}",
+            "name": "A",
+            "query": "sum(rate(istio_requests_total{reporter=\"destination\",destination_service_namespace=~\"$namespace\",destination_service_name=~\"$destination_service\"}[5m])) by (source_workload, destination_service_name)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Incoming Requests by Source Workload",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "Outbound request rate grouped by source workload and destination service.",
+      "id": "w-outgoing-requests-by-dest",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a1b2c3d4-e5f6-7890-abcd-000000000010",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{source_workload}} -> {{destination_service_name}}",
+            "name": "A",
+            "query": "sum(rate(istio_requests_total{reporter=\"source\",destination_service_namespace=~\"$namespace\",destination_service_name=~\"$destination_service\"}[5m])) by (source_workload, destination_service_name)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Outgoing Requests by Destination",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "Distribution of HTTP response status codes across all services.",
+      "id": "w-http-status-codes",
+      "isStacked": true,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a1b2c3d4-e5f6-7890-abcd-000000000011",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{response_code}}",
+            "name": "A",
+            "query": "sum(rate(istio_requests_total{reporter=\"destination\",destination_service_namespace=~\"$namespace\",destination_service_name=~\"$destination_service\"}[5m])) by (response_code)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "HTTP Response Status Codes",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "Distribution of gRPC response status codes across all services.",
+      "id": "w-grpc-status-codes",
+      "isStacked": true,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a1b2c3d4-e5f6-7890-abcd-000000000012",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{grpc_response_status}}",
+            "name": "A",
+            "query": "sum(rate(istio_requests_total{reporter=\"destination\",destination_service_namespace=~\"$namespace\",destination_service_name=~\"$destination_service\",request_protocol=\"grpc\"}[5m])) by (grpc_response_status)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "gRPC Response Status Codes",
+      "yAxisUnit": "reqps"
+    },
+    {
+      "description": "",
+      "id": "row-control-plane",
+      "panelTypes": "row",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "id": "",
+        "queryType": "builder"
+      },
+      "title": "Control Plane (Istiod / Pilot)"
+    },
+    {
+      "description": "Rate of xDS configuration pushes from Istiod to Envoy proxies, by type.",
+      "id": "w-pilot-xds-pushes",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a1b2c3d4-e5f6-7890-abcd-000000000013",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{type}}",
+            "name": "A",
+            "query": "sum(rate(pilot_xds_pushes{type!=\"\"}[5m])) by (type)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Pilot xDS Push Rate by Type",
+      "yAxisUnit": "ops"
+    },
+    {
+      "description": "Number of active xDS connections from Envoy proxies to Istiod.",
+      "id": "w-pilot-xds-connections",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a1b2c3d4-e5f6-7890-abcd-000000000014",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "xDS Connections",
+            "name": "A",
+            "query": "sum(pilot_xds)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Active xDS Connections",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "Rate of xDS push errors from Istiod, indicating configuration delivery failures.",
+      "id": "w-pilot-push-errors",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a1b2c3d4-e5f6-7890-abcd-000000000015",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{type}}",
+            "name": "A",
+            "query": "sum(rate(pilot_xds_push_errors{type!=\"\"}[5m])) by (type)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Pilot xDS Push Errors",
+      "yAxisUnit": "ops"
+    },
+    {
+      "description": "Total number of services known to Istiod.",
+      "id": "w-pilot-known-services",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a1b2c3d4-e5f6-7890-abcd-000000000016",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "Known Services",
+            "name": "A",
+            "query": "sum(pilot_services)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "Pilot Known Services",
+      "yAxisUnit": "short"
+    },
+    {
+      "description": "",
+      "id": "row-tcp",
+      "panelTypes": "row",
+      "query": {
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "id": "",
+        "queryType": "builder"
+      },
+      "title": "TCP Traffic"
+    },
+    {
+      "description": "Rate of bytes sent over TCP connections, grouped by destination service.",
+      "id": "w-tcp-sent-bytes",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a1b2c3d4-e5f6-7890-abcd-000000000017",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{destination_service_name}}",
+            "name": "A",
+            "query": "sum(rate(istio_tcp_sent_bytes_total{reporter=\"destination\",destination_service_namespace=~\"$namespace\",destination_service_name=~\"$destination_service\"}[5m])) by (destination_service_name)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "TCP Bytes Sent",
+      "yAxisUnit": "binBps"
+    },
+    {
+      "description": "Rate of bytes received over TCP connections, grouped by destination service.",
+      "id": "w-tcp-received-bytes",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "panelTypes": "graph",
+      "query": {
+        "builder": {
+          "queryData": [
+            {
+              "aggregateAttribute": {
+                "dataType": "",
+                "id": "------false",
+                "isColumn": false,
+                "isJSON": false,
+                "key": "",
+                "type": ""
+              },
+              "aggregateOperator": "count",
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "A",
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "groupBy": [],
+              "having": [],
+              "legend": "",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "A",
+              "reduceTo": "sum",
+              "stepInterval": 60
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "disabled": false,
+            "legend": "",
+            "name": "A",
+            "query": ""
+          }
+        ],
+        "id": "a1b2c3d4-e5f6-7890-abcd-000000000018",
+        "promql": [
+          {
+            "disabled": false,
+            "legend": "{{destination_service_name}}",
+            "name": "A",
+            "query": "sum(rate(istio_tcp_received_bytes_total{reporter=\"destination\",destination_service_namespace=~\"$namespace\",destination_service_name=~\"$destination_service\"}[5m])) by (destination_service_name)"
+          }
+        ],
+        "queryType": "promql"
+      },
+      "timePreferance": "GLOBAL_TIME",
+      "title": "TCP Bytes Received",
+      "yAxisUnit": "binBps"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a new Istio service mesh dashboard using Prometheus metrics.

**File**: `istio/istio-prometheus-v1.json`

Covers:
- **Traffic overview**: request rate (RPS), 5xx error rate, request/response sizes
- **Latency**: p50 / p95 / p99 histograms via `istio_request_duration_milliseconds_bucket`, per service and aggregated
- **Service mesh traffic**: requests by source workload, by destination, HTTP and gRPC status code distributions
- **Control plane (Istiod / Pilot)**: xDS push rate, active xDS connections, push errors, known services
- **TCP traffic**: bytes sent/received via `istio_tcp_sent_bytes_total` / `istio_tcp_received_bytes_total`

Dashboard variables: `$namespace` (multi-select) and `$destination_service` (multi-select).

All 18 data widgets use `queryType: promql` with non-empty queries. Layout entries match widget IDs 1:1.

Relates to dashboard template requests for Istio/service mesh monitoring.