### PR TITLE
feat: add K8s SRE Incident Response dashboard

### DIFF
--- a/k8s-sre-incident-response/README.md
+++ b/k8s-sre-incident-response/README.md
@@ -1,0 +1,85 @@
+# K8s SRE — Incident Response Dashboard
+
+> Built for the SRE who gets paged at 2am, not for the engineer browsing infra metrics at 2pm.
+
+## The problem with standard K8s dashboards
+
+Most Kubernetes dashboards show you *everything* — CPU trends, network bytes, disk IOPS across every node. That's great for capacity planning.
+
+During an active incident, it's noise.
+
+This dashboard gives you **8 signals** that answer one question: **what is broken right now, and why?**
+
+Built from real on-call experience running Kubernetes at scale in a high-traffic banking environment — where a missed signal meant a real customer impact.
+
+---
+
+## What's included
+
+| Panel | Signal | Why it matters in an incident |
+|---|---|---|
+| Pod Restart Rate | graph | First sign of crash loops or OOMKills — spikes before alerts fire |
+| Node CPU Pressure | gauge | Above 80% = scheduling risk; above 90% = imminent degradation |
+| Node Memory Pressure | gauge | OOM kill risk; above 85% = pods are at risk |
+| Pending Pods | stat | Any non-zero = scheduling failure — resource starvation or taint mismatch |
+| Container Restarts / OOMKills | stat | Memory limit breaches hiding behind auto-restarts |
+| p99 Latency (SLI) | graph | Your primary SLI — sustained breach = SLO violation |
+| 5XX Error Rate | graph | Error budget consumption in real time — correlate with latency |
+| PVC Usage | table | Silent incidents: a PVC at 80% becomes a P1 crash in 24-48h |
+
+---
+
+## Thresholds (opinionated, adjust to your SLOs)
+
+| Signal | Warning | Critical |
+|---|---|---|
+| Node CPU | 80% | 90% |
+| Node Memory | 85% | 95% |
+| Pending Pods | 1 | 5 |
+| Container Restarts | 1 | 3 |
+
+---
+
+## Data source requirements
+
+- OpenTelemetry Collector with **Kubernetes receiver** enabled
+- Kubelet metrics scraping enabled
+- APM instrumentation via OpenTelemetry SDK (for p99 latency and error rate panels)
+
+---
+
+## Import instructions
+
+1. Go to **SigNoz → Dashboards → New Dashboard → Import JSON**
+2. Upload `k8s-sre-incident-response.json`
+3. Select your **cluster** and **namespace** from the variable dropdowns
+4. Set your SLO threshold line on the p99 latency panel
+
+---
+
+## Triage runbook (use this during an incident)
+
+```
+1. Check Pending Pods → 0 is good, any value = scheduling issue
+2. Check Pod Restart Rate → spike = crash loop, check OOMKill count
+3. Check Node CPU/Memory → if both high, you have resource starvation
+4. Check p99 Latency → breaching SLO threshold? = user-facing impact
+5. Check 5XX Error Rate → correlates with latency? = downstream failure
+6. Check PVC Usage → any at 80%+? = proactive fix needed NOW
+```
+
+---
+
+## Author
+
+**Shobhit Verma** — Lead SRE | AWS | Dynatrace | Kubernetes | AI Automation
+
+- GitHub: [@infrawithshobhit](https://github.com/infrawithshobhit)
+- LinkedIn: [linkedin.com/in/vershobhit](https://linkedin.com/in/vershobhit)
+- Content: [@TheJugaadSRE](https://instagram.com/thejugaadsre)
+
+15+ years in platform and reliability engineering. This dashboard reflects real patterns from operating high-traffic systems where on-call response time directly impacts customer experience.
+
+---
+
+*If this saved you time in an incident, star the repo and share it with your team.*

--- a/k8s-sre-incident-response/k8s-sre-incident-response.json
+++ b/k8s-sre-incident-response/k8s-sre-incident-response.json
@@ -1,0 +1,590 @@
+{
+  "id": "k8s-sre-incident-response",
+  "title": "K8s SRE Incident Response",
+  "description": "On-call triage view. Not for capacity planning — for when something is already broken. Covers the 8 signals that actually matter during an incident.",
+  "tags": ["kubernetes", "sre", "incident-response", "on-call", "reliability", "opentelemetry"],
+  "layout": [],
+  "variables": [
+    {
+      "name": "k8s_cluster_name",
+      "description": "Kubernetes Cluster",
+      "type": "QUERY",
+      "sort": 0,
+      "multiSelect": false,
+      "showALLOption": false,
+      "queryValue": "SELECT JSONExtractString(labels, 'k8s.cluster.name') AS `k8s.cluster.name` FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'k8s.node.cpu.time' GROUP BY `k8s.cluster.name`",
+      "customValue": "",
+      "selectedValue": ""
+    },
+    {
+      "name": "k8s_namespace_name",
+      "description": "Namespace",
+      "type": "QUERY",
+      "sort": 0,
+      "multiSelect": true,
+      "showALLOption": true,
+      "queryValue": "SELECT JSONExtractString(labels, 'k8s.namespace.name') AS `k8s.namespace.name` FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'k8s.pod.cpu.time' AND JSONExtractString(labels, 'k8s.cluster.name') = $k8s_cluster_name GROUP BY `k8s.namespace.name`",
+      "customValue": "",
+      "selectedValue": ""
+    }
+  ],
+  "panels": [
+    {
+      "id": "pod-restart-rate",
+      "type": "graph",
+      "title": "Pod Restart Rate",
+      "description": "Watch for spikes. Steady climb = crash loop. Check OOMKill count next.",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "yAxisUnit": "short",
+      "panelTypes": "graph",
+      "query": {
+        "queryType": "builder",
+        "promql": [],
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "rate",
+              "aggregateAttribute": {
+                "key": "k8s.pod.cpu.time",
+                "dataType": "float64",
+                "type": "Sum",
+                "isColumn": true,
+                "isJSON": false
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "k8s.cluster.name",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "$k8s_cluster_name"
+                  },
+                  {
+                    "key": {
+                      "key": "k8s.namespace.name",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "in",
+                    "value": "$k8s_namespace_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "stepInterval": 60,
+              "having": [],
+              "groupBy": [
+                {
+                  "key": "k8s.pod.name",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{k8s.pod.name}}",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": []
+      },
+      "columnUnits": {},
+      "softMin": 0,
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 }
+    },
+    {
+      "id": "node-cpu-pressure",
+      "type": "gauge",
+      "title": "Node CPU Pressure (%)",
+      "description": ">80% = scheduling risk. >90% = something is about to fall over.",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "yAxisUnit": "percent",
+      "panelTypes": "gauge",
+      "query": {
+        "queryType": "builder",
+        "promql": [],
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "rate",
+              "aggregateAttribute": {
+                "key": "k8s.node.cpu.time",
+                "dataType": "float64",
+                "type": "Sum",
+                "isColumn": true,
+                "isJSON": false
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "k8s.cluster.name",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "$k8s_cluster_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "stepInterval": 60,
+              "having": [],
+              "groupBy": [
+                {
+                  "key": "k8s.node.name",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{k8s.node.name}}",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": []
+      },
+      "thresholds": [
+        { "index": 0, "value": 0, "color": "#1D9E75" },
+        { "index": 1, "value": 80, "color": "#EF9F27" },
+        { "index": 2, "value": 90, "color": "#E24B4A" }
+      ],
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 100,
+      "gridPos": { "x": 12, "y": 0, "w": 6, "h": 8 }
+    },
+    {
+      "id": "node-memory-pressure",
+      "type": "gauge",
+      "title": "Node Memory Pressure (%)",
+      "description": ">85% = OOM risk. Check which pods are the heaviest consumers before it pages you.",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "yAxisUnit": "percent",
+      "panelTypes": "gauge",
+      "query": {
+        "queryType": "builder",
+        "promql": [],
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "avg",
+              "aggregateAttribute": {
+                "key": "k8s.node.memory.working_set",
+                "dataType": "float64",
+                "type": "Gauge",
+                "isColumn": true,
+                "isJSON": false
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "k8s.cluster.name",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "$k8s_cluster_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "stepInterval": 60,
+              "having": [],
+              "groupBy": [
+                {
+                  "key": "k8s.node.name",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{k8s.node.name}}",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": []
+      },
+      "thresholds": [
+        { "index": 0, "value": 0, "color": "#1D9E75" },
+        { "index": 1, "value": 85, "color": "#EF9F27" },
+        { "index": 2, "value": 95, "color": "#E24B4A" }
+      ],
+      "columnUnits": {},
+      "softMin": 0,
+      "softMax": 100,
+      "gridPos": { "x": 18, "y": 0, "w": 6, "h": 8 }
+    },
+    {
+      "id": "pending-pods",
+      "type": "value",
+      "title": "Pending Pods",
+      "description": "Should always be 0. Anything else = scheduling failure. Check resources, taints, or PVC binding.",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "yAxisUnit": "short",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "clickhouse_sql",
+        "promql": [],
+        "builder": {
+          "queryData": [],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": [
+          {
+            "name": "A",
+            "query": "SELECT countIf(last_phase = 1) AS pending_pods FROM (SELECT `k8s.pod.name`, anyLast(`value`) AS last_phase FROM signoz_metrics.distributed_samples_v4 INNER JOIN (SELECT DISTINCT JSONExtractString(labels, 'k8s.pod.name') AS `k8s.pod.name`, JSONExtractString(labels, 'k8s.cluster.name') AS `k8s.cluster.name`, fingerprint FROM signoz_metrics.time_series_v4_1day WHERE (metric_name = 'k8s.pod.phase') AND JSONExtractString(labels, 'k8s.cluster.name') = $k8s_cluster_name) AS filtered_time_series USING fingerprint WHERE (metric_name = 'k8s.pod.phase') AND (unix_milli >= $start_timestamp_ms) AND (unix_milli < $end_timestamp_ms) GROUP BY `k8s.pod.name`)",
+            "legend": "Pending Pods",
+            "disabled": false
+          }
+        ]
+      },
+      "thresholds": [
+        { "index": 0, "value": 0, "color": "#1D9E75" },
+        { "index": 1, "value": 1, "color": "#EF9F27" },
+        { "index": 2, "value": 5, "color": "#E24B4A" }
+      ],
+      "columnUnits": {},
+      "gridPos": { "x": 0, "y": 8, "w": 6, "h": 6 }
+    },
+    {
+      "id": "oomkill-events",
+      "type": "value",
+      "title": "Container OOMKill Events",
+      "description": "Non-zero here with pod restarts = memory leak or limits set too low. Don't just restart — fix it.",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "yAxisUnit": "short",
+      "panelTypes": "value",
+      "query": {
+        "queryType": "builder",
+        "promql": [],
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "sum",
+              "aggregateAttribute": {
+                "key": "k8s.container.restarts",
+                "dataType": "float64",
+                "type": "Gauge",
+                "isColumn": true,
+                "isJSON": false
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "k8s.cluster.name",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "$k8s_cluster_name"
+                  },
+                  {
+                    "key": {
+                      "key": "k8s.namespace.name",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "in",
+                    "value": "$k8s_namespace_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "stepInterval": 60,
+              "having": [],
+              "groupBy": [],
+              "legend": "OOMKill / Restarts",
+              "reduceTo": "sum",
+              "spaceAggregation": "sum"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": []
+      },
+      "thresholds": [
+        { "index": 0, "value": 0, "color": "#1D9E75" },
+        { "index": 1, "value": 1, "color": "#EF9F27" },
+        { "index": 2, "value": 3, "color": "#E24B4A" }
+      ],
+      "columnUnits": {},
+      "gridPos": { "x": 6, "y": 8, "w": 6, "h": 6 }
+    },
+    {
+      "id": "p99-latency",
+      "type": "graph",
+      "title": "p99 Latency — Service SLI (ms)",
+      "description": "Primary SLI. Set a threshold at your SLO value. If this is breaching, error budget is burning.",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "yAxisUnit": "ms",
+      "panelTypes": "graph",
+      "query": {
+        "queryType": "builder",
+        "promql": [],
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "p99",
+              "aggregateAttribute": {
+                "key": "signoz_latency",
+                "dataType": "float64",
+                "type": "Histogram",
+                "isColumn": true,
+                "isJSON": false
+              },
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "stepInterval": 60,
+              "having": [],
+              "groupBy": [
+                {
+                  "key": "service.name",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{service.name}} p99",
+              "reduceTo": "avg",
+              "spaceAggregation": "p99"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": []
+      },
+      "columnUnits": {},
+      "softMin": 0,
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 }
+    },
+    {
+      "id": "5xx-error-rate",
+      "type": "graph",
+      "title": "5XX Error Rate (% of total requests)",
+      "description": "Correlate with p99 — if both spike together, downstream service is failing. If only errors spike, check your own app logs.",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "yAxisUnit": "percentunit",
+      "panelTypes": "graph",
+      "query": {
+        "queryType": "builder",
+        "promql": [],
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "rate",
+              "aggregateAttribute": {
+                "key": "signoz_calls_total",
+                "dataType": "float64",
+                "type": "Sum",
+                "isColumn": true,
+                "isJSON": false
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "status_code",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "STATUS_CODE_ERROR"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "stepInterval": 60,
+              "having": [],
+              "groupBy": [
+                {
+                  "key": "service.name",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{service.name}} errors",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum"
+            },
+            {
+              "dataSource": "metrics",
+              "queryName": "B",
+              "aggregateOperator": "rate",
+              "aggregateAttribute": {
+                "key": "signoz_calls_total",
+                "dataType": "float64",
+                "type": "Sum",
+                "isColumn": true,
+                "isJSON": false
+              },
+              "filters": {
+                "items": [],
+                "op": "AND"
+              },
+              "expression": "B",
+              "disabled": false,
+              "stepInterval": 60,
+              "having": [],
+              "groupBy": [
+                {
+                  "key": "service.name",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "",
+              "reduceTo": "avg",
+              "spaceAggregation": "sum"
+            }
+          ],
+          "queryFormulas": [
+            {
+              "queryName": "F1",
+              "expression": "A/B",
+              "disabled": false,
+              "legend": "{{service.name}} error rate"
+            }
+          ]
+        },
+        "clickhouse_sql": []
+      },
+      "columnUnits": {},
+      "softMin": 0,
+      "gridPos": { "x": 0, "y": 14, "w": 12, "h": 8 }
+    },
+    {
+      "id": "pvc-usage",
+      "type": "table",
+      "title": "PVC Storage Usage",
+      "description": "The silent killer. PVCs don't alert until they're full — by then pods are crashing. Anything >80% needs action now.",
+      "isStacked": false,
+      "nullZeroValues": "zero",
+      "opacity": "1",
+      "yAxisUnit": "bytes",
+      "panelTypes": "table",
+      "query": {
+        "queryType": "builder",
+        "promql": [],
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateOperator": "avg",
+              "aggregateAttribute": {
+                "key": "k8s.volume.available",
+                "dataType": "float64",
+                "type": "Gauge",
+                "isColumn": true,
+                "isJSON": false
+              },
+              "filters": {
+                "items": [
+                  {
+                    "key": {
+                      "key": "k8s.cluster.name",
+                      "dataType": "string",
+                      "type": "tag",
+                      "isColumn": false
+                    },
+                    "op": "=",
+                    "value": "$k8s_cluster_name"
+                  }
+                ],
+                "op": "AND"
+              },
+              "expression": "A",
+              "disabled": false,
+              "stepInterval": 60,
+              "having": [],
+              "groupBy": [
+                {
+                  "key": "k8s.persistentvolumeclaim.name",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                },
+                {
+                  "key": "k8s.namespace.name",
+                  "dataType": "string",
+                  "type": "tag",
+                  "isColumn": false
+                }
+              ],
+              "legend": "{{k8s.namespace.name}} / {{k8s.persistentvolumeclaim.name}}",
+              "reduceTo": "avg",
+              "spaceAggregation": "avg"
+            }
+          ],
+          "queryFormulas": []
+        },
+        "clickhouse_sql": []
+      },
+      "columnUnits": {},
+      "gridPos": { "x": 12, "y": 14, "w": 12, "h": 8 }
+    }
+  ]
+}


### PR DESCRIPTION
 Dashboard: K8s SRE Incident Response

A Kubernetes dashboard built for on-call triage, Based on real life example

Q- Why this dashboard?
Most K8s dashboards show everything, during an active incident.  That's called noise. 
This one surfaces 8 signals that answer, what is broken right now, and why?

### Panels included
- Pod Restart Rate — early crash loop detection
- Node CPU Pressure — scheduling risk threshold (warn: 80%, crit: 90%)
- Node Memory Pressure — OOM risk (warn: 85%, crit: 95%)
- Pending Pods — scheduling failure indicator
- Container Restarts / OOMKills — memory leak signal
- p99 Latency — primary SLI for SLO tracking
- 5XX Error Rate — error budget burn rate
- PVC Storage Usage — proactive storage incident prevention

### Data source
OpenTelemetry Collector with Kubernetes receiver + kubelet metrics.
APM panels require OTel SDK instrumentation.

### Variables
- `k8s_cluster_name` — cluster selector
- `k8s_namespace_name` — multi-select namespace filter