### PR TITLE
Add Bugsnag dashboard

### DIFF
--- a/bugsnag/README.md
+++ b/bugsnag/README.md
@@ -1,0 +1,57 @@
+# Bugsnag Dashboard
+
+## Details
+
+This dashboard monitors error and crash events forwarded from Bugsnag to SigNoz via Bugsnag's webhook data forwarding — ingested by the collector's bundled `webhookevent` receiver and parsed by a transform processor (see the [Bugsnag integration guide](https://signoz.io/docs/integrations/outposts/bugsnag/)). It is built on log records carrying `bugsnag.*`, `exception.*`, `app.*`, `os.*`, `device.*`, and `user.*` attributes; every panel filters on `service.name = 'bugsnag'`, the service name the integration assigns to forwarded events.
+
+## Dashboard panels
+
+### Stability Summary
+
+#### Total Error Events
+
+A count of all Bugsnag webhook events over the selected time range — a quick pulse on overall error activity.
+
+#### Unhandled Crashes %
+
+The share of events flagged unhandled by Bugsnag, computed as `A / B * 100` where A counts events with `bugsnag.error.unhandled = true` and B counts all events. The headline stability signal.
+
+#### Affected Users
+
+Count of distinct `user.id` values across error events — customer impact rather than raw volume.
+
+#### App Versions Reporting
+
+Count of distinct `app.version` values producing errors in the window.
+
+### Error Trends
+
+#### Error Events by Severity
+
+Time-series of event counts grouped by mapped severity (`ERROR`/`WARN`/`INFO`), revealing spikes and their character.
+
+#### Error Events by App Version
+
+Time-series of event counts grouped by `app.version` — release regressions show up here immediately.
+
+### Top Offenders
+
+#### Top Exception Classes
+
+Table of `exception.type` ranked by event count, so the highest-impact bugs surface first.
+
+### Devices & Platforms
+
+#### Errors by OS Version
+
+Table of events grouped by `os.name` and `os.version`, catching failures tied to a platform update.
+
+#### Errors by Device Model
+
+Table of each device model's error event count, surfacing device-specific problems.
+
+### Recent Activity
+
+#### Recent Error Events
+
+List of the latest Bugsnag events, newest first. Each record carries the exception class and message plus a `bugsnag.error.url` deep link back to the issue in Bugsnag.

--- a/bugsnag/README.md
+++ b/bugsnag/README.md
@@ -26,6 +26,10 @@ Count of distinct `app.version` values producing errors in the window.
 
 ### Error Trends
 
+#### Crashes vs Handled Errors
+
+Time-series split by `bugsnag.error.unhandled` — crashes and caught errors as separate series, so a stability regression stands out from ordinary error noise.
+
 #### Error Events by Severity
 
 Time-series of event counts grouped by mapped severity (`ERROR`/`WARN`/`INFO`), revealing spikes and their character.
@@ -38,7 +42,11 @@ Time-series of event counts grouped by `app.version` — release regressions sho
 
 #### Top Exception Classes
 
-Table of `exception.type` ranked by event count, so the highest-impact bugs surface first.
+Table of `exception.type` ranked by event count and split by unhandled/handled, so the highest-impact bugs surface first. An `exception.type` dashboard variable focuses the breakdown panels and the events list on one class for drill-down.
+
+#### Errors by Context
+
+Table of `bugsnag.error.context` — the screen, activity, or route where errors concentrate.
 
 ### Devices & Platforms
 
@@ -54,4 +62,4 @@ Table of each device model's error event count, surfacing device-specific proble
 
 #### Recent Error Events
 
-List of the latest Bugsnag events, newest first. Each record carries the exception class and message plus a `bugsnag.error.url` deep link back to the issue in Bugsnag.
+List of the latest Bugsnag events, newest first, with a readable `ExceptionClass: message` body line. Opening an event shows the stacktrace (`exception.stacktrace`), the full raw payload (`bugsnag.payload`), and a `bugsnag.error.url` deep link back to the issue in Bugsnag.

--- a/bugsnag/bugsnag-dashboard.json
+++ b/bugsnag/bugsnag-dashboard.json
@@ -1,0 +1,1218 @@
+{
+    "description": "Error and crash events forwarded from Bugsnag via webhook (collector webhookevent receiver). Volume, unhandled share, affected users, top exceptions, device/OS breakdowns.",
+    "image": "",
+    "layout": [
+        {
+            "h": 6,
+            "i": "18983979-e3a5-486a-b514-7dad063f4440",
+            "moved": false,
+            "static": false,
+            "w": 3,
+            "x": 0,
+            "y": 0
+        },
+        {
+            "h": 6,
+            "i": "1725d471-02fd-4b1c-861e-bf5f9a0607ed",
+            "moved": false,
+            "static": false,
+            "w": 3,
+            "x": 3,
+            "y": 0
+        },
+        {
+            "h": 6,
+            "i": "10020874-7f8c-4aa5-9551-464922ed17c5",
+            "moved": false,
+            "static": false,
+            "w": 3,
+            "x": 6,
+            "y": 0
+        },
+        {
+            "h": 6,
+            "i": "03914555-7e5c-43d3-acbb-fe809d1eedb3",
+            "moved": false,
+            "static": false,
+            "w": 3,
+            "x": 9,
+            "y": 0
+        },
+        {
+            "h": 6,
+            "i": "cebf4c7e-0ce5-4165-8993-c5b789985a8b",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 6
+        },
+        {
+            "h": 6,
+            "i": "d2a6c96f-c2fb-4e80-875d-ec24db4585d0",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 6
+        },
+        {
+            "h": 6,
+            "i": "4a033855-2c2f-4b7a-9ace-7902a6ca2ab9",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 12
+        },
+        {
+            "h": 6,
+            "i": "965d189e-42c8-4f32-ba4d-1d9cf5fc8dff",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 12
+        },
+        {
+            "h": 6,
+            "i": "33885bfe-9291-4cf9-9952-d43d886b17e7",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 18
+        },
+        {
+            "h": 8,
+            "i": "22df07f9-5715-4e2c-9bdd-b9529c68c584",
+            "moved": false,
+            "static": false,
+            "w": 12,
+            "x": 0,
+            "y": 24
+        }
+    ],
+    "panelMap": {},
+    "tags": [
+        "bugsnag",
+        "errors",
+        "crashes",
+        "mobile"
+    ],
+    "title": "Bugsnag \u2014 Errors & Crashes",
+    "uploadedGrafana": false,
+    "variables": {},
+    "version": "v5",
+    "widgets": [
+        {
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "columnUnits": {},
+            "description": "All Bugsnag webhook events received in the selected window.",
+            "fillSpans": false,
+            "id": "18983979-e3a5-486a-b514-7dad063f4440",
+            "isStacked": false,
+            "mergeAllActiveQueries": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "value",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregations": [
+                                {
+                                    "expression": "count()"
+                                }
+                            ],
+                            "dataSource": "logs",
+                            "disabled": false,
+                            "expression": "A",
+                            "filter": {
+                                "expression": "service.name = 'bugsnag'"
+                            },
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "aa03aa1e-d64a-4f7d-85e6-ca7ee06c2ff4",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "service.name--string--resource--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "service.name",
+                                            "type": "resource"
+                                        },
+                                        "op": "=",
+                                        "value": "bugsnag"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "functions": [],
+                            "groupBy": [],
+                            "having": {
+                                "expression": ""
+                            },
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A"
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "id": "8485ac0b-c4d2-4d21-95bf-ab95fa8de3d3",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [],
+            "softMax": 0,
+            "softMin": 0,
+            "stackedBarChart": false,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Total Error Events",
+            "yAxisUnit": "short"
+        },
+        {
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "columnUnits": {},
+            "description": "Share of events flagged unhandled by Bugsnag - the headline stability signal.",
+            "fillSpans": false,
+            "id": "1725d471-02fd-4b1c-861e-bf5f9a0607ed",
+            "isStacked": false,
+            "mergeAllActiveQueries": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "value",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregations": [
+                                {
+                                    "expression": "count()"
+                                }
+                            ],
+                            "dataSource": "logs",
+                            "disabled": true,
+                            "expression": "A",
+                            "filter": {
+                                "expression": "service.name = 'bugsnag' AND bugsnag.error.unhandled = true"
+                            },
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "812f9b15-ed3c-47ce-878f-340eea192d54",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "service.name--string--resource--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "service.name",
+                                            "type": "resource"
+                                        },
+                                        "op": "=",
+                                        "value": "bugsnag"
+                                    },
+                                    {
+                                        "id": "7e36579b-430d-44f5-8e12-38171220bf9f",
+                                        "key": {
+                                            "dataType": "bool",
+                                            "id": "bugsnag.error.unhandled--bool--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "bugsnag.error.unhandled",
+                                            "type": "tag"
+                                        },
+                                        "op": "=",
+                                        "value": "true"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "functions": [],
+                            "groupBy": [],
+                            "having": {
+                                "expression": ""
+                            },
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A"
+                        },
+                        {
+                            "aggregations": [
+                                {
+                                    "expression": "count()"
+                                }
+                            ],
+                            "dataSource": "logs",
+                            "disabled": true,
+                            "expression": "B",
+                            "filter": {
+                                "expression": "service.name = 'bugsnag'"
+                            },
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "6a14e30b-ff90-4506-b969-17f98d3b14aa",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "service.name--string--resource--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "service.name",
+                                            "type": "resource"
+                                        },
+                                        "op": "=",
+                                        "value": "bugsnag"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "functions": [],
+                            "groupBy": [],
+                            "having": {
+                                "expression": ""
+                            },
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "B"
+                        }
+                    ],
+                    "queryFormulas": [
+                        {
+                            "disabled": false,
+                            "expression": "A/B*100",
+                            "legend": "unhandled %",
+                            "queryName": "F1"
+                        }
+                    ]
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "id": "caf0c9fd-a13e-4894-8749-7366c4382ddf",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [],
+            "softMax": 0,
+            "softMin": 0,
+            "stackedBarChart": false,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Unhandled Crashes %",
+            "yAxisUnit": "percent"
+        },
+        {
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "columnUnits": {},
+            "description": "Distinct users that hit an error (user.id from Bugsnag payloads).",
+            "fillSpans": false,
+            "id": "10020874-7f8c-4aa5-9551-464922ed17c5",
+            "isStacked": false,
+            "mergeAllActiveQueries": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "value",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregations": [
+                                {
+                                    "expression": "count_distinct(user.id)"
+                                }
+                            ],
+                            "dataSource": "logs",
+                            "disabled": false,
+                            "expression": "A",
+                            "filter": {
+                                "expression": "service.name = 'bugsnag'"
+                            },
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "fdeaa566-f3de-4a9a-b301-aac0df548e1a",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "service.name--string--resource--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "service.name",
+                                            "type": "resource"
+                                        },
+                                        "op": "=",
+                                        "value": "bugsnag"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "functions": [],
+                            "groupBy": [],
+                            "having": {
+                                "expression": ""
+                            },
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A"
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "id": "100e6285-8835-4f70-83cb-14c560091dc5",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [],
+            "softMax": 0,
+            "softMin": 0,
+            "stackedBarChart": false,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Affected Users",
+            "yAxisUnit": "short"
+        },
+        {
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "columnUnits": {},
+            "description": "Distinct app versions producing errors in the window.",
+            "fillSpans": false,
+            "id": "03914555-7e5c-43d3-acbb-fe809d1eedb3",
+            "isStacked": false,
+            "mergeAllActiveQueries": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "value",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregations": [
+                                {
+                                    "expression": "count_distinct(app.version)"
+                                }
+                            ],
+                            "dataSource": "logs",
+                            "disabled": false,
+                            "expression": "A",
+                            "filter": {
+                                "expression": "service.name = 'bugsnag'"
+                            },
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "ee6233e4-0506-4d23-88e8-5c0c91926443",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "service.name--string--resource--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "service.name",
+                                            "type": "resource"
+                                        },
+                                        "op": "=",
+                                        "value": "bugsnag"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "functions": [],
+                            "groupBy": [],
+                            "having": {
+                                "expression": ""
+                            },
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A"
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "id": "690a8f83-afc5-4170-9022-89d7c2ff05e3",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [],
+            "softMax": 0,
+            "softMin": 0,
+            "stackedBarChart": false,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "App Versions Reporting",
+            "yAxisUnit": "short"
+        },
+        {
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "columnUnits": {},
+            "description": "Event volume over time, split by mapped severity.",
+            "fillSpans": false,
+            "id": "cebf4c7e-0ce5-4165-8993-c5b789985a8b",
+            "isStacked": false,
+            "mergeAllActiveQueries": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregations": [
+                                {
+                                    "expression": "count()"
+                                }
+                            ],
+                            "dataSource": "logs",
+                            "disabled": false,
+                            "expression": "A",
+                            "filter": {
+                                "expression": "service.name = 'bugsnag'"
+                            },
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "9cdbf646-f59e-4422-aca2-5b9e5c06fbc9",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "service.name--string--resource--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "service.name",
+                                            "type": "resource"
+                                        },
+                                        "op": "=",
+                                        "value": "bugsnag"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "functions": [],
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "severity_text--string----true",
+                                    "isColumn": true,
+                                    "isJSON": false,
+                                    "key": "severity_text",
+                                    "type": ""
+                                }
+                            ],
+                            "having": {
+                                "expression": ""
+                            },
+                            "legend": "{{severity_text}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A"
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "id": "aa91752c-0b2f-4fb7-bc99-0aa2992564a4",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [],
+            "softMax": 0,
+            "softMin": 0,
+            "stackedBarChart": false,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Error Events by Severity",
+            "yAxisUnit": "short"
+        },
+        {
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "columnUnits": {},
+            "description": "Event volume over time per app version - release regressions show up here.",
+            "fillSpans": false,
+            "id": "d2a6c96f-c2fb-4e80-875d-ec24db4585d0",
+            "isStacked": false,
+            "mergeAllActiveQueries": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregations": [
+                                {
+                                    "expression": "count()"
+                                }
+                            ],
+                            "dataSource": "logs",
+                            "disabled": false,
+                            "expression": "A",
+                            "filter": {
+                                "expression": "service.name = 'bugsnag'"
+                            },
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "7bd0c0a4-1717-423b-af31-16a13a71946d",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "service.name--string--resource--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "service.name",
+                                            "type": "resource"
+                                        },
+                                        "op": "=",
+                                        "value": "bugsnag"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "functions": [],
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "app.version--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "app.version",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": {
+                                "expression": ""
+                            },
+                            "legend": "{{app.version}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A"
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "id": "15c8826e-30ab-4ff0-becc-e5838074d142",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [],
+            "softMax": 0,
+            "softMin": 0,
+            "stackedBarChart": false,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Error Events by App Version",
+            "yAxisUnit": "short"
+        },
+        {
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "columnUnits": {},
+            "description": "Exception classes ranked by event count.",
+            "fillSpans": false,
+            "id": "4a033855-2c2f-4b7a-9ace-7902a6ca2ab9",
+            "isStacked": false,
+            "mergeAllActiveQueries": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "table",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregations": [
+                                {
+                                    "expression": "count()"
+                                }
+                            ],
+                            "dataSource": "logs",
+                            "disabled": false,
+                            "expression": "A",
+                            "filter": {
+                                "expression": "service.name = 'bugsnag'"
+                            },
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "f4715113-d1b1-4ba8-a28a-3d23b0c3bb7c",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "service.name--string--resource--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "service.name",
+                                            "type": "resource"
+                                        },
+                                        "op": "=",
+                                        "value": "bugsnag"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "functions": [],
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "exception.type--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "exception.type",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": {
+                                "expression": ""
+                            },
+                            "legend": "",
+                            "limit": 10,
+                            "orderBy": [
+                                {
+                                    "columnName": "count()",
+                                    "order": "desc"
+                                }
+                            ],
+                            "queryName": "A"
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "id": "e4063f67-7081-4ccd-9c55-cf7a2584b605",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [],
+            "softMax": 0,
+            "softMin": 0,
+            "stackedBarChart": false,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Top Exception Classes",
+            "yAxisUnit": "short"
+        },
+        {
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "columnUnits": {},
+            "description": "Event count per OS name and version.",
+            "fillSpans": false,
+            "id": "965d189e-42c8-4f32-ba4d-1d9cf5fc8dff",
+            "isStacked": false,
+            "mergeAllActiveQueries": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "table",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregations": [
+                                {
+                                    "expression": "count()"
+                                }
+                            ],
+                            "dataSource": "logs",
+                            "disabled": false,
+                            "expression": "A",
+                            "filter": {
+                                "expression": "service.name = 'bugsnag'"
+                            },
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "7ef050db-a2e3-4049-92ae-283f29af9273",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "service.name--string--resource--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "service.name",
+                                            "type": "resource"
+                                        },
+                                        "op": "=",
+                                        "value": "bugsnag"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "functions": [],
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "os.name--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "os.name",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "string",
+                                    "id": "os.version--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "os.version",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": {
+                                "expression": ""
+                            },
+                            "legend": "",
+                            "limit": 10,
+                            "orderBy": [
+                                {
+                                    "columnName": "count()",
+                                    "order": "desc"
+                                }
+                            ],
+                            "queryName": "A"
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "id": "b38fbf16-023c-482f-8ee8-c2afeac86c70",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [],
+            "softMax": 0,
+            "softMin": 0,
+            "stackedBarChart": false,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Errors by OS Version",
+            "yAxisUnit": "short"
+        },
+        {
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "columnUnits": {},
+            "description": "Event count per device model.",
+            "fillSpans": false,
+            "id": "33885bfe-9291-4cf9-9952-d43d886b17e7",
+            "isStacked": false,
+            "mergeAllActiveQueries": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "table",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregations": [
+                                {
+                                    "expression": "count()"
+                                }
+                            ],
+                            "dataSource": "logs",
+                            "disabled": false,
+                            "expression": "A",
+                            "filter": {
+                                "expression": "service.name = 'bugsnag'"
+                            },
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "9c1171f2-527c-4909-b82b-71a9205e0485",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "service.name--string--resource--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "service.name",
+                                            "type": "resource"
+                                        },
+                                        "op": "=",
+                                        "value": "bugsnag"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "functions": [],
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "device.model.name--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "device.model.name",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": {
+                                "expression": ""
+                            },
+                            "legend": "",
+                            "limit": 10,
+                            "orderBy": [
+                                {
+                                    "columnName": "count()",
+                                    "order": "desc"
+                                }
+                            ],
+                            "queryName": "A"
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "id": "5de31e85-8832-459b-9bcb-7b828b3e8b76",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [],
+            "softMax": 0,
+            "softMin": 0,
+            "stackedBarChart": false,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Errors by Device Model",
+            "yAxisUnit": "short"
+        },
+        {
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "columnUnits": {},
+            "description": "Latest Bugsnag events - open one for full payload and the bugsnag.error.url deep link.",
+            "fillSpans": false,
+            "id": "22df07f9-5715-4e2c-9bdd-b9529c68c584",
+            "isStacked": false,
+            "mergeAllActiveQueries": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "list",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregations": [],
+                            "dataSource": "logs",
+                            "disabled": false,
+                            "expression": "A",
+                            "filter": {
+                                "expression": "service.name = 'bugsnag'"
+                            },
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "604ffbc3-0c1e-401e-8318-995c352b1d3c",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "service.name--string--resource--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "service.name",
+                                            "type": "resource"
+                                        },
+                                        "op": "=",
+                                        "value": "bugsnag"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "functions": [],
+                            "groupBy": [],
+                            "having": {
+                                "expression": ""
+                            },
+                            "legend": "",
+                            "limit": null,
+                            "orderBy": [
+                                {
+                                    "columnName": "timestamp",
+                                    "order": "desc"
+                                }
+                            ],
+                            "queryName": "A"
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "id": "50b40cd4-d8a8-4eb9-a3f0-f9d9518095b1",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [],
+            "softMax": 0,
+            "softMin": 0,
+            "stackedBarChart": false,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Recent Error Events",
+            "yAxisUnit": "short"
+        }
+    ]
+}

--- a/bugsnag/bugsnag-dashboard.json
+++ b/bugsnag/bugsnag-dashboard.json
@@ -1,10 +1,10 @@
 {
-    "description": "Error and crash events forwarded from Bugsnag via webhook (collector webhookevent receiver). Volume, unhandled share, affected users, top exceptions, device/OS breakdowns.",
+    "description": "Error and crash events forwarded from Bugsnag via webhook (collector webhookevent receiver). Volume, unhandled share, affected users, top exceptions, device/OS breakdowns. Use the exception.type variable to drill into one exception class.",
     "image": "",
     "layout": [
         {
             "h": 6,
-            "i": "18983979-e3a5-486a-b514-7dad063f4440",
+            "i": "08f7cda7-fe6b-42b1-a470-93c8680e6992",
             "moved": false,
             "static": false,
             "w": 3,
@@ -13,7 +13,7 @@
         },
         {
             "h": 6,
-            "i": "1725d471-02fd-4b1c-861e-bf5f9a0607ed",
+            "i": "04d499bb-c8cb-48a3-8377-92ba80d77a1c",
             "moved": false,
             "static": false,
             "w": 3,
@@ -22,7 +22,7 @@
         },
         {
             "h": 6,
-            "i": "10020874-7f8c-4aa5-9551-464922ed17c5",
+            "i": "497f4761-5d25-482c-9c80-541207b8d747",
             "moved": false,
             "static": false,
             "w": 3,
@@ -31,7 +31,7 @@
         },
         {
             "h": 6,
-            "i": "03914555-7e5c-43d3-acbb-fe809d1eedb3",
+            "i": "3d562521-012d-4b78-8c23-6d26f548a7af",
             "moved": false,
             "static": false,
             "w": 3,
@@ -40,7 +40,7 @@
         },
         {
             "h": 6,
-            "i": "cebf4c7e-0ce5-4165-8993-c5b789985a8b",
+            "i": "57a2fb5b-0aed-47c0-a50c-f0ad536f4d33",
             "moved": false,
             "static": false,
             "w": 6,
@@ -49,7 +49,7 @@
         },
         {
             "h": 6,
-            "i": "d2a6c96f-c2fb-4e80-875d-ec24db4585d0",
+            "i": "dc79f7ad-7b2d-45ac-a0aa-0262d36096d9",
             "moved": false,
             "static": false,
             "w": 6,
@@ -58,7 +58,7 @@
         },
         {
             "h": 6,
-            "i": "4a033855-2c2f-4b7a-9ace-7902a6ca2ab9",
+            "i": "64c0bc08-38aa-474f-a93a-fab31e38f95e",
             "moved": false,
             "static": false,
             "w": 6,
@@ -67,7 +67,7 @@
         },
         {
             "h": 6,
-            "i": "965d189e-42c8-4f32-ba4d-1d9cf5fc8dff",
+            "i": "f7be51fe-4708-49f8-a064-eb1a670fe5a2",
             "moved": false,
             "static": false,
             "w": 6,
@@ -76,7 +76,7 @@
         },
         {
             "h": 6,
-            "i": "33885bfe-9291-4cf9-9952-d43d886b17e7",
+            "i": "8aff78b7-f8ca-4ed0-b5fd-b9ff9e0819d2",
             "moved": false,
             "static": false,
             "w": 6,
@@ -84,13 +84,31 @@
             "y": 18
         },
         {
+            "h": 6,
+            "i": "4be3098f-98ed-4520-a011-8179995eefea",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 6,
+            "y": 18
+        },
+        {
+            "h": 6,
+            "i": "35d75be5-40ba-47e6-b7a1-20b8cbb48fda",
+            "moved": false,
+            "static": false,
+            "w": 6,
+            "x": 0,
+            "y": 24
+        },
+        {
             "h": 8,
-            "i": "22df07f9-5715-4e2c-9bdd-b9529c68c584",
+            "i": "8569b010-0ed3-4d60-ac63-82a3ae9e0753",
             "moved": false,
             "static": false,
             "w": 12,
             "x": 0,
-            "y": 24
+            "y": 30
         }
     ],
     "panelMap": {},
@@ -102,7 +120,27 @@
     ],
     "title": "Bugsnag \u2014 Errors & Crashes",
     "uploadedGrafana": false,
-    "variables": {},
+    "variables": {
+        "fb969708-b479-4c28-8175-4252c4c5c8f7": {
+            "allSelected": true,
+            "customValue": "",
+            "defaultValue": "",
+            "description": "Focus panels on one or more exception classes",
+            "dynamicVariablesAttribute": "exception.type",
+            "dynamicVariablesSource": "All telemetry",
+            "id": "fb969708-b479-4c28-8175-4252c4c5c8f7",
+            "modificationUUID": "85223bea-8c44-45d8-b826-f6bf96d5b935",
+            "multiSelect": true,
+            "name": "exception.type",
+            "order": 0,
+            "queryValue": "",
+            "selectedValue": [],
+            "showALLOption": true,
+            "sort": "DISABLED",
+            "textboxValue": "",
+            "type": "DYNAMIC"
+        }
+    },
     "version": "v5",
     "widgets": [
         {
@@ -111,7 +149,7 @@
             "columnUnits": {},
             "description": "All Bugsnag webhook events received in the selected window.",
             "fillSpans": false,
-            "id": "18983979-e3a5-486a-b514-7dad063f4440",
+            "id": "08f7cda7-fe6b-42b1-a470-93c8680e6992",
             "isStacked": false,
             "mergeAllActiveQueries": false,
             "nullZeroValues": "zero",
@@ -135,7 +173,7 @@
                             "filters": {
                                 "items": [
                                     {
-                                        "id": "aa03aa1e-d64a-4f7d-85e6-ca7ee06c2ff4",
+                                        "id": "13567314-f078-489b-8733-963df937d86e",
                                         "key": {
                                             "dataType": "string",
                                             "id": "service.name--string--resource--false",
@@ -171,7 +209,7 @@
                         "query": ""
                     }
                 ],
-                "id": "8485ac0b-c4d2-4d21-95bf-ab95fa8de3d3",
+                "id": "adefa57e-9fe8-408a-9c1a-c94e501c8429",
                 "promql": [
                     {
                         "disabled": false,
@@ -209,7 +247,7 @@
             "columnUnits": {},
             "description": "Share of events flagged unhandled by Bugsnag - the headline stability signal.",
             "fillSpans": false,
-            "id": "1725d471-02fd-4b1c-861e-bf5f9a0607ed",
+            "id": "04d499bb-c8cb-48a3-8377-92ba80d77a1c",
             "isStacked": false,
             "mergeAllActiveQueries": false,
             "nullZeroValues": "zero",
@@ -233,7 +271,7 @@
                             "filters": {
                                 "items": [
                                     {
-                                        "id": "812f9b15-ed3c-47ce-878f-340eea192d54",
+                                        "id": "7ccc9102-114d-446a-8e71-1daba5d078f3",
                                         "key": {
                                             "dataType": "string",
                                             "id": "service.name--string--resource--false",
@@ -246,7 +284,7 @@
                                         "value": "bugsnag"
                                     },
                                     {
-                                        "id": "7e36579b-430d-44f5-8e12-38171220bf9f",
+                                        "id": "724ae207-0c2a-4d59-b616-99e36c4bc65d",
                                         "key": {
                                             "dataType": "bool",
                                             "id": "bugsnag.error.unhandled--bool--tag--false",
@@ -286,7 +324,7 @@
                             "filters": {
                                 "items": [
                                     {
-                                        "id": "6a14e30b-ff90-4506-b969-17f98d3b14aa",
+                                        "id": "5ddfce29-8da4-430d-a04b-9db82512586e",
                                         "key": {
                                             "dataType": "string",
                                             "id": "service.name--string--resource--false",
@@ -329,7 +367,7 @@
                         "query": ""
                     }
                 ],
-                "id": "caf0c9fd-a13e-4894-8749-7366c4382ddf",
+                "id": "f0dd2be6-746d-4489-92f8-8d27b449e822",
                 "promql": [
                     {
                         "disabled": false,
@@ -367,7 +405,7 @@
             "columnUnits": {},
             "description": "Distinct users that hit an error (user.id from Bugsnag payloads).",
             "fillSpans": false,
-            "id": "10020874-7f8c-4aa5-9551-464922ed17c5",
+            "id": "497f4761-5d25-482c-9c80-541207b8d747",
             "isStacked": false,
             "mergeAllActiveQueries": false,
             "nullZeroValues": "zero",
@@ -391,7 +429,7 @@
                             "filters": {
                                 "items": [
                                     {
-                                        "id": "fdeaa566-f3de-4a9a-b301-aac0df548e1a",
+                                        "id": "d80f38a7-8d3e-44bc-97ee-0f72eb2f07a2",
                                         "key": {
                                             "dataType": "string",
                                             "id": "service.name--string--resource--false",
@@ -427,7 +465,7 @@
                         "query": ""
                     }
                 ],
-                "id": "100e6285-8835-4f70-83cb-14c560091dc5",
+                "id": "4ef3ac7b-9fb7-4daf-b224-0129f05ff65e",
                 "promql": [
                     {
                         "disabled": false,
@@ -465,7 +503,7 @@
             "columnUnits": {},
             "description": "Distinct app versions producing errors in the window.",
             "fillSpans": false,
-            "id": "03914555-7e5c-43d3-acbb-fe809d1eedb3",
+            "id": "3d562521-012d-4b78-8c23-6d26f548a7af",
             "isStacked": false,
             "mergeAllActiveQueries": false,
             "nullZeroValues": "zero",
@@ -489,7 +527,7 @@
                             "filters": {
                                 "items": [
                                     {
-                                        "id": "ee6233e4-0506-4d23-88e8-5c0c91926443",
+                                        "id": "d04772a6-3e32-4654-9794-02b8d4f085ce",
                                         "key": {
                                             "dataType": "string",
                                             "id": "service.name--string--resource--false",
@@ -525,7 +563,7 @@
                         "query": ""
                     }
                 ],
-                "id": "690a8f83-afc5-4170-9022-89d7c2ff05e3",
+                "id": "35c1be07-1cc9-44f8-955e-e40aa4278854",
                 "promql": [
                     {
                         "disabled": false,
@@ -561,9 +599,9 @@
             "bucketCount": 30,
             "bucketWidth": 0,
             "columnUnits": {},
-            "description": "Event volume over time, split by mapped severity.",
+            "description": "Event volume over time split by bugsnag.error.unhandled - true means the app crashed, false means the error was caught.",
             "fillSpans": false,
-            "id": "cebf4c7e-0ce5-4165-8993-c5b789985a8b",
+            "id": "57a2fb5b-0aed-47c0-a50c-f0ad536f4d33",
             "isStacked": false,
             "mergeAllActiveQueries": false,
             "nullZeroValues": "zero",
@@ -582,12 +620,12 @@
                             "disabled": false,
                             "expression": "A",
                             "filter": {
-                                "expression": "service.name = 'bugsnag'"
+                                "expression": "service.name = 'bugsnag' AND exception.type IN $exception.type"
                             },
                             "filters": {
                                 "items": [
                                     {
-                                        "id": "9cdbf646-f59e-4422-aca2-5b9e5c06fbc9",
+                                        "id": "363a3c71-7ae5-419a-b16d-98a30bef6d22",
                                         "key": {
                                             "dataType": "string",
                                             "id": "service.name--string--resource--false",
@@ -598,6 +636,139 @@
                                         },
                                         "op": "=",
                                         "value": "bugsnag"
+                                    },
+                                    {
+                                        "id": "f5a51096-01fb-4ebc-a364-e64ec7eeeb09",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "exception.type--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "exception.type",
+                                            "type": "tag"
+                                        },
+                                        "op": "IN",
+                                        "value": "$exception.type"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "functions": [],
+                            "groupBy": [
+                                {
+                                    "dataType": "bool",
+                                    "id": "bugsnag.error.unhandled--bool--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "bugsnag.error.unhandled",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": {
+                                "expression": ""
+                            },
+                            "legend": "unhandled={{bugsnag.error.unhandled}}",
+                            "limit": null,
+                            "orderBy": [],
+                            "queryName": "A"
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "id": "3dfc56ba-1657-4acf-8317-67d9f7dde3e4",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [],
+            "softMax": 0,
+            "softMin": 0,
+            "stackedBarChart": false,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Crashes vs Handled Errors",
+            "yAxisUnit": "short"
+        },
+        {
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "columnUnits": {},
+            "description": "Event volume over time, split by mapped severity.",
+            "fillSpans": false,
+            "id": "dc79f7ad-7b2d-45ac-a0aa-0262d36096d9",
+            "isStacked": false,
+            "mergeAllActiveQueries": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "graph",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregations": [
+                                {
+                                    "expression": "count()"
+                                }
+                            ],
+                            "dataSource": "logs",
+                            "disabled": false,
+                            "expression": "A",
+                            "filter": {
+                                "expression": "service.name = 'bugsnag' AND exception.type IN $exception.type"
+                            },
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "4683ccbd-3273-4f86-bd04-ed8aca41b66b",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "service.name--string--resource--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "service.name",
+                                            "type": "resource"
+                                        },
+                                        "op": "=",
+                                        "value": "bugsnag"
+                                    },
+                                    {
+                                        "id": "de48bab5-ad1a-4bb8-9a75-86a77a9e1f03",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "exception.type--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "exception.type",
+                                            "type": "tag"
+                                        },
+                                        "op": "IN",
+                                        "value": "$exception.type"
                                     }
                                 ],
                                 "op": "AND"
@@ -632,7 +803,7 @@
                         "query": ""
                     }
                 ],
-                "id": "aa91752c-0b2f-4fb7-bc99-0aa2992564a4",
+                "id": "fe910ef1-4a18-4aff-9a76-e59a29ee27bd",
                 "promql": [
                     {
                         "disabled": false,
@@ -670,7 +841,7 @@
             "columnUnits": {},
             "description": "Event volume over time per app version - release regressions show up here.",
             "fillSpans": false,
-            "id": "d2a6c96f-c2fb-4e80-875d-ec24db4585d0",
+            "id": "64c0bc08-38aa-474f-a93a-fab31e38f95e",
             "isStacked": false,
             "mergeAllActiveQueries": false,
             "nullZeroValues": "zero",
@@ -689,12 +860,12 @@
                             "disabled": false,
                             "expression": "A",
                             "filter": {
-                                "expression": "service.name = 'bugsnag'"
+                                "expression": "service.name = 'bugsnag' AND exception.type IN $exception.type"
                             },
                             "filters": {
                                 "items": [
                                     {
-                                        "id": "7bd0c0a4-1717-423b-af31-16a13a71946d",
+                                        "id": "b30f5a94-de74-4bce-865b-c9746212e590",
                                         "key": {
                                             "dataType": "string",
                                             "id": "service.name--string--resource--false",
@@ -705,6 +876,19 @@
                                         },
                                         "op": "=",
                                         "value": "bugsnag"
+                                    },
+                                    {
+                                        "id": "ee2fc01c-bfea-4a81-9fe1-564b2968a704",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "exception.type--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "exception.type",
+                                            "type": "tag"
+                                        },
+                                        "op": "IN",
+                                        "value": "$exception.type"
                                     }
                                 ],
                                 "op": "AND"
@@ -739,7 +923,7 @@
                         "query": ""
                     }
                 ],
-                "id": "15c8826e-30ab-4ff0-becc-e5838074d142",
+                "id": "6379415a-45a0-4068-baf0-316f15fb995d",
                 "promql": [
                     {
                         "disabled": false,
@@ -775,9 +959,9 @@
             "bucketCount": 30,
             "bucketWidth": 0,
             "columnUnits": {},
-            "description": "Exception classes ranked by event count.",
+            "description": "Where in the app errors happen - the screen, activity, or route Bugsnag reports as context.",
             "fillSpans": false,
-            "id": "4a033855-2c2f-4b7a-9ace-7902a6ca2ab9",
+            "id": "f7be51fe-4708-49f8-a064-eb1a670fe5a2",
             "isStacked": false,
             "mergeAllActiveQueries": false,
             "nullZeroValues": "zero",
@@ -796,12 +980,12 @@
                             "disabled": false,
                             "expression": "A",
                             "filter": {
-                                "expression": "service.name = 'bugsnag'"
+                                "expression": "service.name = 'bugsnag' AND exception.type IN $exception.type"
                             },
                             "filters": {
                                 "items": [
                                     {
-                                        "id": "f4715113-d1b1-4ba8-a28a-3d23b0c3bb7c",
+                                        "id": "ae666646-38c4-47f8-a229-5fe9f9c5a352",
                                         "key": {
                                             "dataType": "string",
                                             "id": "service.name--string--resource--false",
@@ -812,6 +996,19 @@
                                         },
                                         "op": "=",
                                         "value": "bugsnag"
+                                    },
+                                    {
+                                        "id": "d87f825e-2c6e-44ed-957d-e34da4c166fb",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "exception.type--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "exception.type",
+                                            "type": "tag"
+                                        },
+                                        "op": "IN",
+                                        "value": "$exception.type"
                                     }
                                 ],
                                 "op": "AND"
@@ -820,10 +1017,10 @@
                             "groupBy": [
                                 {
                                     "dataType": "string",
-                                    "id": "exception.type--string--tag--false",
+                                    "id": "bugsnag.error.context--string--tag--false",
                                     "isColumn": false,
                                     "isJSON": false,
-                                    "key": "exception.type",
+                                    "key": "bugsnag.error.context",
                                     "type": "tag"
                                 }
                             ],
@@ -851,7 +1048,127 @@
                         "query": ""
                     }
                 ],
-                "id": "e4063f67-7081-4ccd-9c55-cf7a2584b605",
+                "id": "17ce02f6-b4df-449c-b581-34c4835c6400",
+                "promql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "queryType": "builder"
+            },
+            "selectedLogFields": [
+                {
+                    "dataType": "string",
+                    "name": "body",
+                    "type": ""
+                },
+                {
+                    "dataType": "string",
+                    "name": "timestamp",
+                    "type": ""
+                }
+            ],
+            "selectedTracesFields": [],
+            "softMax": 0,
+            "softMin": 0,
+            "stackedBarChart": false,
+            "thresholds": [],
+            "timePreferance": "GLOBAL_TIME",
+            "title": "Errors by Context",
+            "yAxisUnit": "short"
+        },
+        {
+            "bucketCount": 30,
+            "bucketWidth": 0,
+            "columnUnits": {},
+            "description": "Exception classes ranked by event count, split into unhandled (crash) and handled. Use the exception.type variable above to focus every other panel on one class.",
+            "fillSpans": false,
+            "id": "8aff78b7-f8ca-4ed0-b5fd-b9ff9e0819d2",
+            "isStacked": false,
+            "mergeAllActiveQueries": false,
+            "nullZeroValues": "zero",
+            "opacity": "1",
+            "panelTypes": "table",
+            "query": {
+                "builder": {
+                    "queryData": [
+                        {
+                            "aggregations": [
+                                {
+                                    "expression": "count()"
+                                }
+                            ],
+                            "dataSource": "logs",
+                            "disabled": false,
+                            "expression": "A",
+                            "filter": {
+                                "expression": "service.name = 'bugsnag'"
+                            },
+                            "filters": {
+                                "items": [
+                                    {
+                                        "id": "a5eaa42f-07b0-4327-bcd4-c8477c06e73a",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "service.name--string--resource--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "service.name",
+                                            "type": "resource"
+                                        },
+                                        "op": "=",
+                                        "value": "bugsnag"
+                                    }
+                                ],
+                                "op": "AND"
+                            },
+                            "functions": [],
+                            "groupBy": [
+                                {
+                                    "dataType": "string",
+                                    "id": "exception.type--string--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "exception.type",
+                                    "type": "tag"
+                                },
+                                {
+                                    "dataType": "bool",
+                                    "id": "bugsnag.error.unhandled--bool--tag--false",
+                                    "isColumn": false,
+                                    "isJSON": false,
+                                    "key": "bugsnag.error.unhandled",
+                                    "type": "tag"
+                                }
+                            ],
+                            "having": {
+                                "expression": ""
+                            },
+                            "legend": "",
+                            "limit": 10,
+                            "orderBy": [
+                                {
+                                    "columnName": "count()",
+                                    "order": "desc"
+                                }
+                            ],
+                            "queryName": "A"
+                        }
+                    ],
+                    "queryFormulas": []
+                },
+                "clickhouse_sql": [
+                    {
+                        "disabled": false,
+                        "legend": "",
+                        "name": "A",
+                        "query": ""
+                    }
+                ],
+                "id": "5d5e4711-47b1-4918-ab9d-ecea45660531",
                 "promql": [
                     {
                         "disabled": false,
@@ -889,7 +1206,7 @@
             "columnUnits": {},
             "description": "Event count per OS name and version.",
             "fillSpans": false,
-            "id": "965d189e-42c8-4f32-ba4d-1d9cf5fc8dff",
+            "id": "4be3098f-98ed-4520-a011-8179995eefea",
             "isStacked": false,
             "mergeAllActiveQueries": false,
             "nullZeroValues": "zero",
@@ -908,12 +1225,12 @@
                             "disabled": false,
                             "expression": "A",
                             "filter": {
-                                "expression": "service.name = 'bugsnag'"
+                                "expression": "service.name = 'bugsnag' AND exception.type IN $exception.type"
                             },
                             "filters": {
                                 "items": [
                                     {
-                                        "id": "7ef050db-a2e3-4049-92ae-283f29af9273",
+                                        "id": "9e5b83bd-350b-4a6a-bf3f-73a29c2af229",
                                         "key": {
                                             "dataType": "string",
                                             "id": "service.name--string--resource--false",
@@ -924,6 +1241,19 @@
                                         },
                                         "op": "=",
                                         "value": "bugsnag"
+                                    },
+                                    {
+                                        "id": "ab195e41-7280-4b71-98c8-4a06a9e54b52",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "exception.type--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "exception.type",
+                                            "type": "tag"
+                                        },
+                                        "op": "IN",
+                                        "value": "$exception.type"
                                     }
                                 ],
                                 "op": "AND"
@@ -971,7 +1301,7 @@
                         "query": ""
                     }
                 ],
-                "id": "b38fbf16-023c-482f-8ee8-c2afeac86c70",
+                "id": "ee23830a-0e2c-49f4-9ce5-9fcadd1a78e9",
                 "promql": [
                     {
                         "disabled": false,
@@ -1009,7 +1339,7 @@
             "columnUnits": {},
             "description": "Event count per device model.",
             "fillSpans": false,
-            "id": "33885bfe-9291-4cf9-9952-d43d886b17e7",
+            "id": "35d75be5-40ba-47e6-b7a1-20b8cbb48fda",
             "isStacked": false,
             "mergeAllActiveQueries": false,
             "nullZeroValues": "zero",
@@ -1028,12 +1358,12 @@
                             "disabled": false,
                             "expression": "A",
                             "filter": {
-                                "expression": "service.name = 'bugsnag'"
+                                "expression": "service.name = 'bugsnag' AND exception.type IN $exception.type"
                             },
                             "filters": {
                                 "items": [
                                     {
-                                        "id": "9c1171f2-527c-4909-b82b-71a9205e0485",
+                                        "id": "277183d9-8ea1-412d-8065-f105aada66b4",
                                         "key": {
                                             "dataType": "string",
                                             "id": "service.name--string--resource--false",
@@ -1044,6 +1374,19 @@
                                         },
                                         "op": "=",
                                         "value": "bugsnag"
+                                    },
+                                    {
+                                        "id": "9803578e-0d0f-4a66-9a6a-03a5b0c5dc7e",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "exception.type--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "exception.type",
+                                            "type": "tag"
+                                        },
+                                        "op": "IN",
+                                        "value": "$exception.type"
                                     }
                                 ],
                                 "op": "AND"
@@ -1083,7 +1426,7 @@
                         "query": ""
                     }
                 ],
-                "id": "5de31e85-8832-459b-9bcb-7b828b3e8b76",
+                "id": "62b9607c-52a1-4a1b-a7aa-950130c24c9b",
                 "promql": [
                     {
                         "disabled": false,
@@ -1119,9 +1462,9 @@
             "bucketCount": 30,
             "bucketWidth": 0,
             "columnUnits": {},
-            "description": "Latest Bugsnag events - open one for full payload and the bugsnag.error.url deep link.",
+            "description": "Latest Bugsnag events - readable exception line as the body; open one for the stacktrace, full payload (bugsnag.payload), and the bugsnag.error.url deep link.",
             "fillSpans": false,
-            "id": "22df07f9-5715-4e2c-9bdd-b9529c68c584",
+            "id": "8569b010-0ed3-4d60-ac63-82a3ae9e0753",
             "isStacked": false,
             "mergeAllActiveQueries": false,
             "nullZeroValues": "zero",
@@ -1136,12 +1479,12 @@
                             "disabled": false,
                             "expression": "A",
                             "filter": {
-                                "expression": "service.name = 'bugsnag'"
+                                "expression": "service.name = 'bugsnag' AND exception.type IN $exception.type"
                             },
                             "filters": {
                                 "items": [
                                     {
-                                        "id": "604ffbc3-0c1e-401e-8318-995c352b1d3c",
+                                        "id": "4ff39220-e358-4987-975e-98389e6382fe",
                                         "key": {
                                             "dataType": "string",
                                             "id": "service.name--string--resource--false",
@@ -1152,6 +1495,19 @@
                                         },
                                         "op": "=",
                                         "value": "bugsnag"
+                                    },
+                                    {
+                                        "id": "4f120baa-1617-40b3-8aa3-0baf0ba628bd",
+                                        "key": {
+                                            "dataType": "string",
+                                            "id": "exception.type--string--tag--false",
+                                            "isColumn": false,
+                                            "isJSON": false,
+                                            "key": "exception.type",
+                                            "type": "tag"
+                                        },
+                                        "op": "IN",
+                                        "value": "$exception.type"
                                     }
                                 ],
                                 "op": "AND"
@@ -1182,7 +1538,7 @@
                         "query": ""
                     }
                 ],
-                "id": "50b40cd4-d8a8-4eb9-a3f0-f9d9518095b1",
+                "id": "2bfd1340-a6cb-4798-9e82-e4832acb7d11",
                 "promql": [
                     {
                         "disabled": false,


### PR DESCRIPTION
## What

Adds a log-based dashboard for **Bugsnag error and crash events** forwarded to SigNoz via Bugsnag's [webhook data forwarding](https://docs.bugsnag.com/product/integrations/data-forwarding/webhook/), ingested with the collector's bundled `webhookevent` receiver plus a transform processor (config-only for self-hosted SigNoz — no extra services).

Panels: total events, unhandled-crash %, affected users, app versions reporting, volume over time by severity and by app version, top exception classes, OS/device breakdowns, and a recent-events list with `bugsnag.error.url` deep links.

Every panel filters on `service.name = 'bugsnag'` and uses v5 builder queries over log attributes (`exception.*`, `app.version`, `os.*`, `device.*`, `user.id`, `bugsnag.*`).

## Verification

Running live on a production self-hosted SigNoz (v0.132.2) receiving real Bugsnag webhook deliveries — all panels render and populate.

## Notes

- A companion docs PR on signoz-web (Bugsnag integration guide + dashboard template page referencing this JSON's raw URL) follows this PR.
- Panel screenshots for the README to be added as a follow-up commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)