### PR TITLE
fix: pair Temporal Cloud limits with their counts and throttles

### DIFF
--- a/temporal.io/temporal-cloud-metrics.json
+++ b/temporal.io/temporal-cloud-metrics.json
@@ -30,485 +30,441 @@
   },
   "layout": [
     {
+      "h": 1,
       "i": "row-overview",
-      "x": 0,
-      "y": 0,
-      "w": 12,
-      "h": 1,
-      "minW": 12,
-      "minH": 1,
       "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
       "static": false,
-      "moved": false
+      "w": 12,
+      "x": 0,
+      "y": 0
     },
     {
+      "h": 3,
       "i": "p-open-workflows",
-      "x": 0,
-      "y": 1,
-      "w": 3,
-      "h": 3,
-      "static": false,
       "moved": false,
-      "minW": 2,
-      "minH": 2
-    },
-    {
-      "i": "p-action-limit",
-      "x": 3,
-      "y": 1,
-      "w": 3,
-      "h": 3,
       "static": false,
-      "moved": false,
-      "minW": 2,
-      "minH": 2
-    },
-    {
-      "i": "p-ops-limit",
-      "x": 6,
-      "y": 1,
-      "w": 3,
-      "h": 3,
-      "static": false,
-      "moved": false,
-      "minW": 2,
-      "minH": 2
-    },
-    {
-      "i": "p-service-request-limit",
-      "x": 9,
-      "y": 1,
-      "w": 3,
-      "h": 3,
-      "static": false,
-      "moved": false,
-      "minW": 2,
-      "minH": 2
-    },
-    {
-      "i": "p-total-action-rate",
-      "x": 0,
-      "y": 4,
-      "w": 6,
-      "h": 6,
-      "static": false,
-      "moved": false,
-      "minW": 4,
-      "minH": 5
-    },
-    {
-      "i": "p-operations-rate",
-      "x": 6,
-      "y": 4,
-      "w": 6,
-      "h": 6,
-      "static": false,
-      "moved": false,
-      "minW": 4,
-      "minH": 5
-    },
-    {
-      "i": "row-workflows",
-      "x": 0,
-      "y": 10,
       "w": 12,
-      "h": 1,
-      "minW": 12,
-      "minH": 1,
-      "maxH": 1,
-      "static": false,
-      "moved": false
+      "x": 0,
+      "y": 1,
+      "minH": 2,
+      "minW": 2
     },
     {
+      "h": 6,
+      "i": "p-total-action-rate",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 0,
+      "y": 4,
+      "minH": 5,
+      "minW": 4
+    },
+    {
+      "h": 6,
+      "i": "p-operations-rate",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 4,
+      "minH": 5,
+      "minW": 4
+    },
+    {
+      "h": 1,
+      "i": "row-workflows",
+      "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 10
+    },
+    {
+      "h": 6,
       "i": "p-wf-success",
+      "moved": false,
+      "static": false,
+      "w": 6,
       "x": 0,
       "y": 11,
-      "w": 6,
-      "h": 6,
-      "static": false,
-      "moved": false,
-      "minW": 4,
-      "minH": 5
+      "minH": 5,
+      "minW": 4
     },
     {
+      "h": 6,
       "i": "p-wf-failed",
+      "moved": false,
+      "static": false,
+      "w": 6,
       "x": 6,
       "y": 11,
-      "w": 6,
-      "h": 6,
-      "static": false,
-      "moved": false,
-      "minW": 4,
-      "minH": 5
+      "minH": 5,
+      "minW": 4
     },
     {
+      "h": 7,
       "i": "p-wf-terminate-timeout-cancel",
+      "moved": false,
+      "static": false,
+      "w": 12,
       "x": 0,
       "y": 17,
-      "w": 12,
-      "h": 7,
-      "static": false,
-      "moved": false,
-      "minW": 4,
-      "minH": 5
+      "minH": 5,
+      "minW": 4
     },
     {
+      "h": 6,
       "i": "p-wf-continued",
+      "moved": false,
+      "static": false,
+      "w": 6,
       "x": 0,
       "y": 24,
-      "w": 6,
-      "h": 6,
-      "static": false,
-      "moved": false,
-      "minW": 4,
-      "minH": 5
+      "minH": 5,
+      "minW": 4
     },
     {
+      "h": 6,
       "i": "p-wf-stc-latency",
+      "moved": false,
+      "static": false,
+      "w": 6,
       "x": 6,
       "y": 24,
-      "w": 6,
-      "h": 6,
-      "static": false,
-      "moved": false,
-      "minW": 4,
-      "minH": 5
+      "minH": 5,
+      "minW": 4
     },
     {
-      "i": "row-activities",
-      "x": 0,
-      "y": 30,
-      "w": 12,
       "h": 1,
-      "minW": 12,
-      "minH": 1,
+      "i": "row-activities",
       "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
       "static": false,
-      "moved": false
+      "w": 12,
+      "x": 0,
+      "y": 30
     },
     {
+      "h": 6,
       "i": "p-act-success",
+      "moved": false,
+      "static": false,
+      "w": 6,
       "x": 0,
       "y": 31,
-      "w": 6,
-      "h": 6,
-      "static": false,
-      "moved": false,
-      "minW": 4,
-      "minH": 5
+      "minH": 5,
+      "minW": 4
     },
     {
+      "h": 6,
       "i": "p-act-fail-timeout-cancel",
+      "moved": false,
+      "static": false,
+      "w": 6,
       "x": 6,
       "y": 31,
-      "w": 6,
-      "h": 6,
-      "static": false,
-      "moved": false,
-      "minW": 4,
-      "minH": 5
+      "minH": 5,
+      "minW": 4
     },
     {
+      "h": 7,
       "i": "p-act-stc-latency",
+      "moved": false,
+      "static": false,
+      "w": 12,
       "x": 0,
       "y": 37,
-      "w": 12,
-      "h": 7,
-      "static": false,
-      "moved": false,
-      "minW": 4,
-      "minH": 5
+      "minH": 5,
+      "minW": 4
     },
     {
+      "h": 6,
       "i": "p-act-start-latency",
+      "moved": false,
+      "static": false,
+      "w": 6,
       "x": 0,
       "y": 44,
-      "w": 6,
-      "h": 6,
-      "static": false,
-      "moved": false,
-      "minW": 4,
-      "minH": 5
+      "minH": 5,
+      "minW": 4
     },
     {
+      "h": 6,
       "i": "p-act-task-issues",
+      "moved": false,
+      "static": false,
+      "w": 6,
       "x": 6,
       "y": 44,
-      "w": 6,
-      "h": 6,
-      "static": false,
-      "moved": false,
-      "minW": 4,
-      "minH": 5
+      "minH": 5,
+      "minW": 4
     },
     {
+      "h": 1,
       "i": "row-schedules",
-      "x": 0,
-      "y": 50,
-      "w": 12,
-      "h": 1,
-      "minW": 12,
-      "minH": 1,
       "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
       "static": false,
-      "moved": false
+      "w": 12,
+      "x": 0,
+      "y": 50
     },
     {
+      "h": 6,
       "i": "p-sched-success",
+      "moved": false,
+      "static": false,
+      "w": 6,
       "x": 0,
       "y": 51,
-      "w": 6,
-      "h": 6,
-      "static": false,
-      "moved": false,
-      "minW": 4,
-      "minH": 5
+      "minH": 5,
+      "minW": 4
     },
     {
+      "h": 6,
       "i": "p-sched-issues",
+      "moved": false,
+      "static": false,
+      "w": 6,
       "x": 6,
       "y": 51,
-      "w": 6,
-      "h": 6,
-      "static": false,
-      "moved": false,
-      "minW": 4,
-      "minH": 5
+      "minH": 5,
+      "minW": 4
     },
     {
-      "i": "row-service-requests",
-      "x": 0,
-      "y": 57,
-      "w": 12,
       "h": 1,
-      "minW": 12,
-      "minH": 1,
+      "i": "row-service-requests",
       "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
       "static": false,
-      "moved": false
+      "w": 12,
+      "x": 0,
+      "y": 57
     },
     {
+      "h": 6,
       "i": "p-svc-request-rate",
+      "moved": false,
+      "static": false,
+      "w": 6,
       "x": 0,
       "y": 58,
-      "w": 6,
-      "h": 6,
-      "static": false,
-      "moved": false,
-      "minW": 4,
-      "minH": 5
+      "minH": 5,
+      "minW": 4
     },
     {
+      "h": 6,
       "i": "p-svc-error-rate",
+      "moved": false,
+      "static": false,
+      "w": 6,
       "x": 6,
       "y": 58,
-      "w": 6,
-      "h": 6,
-      "static": false,
-      "moved": false,
-      "minW": 4,
-      "minH": 5
+      "minH": 5,
+      "minW": 4
     },
     {
+      "h": 6,
       "i": "p-svc-throttled-exhausted",
+      "moved": false,
+      "static": false,
+      "w": 6,
       "x": 0,
       "y": 64,
-      "w": 6,
-      "h": 6,
-      "static": false,
-      "moved": false,
-      "minW": 4,
-      "minH": 5
+      "minH": 5,
+      "minW": 4
     },
     {
+      "h": 6,
       "i": "p-svc-pending",
+      "moved": false,
+      "static": false,
+      "w": 6,
       "x": 6,
       "y": 64,
-      "w": 6,
-      "h": 6,
-      "static": false,
-      "moved": false,
-      "minW": 4,
-      "minH": 5
+      "minH": 5,
+      "minW": 4
     },
     {
+      "h": 7,
       "i": "p-svc-latency",
+      "moved": false,
+      "static": false,
+      "w": 12,
       "x": 0,
       "y": 70,
-      "w": 12,
-      "h": 7,
-      "static": false,
-      "moved": false,
-      "minW": 4,
-      "minH": 5
+      "minH": 5,
+      "minW": 4
     },
     {
-      "i": "row-task-queues",
-      "x": 0,
-      "y": 77,
-      "w": 12,
       "h": 1,
-      "minW": 12,
-      "minH": 1,
+      "i": "row-task-queues",
       "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
       "static": false,
-      "moved": false
+      "w": 12,
+      "x": 0,
+      "y": 77
     },
     {
+      "h": 6,
       "i": "p-backlog",
+      "moved": false,
+      "static": false,
+      "w": 6,
       "x": 0,
       "y": 78,
-      "w": 6,
-      "h": 6,
-      "static": false,
-      "moved": false,
-      "minW": 4,
-      "minH": 5
+      "minH": 5,
+      "minW": 4
     },
     {
+      "h": 6,
       "i": "p-poll-success-sync",
+      "moved": false,
+      "static": false,
+      "w": 6,
       "x": 6,
       "y": 78,
-      "w": 6,
-      "h": 6,
-      "static": false,
-      "moved": false,
-      "minW": 4,
-      "minH": 5
+      "minH": 5,
+      "minW": 4
     },
     {
+      "h": 6,
       "i": "p-poll-timeout",
+      "moved": false,
+      "static": false,
+      "w": 6,
       "x": 0,
       "y": 84,
-      "w": 6,
-      "h": 6,
-      "static": false,
-      "moved": false,
-      "minW": 4,
-      "minH": 5
+      "minH": 5,
+      "minW": 4
     },
     {
+      "h": 6,
       "i": "p-no-poller",
+      "moved": false,
+      "static": false,
+      "w": 6,
       "x": 6,
       "y": 84,
-      "w": 6,
-      "h": 6,
-      "static": false,
-      "moved": false,
-      "minW": 4,
-      "minH": 5
+      "minH": 5,
+      "minW": 4
     },
     {
+      "h": 6,
       "i": "p-poller-capacity",
+      "moved": false,
+      "static": false,
+      "w": 12,
       "x": 0,
       "y": 90,
-      "w": 12,
-      "h": 6,
-      "static": false,
-      "moved": false,
-      "minW": 4,
-      "minH": 5
+      "minH": 5,
+      "minW": 4
     },
     {
-      "i": "row-replication",
-      "x": 0,
-      "y": 96,
-      "w": 12,
       "h": 1,
-      "minW": 12,
-      "minH": 1,
+      "i": "row-replication",
       "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
       "static": false,
-      "moved": false
+      "w": 12,
+      "x": 0,
+      "y": 96
     },
     {
+      "h": 7,
       "i": "p-replication-lag",
+      "moved": false,
+      "static": false,
+      "w": 12,
       "x": 0,
       "y": 97,
-      "w": 12,
-      "h": 7,
-      "static": false,
-      "moved": false,
-      "minW": 4,
-      "minH": 5
+      "minH": 5,
+      "minW": 4
     },
     {
-      "i": "row-capacity",
-      "x": 0,
-      "y": 104,
-      "w": 12,
       "h": 1,
-      "minW": 12,
-      "minH": 1,
+      "i": "row-capacity",
       "maxH": 1,
+      "minH": 1,
+      "minW": 12,
+      "moved": false,
       "static": false,
-      "moved": false
+      "w": 12,
+      "x": 0,
+      "y": 104
     },
     {
+      "h": 6,
       "i": "p-cap-actions",
+      "moved": false,
+      "static": false,
+      "w": 6,
       "x": 0,
       "y": 105,
-      "w": 6,
-      "h": 6,
-      "static": false,
-      "moved": false,
-      "minW": 4,
-      "minH": 5
+      "minH": 5,
+      "minW": 4
     },
     {
-      "i": "p-cap-operations",
-      "x": 6,
-      "y": 105,
-      "w": 6,
       "h": 6,
-      "static": false,
-      "moved": false,
-      "minW": 4,
-      "minH": 5
-    },
-    {
       "i": "p-cap-service-requests",
+      "moved": false,
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 105,
+      "minH": 5,
+      "minW": 4
+    },
+    {
+      "h": 6,
+      "i": "p-cap-operations",
+      "moved": false,
+      "static": false,
+      "w": 6,
       "x": 0,
       "y": 111,
-      "w": 6,
-      "h": 6,
-      "static": false,
-      "moved": false,
-      "minW": 4,
-      "minH": 5
+      "minH": 5,
+      "minW": 4
     },
     {
-      "i": "p-cap-throttled",
-      "x": 6,
-      "y": 111,
-      "w": 6,
       "h": 6,
-      "static": false,
-      "moved": false,
-      "minW": 4,
-      "minH": 5
-    },
-    {
       "i": "p-on-demand-limits",
-      "x": 0,
-      "y": 117,
-      "w": 6,
-      "h": 6,
-      "static": false,
       "moved": false,
-      "minW": 4,
-      "minH": 5
+      "static": false,
+      "w": 6,
+      "x": 6,
+      "y": 111,
+      "minH": 5,
+      "minW": 4
     },
     {
-      "i": "p-billable-actions",
-      "x": 6,
-      "y": 117,
-      "w": 6,
       "h": 6,
-      "static": false,
+      "i": "p-billable-actions",
       "moved": false,
-      "minW": 4,
-      "minH": 5
+      "static": false,
+      "w": 12,
+      "x": 0,
+      "y": 117,
+      "minH": 5,
+      "minW": 4
     }
   ],
   "panelMap": {
@@ -516,70 +472,37 @@
       "collapsed": false,
       "widgets": [
         {
+          "h": 3,
           "i": "p-open-workflows",
+          "moved": false,
+          "static": false,
+          "w": 12,
           "x": 0,
           "y": 1,
-          "w": 3,
-          "h": 3,
-          "static": false,
-          "moved": false,
-          "minW": 2,
-          "minH": 2
+          "minH": 2,
+          "minW": 2
         },
         {
-          "i": "p-action-limit",
-          "x": 3,
-          "y": 1,
-          "w": 3,
-          "h": 3,
-          "static": false,
-          "moved": false,
-          "minW": 2,
-          "minH": 2
-        },
-        {
-          "i": "p-ops-limit",
-          "x": 6,
-          "y": 1,
-          "w": 3,
-          "h": 3,
-          "static": false,
-          "moved": false,
-          "minW": 2,
-          "minH": 2
-        },
-        {
-          "i": "p-service-request-limit",
-          "x": 9,
-          "y": 1,
-          "w": 3,
-          "h": 3,
-          "static": false,
-          "moved": false,
-          "minW": 2,
-          "minH": 2
-        },
-        {
+          "h": 6,
           "i": "p-total-action-rate",
+          "moved": false,
+          "static": false,
+          "w": 6,
           "x": 0,
           "y": 4,
-          "w": 6,
-          "h": 6,
-          "static": false,
-          "moved": false,
-          "minW": 4,
-          "minH": 5
+          "minH": 5,
+          "minW": 4
         },
         {
+          "h": 6,
           "i": "p-operations-rate",
+          "moved": false,
+          "static": false,
+          "w": 6,
           "x": 6,
           "y": 4,
-          "w": 6,
-          "h": 6,
-          "static": false,
-          "moved": false,
-          "minW": 4,
-          "minH": 5
+          "minH": 5,
+          "minW": 4
         }
       ]
     },
@@ -587,59 +510,59 @@
       "collapsed": false,
       "widgets": [
         {
+          "h": 6,
           "i": "p-wf-success",
+          "moved": false,
+          "static": false,
+          "w": 6,
           "x": 0,
           "y": 11,
-          "w": 6,
-          "h": 6,
-          "static": false,
-          "moved": false,
-          "minW": 4,
-          "minH": 5
+          "minH": 5,
+          "minW": 4
         },
         {
+          "h": 6,
           "i": "p-wf-failed",
+          "moved": false,
+          "static": false,
+          "w": 6,
           "x": 6,
           "y": 11,
-          "w": 6,
-          "h": 6,
-          "static": false,
-          "moved": false,
-          "minW": 4,
-          "minH": 5
+          "minH": 5,
+          "minW": 4
         },
         {
+          "h": 7,
           "i": "p-wf-terminate-timeout-cancel",
+          "moved": false,
+          "static": false,
+          "w": 12,
           "x": 0,
           "y": 17,
-          "w": 12,
-          "h": 7,
-          "static": false,
-          "moved": false,
-          "minW": 4,
-          "minH": 5
+          "minH": 5,
+          "minW": 4
         },
         {
+          "h": 6,
           "i": "p-wf-continued",
+          "moved": false,
+          "static": false,
+          "w": 6,
           "x": 0,
           "y": 24,
-          "w": 6,
-          "h": 6,
-          "static": false,
-          "moved": false,
-          "minW": 4,
-          "minH": 5
+          "minH": 5,
+          "minW": 4
         },
         {
+          "h": 6,
           "i": "p-wf-stc-latency",
+          "moved": false,
+          "static": false,
+          "w": 6,
           "x": 6,
           "y": 24,
-          "w": 6,
-          "h": 6,
-          "static": false,
-          "moved": false,
-          "minW": 4,
-          "minH": 5
+          "minH": 5,
+          "minW": 4
         }
       ]
     },
@@ -647,59 +570,59 @@
       "collapsed": false,
       "widgets": [
         {
+          "h": 6,
           "i": "p-act-success",
+          "moved": false,
+          "static": false,
+          "w": 6,
           "x": 0,
           "y": 31,
-          "w": 6,
-          "h": 6,
-          "static": false,
-          "moved": false,
-          "minW": 4,
-          "minH": 5
+          "minH": 5,
+          "minW": 4
         },
         {
+          "h": 6,
           "i": "p-act-fail-timeout-cancel",
+          "moved": false,
+          "static": false,
+          "w": 6,
           "x": 6,
           "y": 31,
-          "w": 6,
-          "h": 6,
-          "static": false,
-          "moved": false,
-          "minW": 4,
-          "minH": 5
+          "minH": 5,
+          "minW": 4
         },
         {
+          "h": 7,
           "i": "p-act-stc-latency",
+          "moved": false,
+          "static": false,
+          "w": 12,
           "x": 0,
           "y": 37,
-          "w": 12,
-          "h": 7,
-          "static": false,
-          "moved": false,
-          "minW": 4,
-          "minH": 5
+          "minH": 5,
+          "minW": 4
         },
         {
+          "h": 6,
           "i": "p-act-start-latency",
+          "moved": false,
+          "static": false,
+          "w": 6,
           "x": 0,
           "y": 44,
-          "w": 6,
-          "h": 6,
-          "static": false,
-          "moved": false,
-          "minW": 4,
-          "minH": 5
+          "minH": 5,
+          "minW": 4
         },
         {
+          "h": 6,
           "i": "p-act-task-issues",
+          "moved": false,
+          "static": false,
+          "w": 6,
           "x": 6,
           "y": 44,
-          "w": 6,
-          "h": 6,
-          "static": false,
-          "moved": false,
-          "minW": 4,
-          "minH": 5
+          "minH": 5,
+          "minW": 4
         }
       ]
     },
@@ -707,26 +630,26 @@
       "collapsed": false,
       "widgets": [
         {
+          "h": 6,
           "i": "p-sched-success",
+          "moved": false,
+          "static": false,
+          "w": 6,
           "x": 0,
           "y": 51,
-          "w": 6,
-          "h": 6,
-          "static": false,
-          "moved": false,
-          "minW": 4,
-          "minH": 5
+          "minH": 5,
+          "minW": 4
         },
         {
+          "h": 6,
           "i": "p-sched-issues",
+          "moved": false,
+          "static": false,
+          "w": 6,
           "x": 6,
           "y": 51,
-          "w": 6,
-          "h": 6,
-          "static": false,
-          "moved": false,
-          "minW": 4,
-          "minH": 5
+          "minH": 5,
+          "minW": 4
         }
       ]
     },
@@ -734,59 +657,59 @@
       "collapsed": false,
       "widgets": [
         {
+          "h": 6,
           "i": "p-svc-request-rate",
+          "moved": false,
+          "static": false,
+          "w": 6,
           "x": 0,
           "y": 58,
-          "w": 6,
-          "h": 6,
-          "static": false,
-          "moved": false,
-          "minW": 4,
-          "minH": 5
+          "minH": 5,
+          "minW": 4
         },
         {
+          "h": 6,
           "i": "p-svc-error-rate",
+          "moved": false,
+          "static": false,
+          "w": 6,
           "x": 6,
           "y": 58,
-          "w": 6,
-          "h": 6,
-          "static": false,
-          "moved": false,
-          "minW": 4,
-          "minH": 5
+          "minH": 5,
+          "minW": 4
         },
         {
+          "h": 6,
           "i": "p-svc-throttled-exhausted",
+          "moved": false,
+          "static": false,
+          "w": 6,
           "x": 0,
           "y": 64,
-          "w": 6,
-          "h": 6,
-          "static": false,
-          "moved": false,
-          "minW": 4,
-          "minH": 5
+          "minH": 5,
+          "minW": 4
         },
         {
+          "h": 6,
           "i": "p-svc-pending",
+          "moved": false,
+          "static": false,
+          "w": 6,
           "x": 6,
           "y": 64,
-          "w": 6,
-          "h": 6,
-          "static": false,
-          "moved": false,
-          "minW": 4,
-          "minH": 5
+          "minH": 5,
+          "minW": 4
         },
         {
+          "h": 7,
           "i": "p-svc-latency",
+          "moved": false,
+          "static": false,
+          "w": 12,
           "x": 0,
           "y": 70,
-          "w": 12,
-          "h": 7,
-          "static": false,
-          "moved": false,
-          "minW": 4,
-          "minH": 5
+          "minH": 5,
+          "minW": 4
         }
       ]
     },
@@ -794,59 +717,59 @@
       "collapsed": false,
       "widgets": [
         {
+          "h": 6,
           "i": "p-backlog",
+          "moved": false,
+          "static": false,
+          "w": 6,
           "x": 0,
           "y": 78,
-          "w": 6,
-          "h": 6,
-          "static": false,
-          "moved": false,
-          "minW": 4,
-          "minH": 5
+          "minH": 5,
+          "minW": 4
         },
         {
+          "h": 6,
           "i": "p-poll-success-sync",
+          "moved": false,
+          "static": false,
+          "w": 6,
           "x": 6,
           "y": 78,
-          "w": 6,
-          "h": 6,
-          "static": false,
-          "moved": false,
-          "minW": 4,
-          "minH": 5
+          "minH": 5,
+          "minW": 4
         },
         {
+          "h": 6,
           "i": "p-poll-timeout",
+          "moved": false,
+          "static": false,
+          "w": 6,
           "x": 0,
           "y": 84,
-          "w": 6,
-          "h": 6,
-          "static": false,
-          "moved": false,
-          "minW": 4,
-          "minH": 5
+          "minH": 5,
+          "minW": 4
         },
         {
+          "h": 6,
           "i": "p-no-poller",
+          "moved": false,
+          "static": false,
+          "w": 6,
           "x": 6,
           "y": 84,
-          "w": 6,
-          "h": 6,
-          "static": false,
-          "moved": false,
-          "minW": 4,
-          "minH": 5
+          "minH": 5,
+          "minW": 4
         },
         {
+          "h": 6,
           "i": "p-poller-capacity",
+          "moved": false,
+          "static": false,
+          "w": 12,
           "x": 0,
           "y": 90,
-          "w": 12,
-          "h": 6,
-          "static": false,
-          "moved": false,
-          "minW": 4,
-          "minH": 5
+          "minH": 5,
+          "minW": 4
         }
       ]
     },
@@ -854,15 +777,15 @@
       "collapsed": false,
       "widgets": [
         {
+          "h": 7,
           "i": "p-replication-lag",
+          "moved": false,
+          "static": false,
+          "w": 12,
           "x": 0,
           "y": 97,
-          "w": 12,
-          "h": 7,
-          "static": false,
-          "moved": false,
-          "minW": 4,
-          "minH": 5
+          "minH": 5,
+          "minW": 4
         }
       ]
     },
@@ -870,70 +793,59 @@
       "collapsed": false,
       "widgets": [
         {
+          "h": 6,
           "i": "p-cap-actions",
+          "moved": false,
+          "static": false,
+          "w": 6,
           "x": 0,
           "y": 105,
-          "w": 6,
-          "h": 6,
-          "static": false,
-          "moved": false,
-          "minW": 4,
-          "minH": 5
+          "minH": 5,
+          "minW": 4
         },
         {
-          "i": "p-cap-operations",
-          "x": 6,
-          "y": 105,
-          "w": 6,
           "h": 6,
-          "static": false,
-          "moved": false,
-          "minW": 4,
-          "minH": 5
-        },
-        {
           "i": "p-cap-service-requests",
+          "moved": false,
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 105,
+          "minH": 5,
+          "minW": 4
+        },
+        {
+          "h": 6,
+          "i": "p-cap-operations",
+          "moved": false,
+          "static": false,
+          "w": 6,
           "x": 0,
           "y": 111,
-          "w": 6,
-          "h": 6,
-          "static": false,
-          "moved": false,
-          "minW": 4,
-          "minH": 5
+          "minH": 5,
+          "minW": 4
         },
         {
-          "i": "p-cap-throttled",
-          "x": 6,
-          "y": 111,
-          "w": 6,
           "h": 6,
-          "static": false,
-          "moved": false,
-          "minW": 4,
-          "minH": 5
-        },
-        {
           "i": "p-on-demand-limits",
-          "x": 0,
-          "y": 117,
-          "w": 6,
-          "h": 6,
-          "static": false,
           "moved": false,
-          "minW": 4,
-          "minH": 5
+          "static": false,
+          "w": 6,
+          "x": 6,
+          "y": 111,
+          "minH": 5,
+          "minW": 4
         },
         {
-          "i": "p-billable-actions",
-          "x": 6,
-          "y": 117,
-          "w": 6,
           "h": 6,
-          "static": false,
+          "i": "p-billable-actions",
           "moved": false,
-          "minW": 4,
-          "minH": 5
+          "static": false,
+          "w": 12,
+          "x": 0,
+          "y": 117,
+          "minH": 5,
+          "minW": 4
         }
       ]
     }
@@ -1021,315 +933,6 @@
               "aggregations": [
                 {
                   "metricName": "temporal_cloud_v1_namespace_open_workflows",
-                  "temporality": "unspecified",
-                  "timeAggregation": "latest",
-                  "spaceAggregation": "sum",
-                  "reduceTo": "last"
-                }
-              ],
-              "filter": {
-                "expression": "temporal_namespace IN $temporal_namespace"
-              },
-              "groupBy": [],
-              "having": [],
-              "legend": "",
-              "limit": null,
-              "orderBy": [],
-              "stepInterval": 60
-            }
-          ]
-        }
-      },
-      "customLegendColors": {},
-      "legendPosition": "bottom",
-      "selectedLogFields": [
-        {
-          "fieldContext": "log",
-          "name": "timestamp",
-          "signal": "logs",
-          "type": "log"
-        },
-        {
-          "fieldContext": "log",
-          "name": "body",
-          "signal": "logs",
-          "type": "log"
-        }
-      ],
-      "selectedTracesFields": [
-        {
-          "fieldContext": "resource",
-          "fieldDataType": "string",
-          "name": "service.name",
-          "signal": "traces"
-        },
-        {
-          "fieldContext": "span",
-          "fieldDataType": "string",
-          "name": "name",
-          "signal": "traces"
-        },
-        {
-          "fieldContext": "span",
-          "name": "duration_nano",
-          "signal": "traces"
-        },
-        {
-          "fieldContext": "span",
-          "name": "http_method",
-          "signal": "traces"
-        },
-        {
-          "fieldContext": "span",
-          "name": "response_status_code",
-          "signal": "traces"
-        }
-      ],
-      "contextLinks": {
-        "linksData": []
-      },
-      "decimalPrecision": 2
-    },
-    {
-      "id": "p-action-limit",
-      "title": "Action limit (/s)",
-      "description": "Current configured actions-per-second limit for the namespace.",
-      "panelTypes": "value",
-      "yAxisUnit": "short",
-      "softMax": 0,
-      "softMin": 0,
-      "fillSpans": false,
-      "isLogScale": false,
-      "isStacked": false,
-      "mergeAllActiveQueries": false,
-      "nullZeroValues": "zero",
-      "opacity": "1",
-      "stackedBarChart": false,
-      "thresholds": [],
-      "timePreferance": "GLOBAL_TIME",
-      "bucketCount": 30,
-      "bucketWidth": 0,
-      "columnUnits": {},
-      "query": {
-        "queryType": "builder",
-        "builder": {
-          "queryFormulas": [],
-          "queryData": [
-            {
-              "queryName": "A",
-              "expression": "A",
-              "dataSource": "metrics",
-              "disabled": false,
-              "functions": [],
-              "aggregations": [
-                {
-                  "metricName": "temporal_cloud_v1_action_limit",
-                  "temporality": "unspecified",
-                  "timeAggregation": "latest",
-                  "spaceAggregation": "sum",
-                  "reduceTo": "last"
-                }
-              ],
-              "filter": {
-                "expression": "temporal_namespace IN $temporal_namespace"
-              },
-              "groupBy": [],
-              "having": [],
-              "legend": "",
-              "limit": null,
-              "orderBy": [],
-              "stepInterval": 60
-            }
-          ]
-        }
-      },
-      "customLegendColors": {},
-      "legendPosition": "bottom",
-      "selectedLogFields": [
-        {
-          "fieldContext": "log",
-          "name": "timestamp",
-          "signal": "logs",
-          "type": "log"
-        },
-        {
-          "fieldContext": "log",
-          "name": "body",
-          "signal": "logs",
-          "type": "log"
-        }
-      ],
-      "selectedTracesFields": [
-        {
-          "fieldContext": "resource",
-          "fieldDataType": "string",
-          "name": "service.name",
-          "signal": "traces"
-        },
-        {
-          "fieldContext": "span",
-          "fieldDataType": "string",
-          "name": "name",
-          "signal": "traces"
-        },
-        {
-          "fieldContext": "span",
-          "name": "duration_nano",
-          "signal": "traces"
-        },
-        {
-          "fieldContext": "span",
-          "name": "http_method",
-          "signal": "traces"
-        },
-        {
-          "fieldContext": "span",
-          "name": "response_status_code",
-          "signal": "traces"
-        }
-      ],
-      "contextLinks": {
-        "linksData": []
-      },
-      "decimalPrecision": 2
-    },
-    {
-      "id": "p-ops-limit",
-      "title": "Operations limit (/s)",
-      "description": "Current configured operations-per-second limit for the namespace.",
-      "panelTypes": "value",
-      "yAxisUnit": "short",
-      "softMax": 0,
-      "softMin": 0,
-      "fillSpans": false,
-      "isLogScale": false,
-      "isStacked": false,
-      "mergeAllActiveQueries": false,
-      "nullZeroValues": "zero",
-      "opacity": "1",
-      "stackedBarChart": false,
-      "thresholds": [],
-      "timePreferance": "GLOBAL_TIME",
-      "bucketCount": 30,
-      "bucketWidth": 0,
-      "columnUnits": {},
-      "query": {
-        "queryType": "builder",
-        "builder": {
-          "queryFormulas": [],
-          "queryData": [
-            {
-              "queryName": "A",
-              "expression": "A",
-              "dataSource": "metrics",
-              "disabled": false,
-              "functions": [],
-              "aggregations": [
-                {
-                  "metricName": "temporal_cloud_v1_operations_limit",
-                  "temporality": "unspecified",
-                  "timeAggregation": "latest",
-                  "spaceAggregation": "sum",
-                  "reduceTo": "last"
-                }
-              ],
-              "filter": {
-                "expression": "temporal_namespace IN $temporal_namespace"
-              },
-              "groupBy": [],
-              "having": [],
-              "legend": "",
-              "limit": null,
-              "orderBy": [],
-              "stepInterval": 60
-            }
-          ]
-        }
-      },
-      "customLegendColors": {},
-      "legendPosition": "bottom",
-      "selectedLogFields": [
-        {
-          "fieldContext": "log",
-          "name": "timestamp",
-          "signal": "logs",
-          "type": "log"
-        },
-        {
-          "fieldContext": "log",
-          "name": "body",
-          "signal": "logs",
-          "type": "log"
-        }
-      ],
-      "selectedTracesFields": [
-        {
-          "fieldContext": "resource",
-          "fieldDataType": "string",
-          "name": "service.name",
-          "signal": "traces"
-        },
-        {
-          "fieldContext": "span",
-          "fieldDataType": "string",
-          "name": "name",
-          "signal": "traces"
-        },
-        {
-          "fieldContext": "span",
-          "name": "duration_nano",
-          "signal": "traces"
-        },
-        {
-          "fieldContext": "span",
-          "name": "http_method",
-          "signal": "traces"
-        },
-        {
-          "fieldContext": "span",
-          "name": "response_status_code",
-          "signal": "traces"
-        }
-      ],
-      "contextLinks": {
-        "linksData": []
-      },
-      "decimalPrecision": 2
-    },
-    {
-      "id": "p-service-request-limit",
-      "title": "Service request limit (/s)",
-      "description": "Current configured frontend service requests-per-second limit.",
-      "panelTypes": "value",
-      "yAxisUnit": "short",
-      "softMax": 0,
-      "softMin": 0,
-      "fillSpans": false,
-      "isLogScale": false,
-      "isStacked": false,
-      "mergeAllActiveQueries": false,
-      "nullZeroValues": "zero",
-      "opacity": "1",
-      "stackedBarChart": false,
-      "thresholds": [],
-      "timePreferance": "GLOBAL_TIME",
-      "bucketCount": 30,
-      "bucketWidth": 0,
-      "columnUnits": {},
-      "query": {
-        "queryType": "builder",
-        "builder": {
-          "queryFormulas": [],
-          "queryData": [
-            {
-              "queryName": "A",
-              "expression": "A",
-              "dataSource": "metrics",
-              "disabled": false,
-              "functions": [],
-              "aggregations": [
-                {
-                  "metricName": "temporal_cloud_v1_service_request_limit",
                   "temporality": "unspecified",
                   "timeAggregation": "latest",
                   "spaceAggregation": "sum",
@@ -2608,7 +2211,7 @@
     {
       "id": "p-act-stc-latency",
       "title": "Activity schedule-to-close latency (p50/p95/p99)",
-      "description": "Per-namespace activity schedule-to-close latency percentiles.",
+      "description": "Activity schedule-to-close latency percentiles. Pre-computed by Temporal, so percentiles are not re-aggregated. Series split by activity type only when the opt-in temporal_activity_type label is enabled on the scrape (params: labels=[temporal_activity_type]); without it this is a single namespace-wide series.",
       "panelTypes": "graph",
       "yAxisUnit": "s",
       "softMax": 0,
@@ -2675,7 +2278,7 @@
                 }
               ],
               "having": [],
-              "legend": "{{temporal_namespace}} - {{region}} - {{temporal_activity_type}} - p50",
+              "legend": "{{temporal_namespace}} - {{region}} - p50 {{temporal_activity_type}}",
               "limit": null,
               "orderBy": [],
               "stepInterval": 60
@@ -2725,7 +2328,7 @@
                 }
               ],
               "having": [],
-              "legend": "{{temporal_namespace}} - {{region}} - {{temporal_activity_type}} - p95",
+              "legend": "{{temporal_namespace}} - {{region}} - p95 {{temporal_activity_type}}",
               "limit": null,
               "orderBy": [],
               "stepInterval": 60
@@ -2775,7 +2378,7 @@
                 }
               ],
               "having": [],
-              "legend": "{{temporal_namespace}} - {{region}} - {{temporal_activity_type}} - p99",
+              "legend": "{{temporal_namespace}} - {{region}} - p99 {{temporal_activity_type}}",
               "limit": null,
               "orderBy": [],
               "stepInterval": 60
@@ -2836,7 +2439,7 @@
     {
       "id": "p-act-start-latency",
       "title": "Activity start-to-close latency (p50/p95/p99)",
-      "description": "Precomputed activity start-to-close latency percentiles, split by namespace, region, and opt-in activity type when present.",
+      "description": "Activity start-to-close latency percentiles. Pre-computed by Temporal, so percentiles are not re-aggregated. Series split by activity type only when the opt-in temporal_activity_type label is enabled on the scrape (params: labels=[temporal_activity_type]); without it this is a single namespace-wide series.",
       "panelTypes": "graph",
       "yAxisUnit": "s",
       "softMax": 0,
@@ -2952,7 +2555,7 @@
                 }
               ],
               "having": [],
-              "legend": "{{temporal_namespace}} - {{region}} - {{temporal_activity_type}} - p50",
+              "legend": "{{temporal_namespace}} - {{region}} - p50 {{temporal_activity_type}}",
               "limit": null,
               "orderBy": [],
               "stepInterval": 60
@@ -3002,7 +2605,7 @@
                 }
               ],
               "having": [],
-              "legend": "{{temporal_namespace}} - {{region}} - {{temporal_activity_type}} - p95",
+              "legend": "{{temporal_namespace}} - {{region}} - p95 {{temporal_activity_type}}",
               "limit": null,
               "orderBy": [],
               "stepInterval": 60
@@ -3052,7 +2655,7 @@
                 }
               ],
               "having": [],
-              "legend": "{{temporal_namespace}} - {{region}} - {{temporal_activity_type}} - p99",
+              "legend": "{{temporal_namespace}} - {{region}} - p99 {{temporal_activity_type}}",
               "limit": null,
               "orderBy": [],
               "stepInterval": 60
@@ -3319,7 +2922,7 @@
     },
     {
       "id": "p-sched-issues",
-      "title": "Schedule issues — rate-limited / overrun / missed (/s)",
+      "title": "Schedule issues \u2014 rate-limited / overrun / missed (/s)",
       "description": "Per-second rate of schedule actions that were rate-limited, buffer-overrun, or missed their catchup window.",
       "panelTypes": "graph",
       "yAxisUnit": "short",
@@ -3696,8 +3299,8 @@
     },
     {
       "id": "p-svc-throttled-exhausted",
-      "title": "Throttled + resource-exhausted (/s)",
-      "description": "Throttled requests and ResourceExhausted errors per second.",
+      "title": "Resource exhausted (/s)",
+      "description": "Resource-exhausted errors. Usually self-healing through retries, unlike hitting a rate limit. Throttling now sits with its own limit in Capacity vs Usage.",
       "panelTypes": "graph",
       "yAxisUnit": "short",
       "softMax": 0,
@@ -3722,31 +3325,6 @@
             {
               "queryName": "A",
               "expression": "A",
-              "dataSource": "metrics",
-              "disabled": false,
-              "functions": [],
-              "aggregations": [
-                {
-                  "metricName": "temporal_cloud_v1_service_request_throttled_count",
-                  "temporality": "unspecified",
-                  "timeAggregation": "avg",
-                  "spaceAggregation": "sum",
-                  "reduceTo": "avg"
-                }
-              ],
-              "filter": {
-                "expression": "temporal_namespace IN $temporal_namespace"
-              },
-              "groupBy": [],
-              "having": [],
-              "legend": "throttled",
-              "limit": null,
-              "orderBy": [],
-              "stepInterval": 60
-            },
-            {
-              "queryName": "B",
-              "expression": "B",
               "dataSource": "metrics",
               "disabled": false,
               "functions": [],
@@ -4276,7 +3854,7 @@
     },
     {
       "id": "p-poll-success-sync",
-      "title": "Poll success — total vs sync (/s)",
+      "title": "Poll success \u2014 total vs sync (/s)",
       "description": "Successfully matched tasks per second, with the sync-matched share.",
       "panelTypes": "graph",
       "yAxisUnit": "short",
@@ -4979,7 +4557,7 @@
     {
       "id": "p-cap-actions",
       "title": "Actions used vs limit (/s)",
-      "description": "Actual actions per second versus the configured action limit. Watch this approach the limit.",
+      "description": "Actual actions per second versus the configured action limit. Watch this approach the limit. Throttle is included because a spiky workload can be throttled while the 1-minute averaged count still sits below the limit.",
       "panelTypes": "graph",
       "yAxisUnit": "short",
       "softMax": 0,
@@ -5068,6 +4646,40 @@
               "limit": null,
               "orderBy": [],
               "stepInterval": 60
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "temporal_cloud_v1_total_action_throttled_count",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "unspecified",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "C",
+              "filter": {
+                "expression": "temporal_namespace IN $temporal_namespace"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "temporal_namespace--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "temporal_namespace",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{temporal_namespace}} actions throttled",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "C",
+              "stepInterval": 60
             }
           ]
         }
@@ -5125,7 +4737,7 @@
     {
       "id": "p-cap-operations",
       "title": "Operations used vs limit (/s)",
-      "description": "Actual operations per second versus the configured operations limit.",
+      "description": "Actual operations per second versus the configured operations limit. Throttle is included because a spiky workload can be throttled while the 1-minute averaged count still sits below the limit.",
       "panelTypes": "graph",
       "yAxisUnit": "short",
       "softMax": 0,
@@ -5214,6 +4826,40 @@
               "limit": null,
               "orderBy": [],
               "stepInterval": 60
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "temporal_cloud_v1_operations_throttled_count",
+                  "reduceTo": "avg",
+                  "spaceAggregation": "sum",
+                  "temporality": "unspecified",
+                  "timeAggregation": "avg"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "C",
+              "filter": {
+                "expression": "temporal_namespace IN $temporal_namespace AND is_background = 'false'"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "temporal_namespace--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "temporal_namespace",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{temporal_namespace}} operations throttled",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "C",
+              "stepInterval": 60
             }
           ]
         }
@@ -5271,7 +4917,7 @@
     {
       "id": "p-cap-service-requests",
       "title": "Service requests used vs limit (/s)",
-      "description": "Frontend service request rate compared with the configured service request limit.",
+      "description": "Frontend service request rate compared with the configured service request limit. Throttle is included because a spiky workload can be throttled while the 1-minute averaged count still sits below the limit.",
       "panelTypes": "graph",
       "yAxisUnit": "short",
       "softMax": 0,
@@ -5409,133 +5055,39 @@
               "limit": null,
               "orderBy": [],
               "stepInterval": 60
-            }
-          ]
-        }
-      }
-    },
-    {
-      "id": "p-cap-throttled",
-      "title": "Actions and operations throttled (/s)",
-      "description": "Namespace-level throttling against action and operation limits.",
-      "panelTypes": "graph",
-      "yAxisUnit": "short",
-      "softMax": 0,
-      "softMin": 0,
-      "fillSpans": false,
-      "isLogScale": false,
-      "isStacked": false,
-      "mergeAllActiveQueries": false,
-      "nullZeroValues": "zero",
-      "opacity": "1",
-      "stackedBarChart": false,
-      "thresholds": [],
-      "timePreferance": "GLOBAL_TIME",
-      "bucketCount": 30,
-      "bucketWidth": 0,
-      "columnUnits": {},
-      "customLegendColors": {},
-      "decimalPrecision": 2,
-      "legendPosition": "bottom",
-      "selectedLogFields": [
-        {
-          "fieldContext": "log",
-          "name": "timestamp",
-          "signal": "logs",
-          "type": "log"
-        },
-        {
-          "fieldContext": "log",
-          "name": "body",
-          "signal": "logs",
-          "type": "log"
-        }
-      ],
-      "selectedTracesFields": [
-        {
-          "fieldContext": "resource",
-          "fieldDataType": "string",
-          "name": "service.name",
-          "signal": "traces"
-        },
-        {
-          "fieldContext": "span",
-          "fieldDataType": "string",
-          "name": "name",
-          "signal": "traces"
-        },
-        {
-          "fieldContext": "span",
-          "name": "duration_nano",
-          "signal": "traces"
-        },
-        {
-          "fieldContext": "span",
-          "name": "http_method",
-          "signal": "traces"
-        },
-        {
-          "fieldContext": "span",
-          "name": "response_status_code",
-          "signal": "traces"
-        }
-      ],
-      "contextLinks": {
-        "linksData": []
-      },
-      "query": {
-        "queryType": "builder",
-        "builder": {
-          "queryFormulas": [],
-          "queryData": [
+            },
             {
-              "queryName": "A",
-              "expression": "A",
-              "dataSource": "metrics",
-              "disabled": false,
-              "functions": [],
               "aggregations": [
                 {
-                  "metricName": "temporal_cloud_v1_total_action_throttled_count",
-                  "temporality": "unspecified",
-                  "timeAggregation": "avg",
+                  "metricName": "temporal_cloud_v1_service_request_throttled_count",
+                  "reduceTo": "avg",
                   "spaceAggregation": "sum",
-                  "reduceTo": "avg"
+                  "temporality": "unspecified",
+                  "timeAggregation": "avg"
                 }
               ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "C",
               "filter": {
                 "expression": "temporal_namespace IN $temporal_namespace"
               },
-              "groupBy": [],
-              "having": [],
-              "legend": "actions throttled",
-              "limit": null,
-              "orderBy": [],
-              "stepInterval": 60
-            },
-            {
-              "queryName": "B",
-              "expression": "B",
-              "dataSource": "metrics",
-              "disabled": false,
               "functions": [],
-              "aggregations": [
+              "groupBy": [
                 {
-                  "metricName": "temporal_cloud_v1_operations_throttled_count",
-                  "temporality": "unspecified",
-                  "timeAggregation": "avg",
-                  "spaceAggregation": "sum",
-                  "reduceTo": "avg"
+                  "dataType": "string",
+                  "id": "temporal_namespace--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "temporal_namespace",
+                  "type": "tag"
                 }
               ],
-              "filter": {
-                "expression": "temporal_namespace IN $temporal_namespace AND is_background = 'false'"
-              },
-              "groupBy": [],
               "having": [],
-              "legend": "operations throttled",
+              "legend": "{{temporal_namespace}} requests throttled",
               "limit": null,
               "orderBy": [],
+              "queryName": "C",
               "stepInterval": 60
             }
           ]
@@ -5544,8 +5096,8 @@
     },
     {
       "id": "p-on-demand-limits",
-      "title": "On-demand envelope limits (/s)",
-      "description": "What namespace limits would be in on-demand mode; in on-demand namespaces these match the current limits.",
+      "title": "On-demand envelope vs current limit (/s)",
+      "description": "Each on-demand envelope limit against the limit currently in force. Identical values mean the namespace is on-demand; a gap means it is on provisioned capacity.",
       "panelTypes": "graph",
       "yAxisUnit": "short",
       "softMax": 0,
@@ -5716,6 +5268,108 @@
               "legend": "{{temporal_namespace}} service request envelope",
               "limit": null,
               "orderBy": [],
+              "stepInterval": 60
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "temporal_cloud_v1_action_limit",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": "unspecified",
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "D",
+              "filter": {
+                "expression": "temporal_namespace IN $temporal_namespace"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "temporal_namespace--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "temporal_namespace",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{temporal_namespace}} action limit",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "D",
+              "stepInterval": 60
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "temporal_cloud_v1_operations_limit",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": "unspecified",
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "E",
+              "filter": {
+                "expression": "temporal_namespace IN $temporal_namespace"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "temporal_namespace--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "temporal_namespace",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{temporal_namespace}} operations limit",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "E",
+              "stepInterval": 60
+            },
+            {
+              "aggregations": [
+                {
+                  "metricName": "temporal_cloud_v1_service_request_limit",
+                  "reduceTo": "last",
+                  "spaceAggregation": "sum",
+                  "temporality": "unspecified",
+                  "timeAggregation": "latest"
+                }
+              ],
+              "dataSource": "metrics",
+              "disabled": false,
+              "expression": "F",
+              "filter": {
+                "expression": "temporal_namespace IN $temporal_namespace"
+              },
+              "functions": [],
+              "groupBy": [
+                {
+                  "dataType": "string",
+                  "id": "temporal_namespace--string--tag--false",
+                  "isColumn": false,
+                  "isJSON": false,
+                  "key": "temporal_namespace",
+                  "type": "tag"
+                }
+              ],
+              "having": [],
+              "legend": "{{temporal_namespace}} service request limit",
+              "limit": null,
+              "orderBy": [],
+              "queryName": "F",
               "stepInterval": 60
             }
           ]


### PR DESCRIPTION
Capacity vs Usage panels follow the limit / count / throttle table in [Monitoring Trends Against Limits](https://docs.temporal.io/cloud/service-health#rps-aps-rate-limits).

### Fixes

- `Actions used vs limit`, `Service requests used vs limit`, `Operations used vs limit` — each gains its throttle metric alongside count and limit. Counts are per-second rates averaged over one minute, so a sub-minute burst can be throttled while the count stays below the limit; throttle is the only signal that a limit was hit.
- `On-demand envelope limits` → `On-demand envelope vs current limit` — each envelope metric paired with the limit in force. Equal values indicate on-demand mode, a gap indicates provisioned capacity.
- `Throttled + resource-exhausted` → `Resource exhausted` — `service_request_throttled_count` moved to `Service requests used vs limit`. Resource exhaustion self-heals through retries and is a separate failure mode from rate limiting.
- `operations_throttled_count` retains its `is_background = 'false'` filter, matching the count it is plotted against.
- Activity latency legends move `temporal_activity_type` to the end. The label is opt-in on the scrape; when absent SigNoz returns the series with an empty value, so the placeholder's delimiters rendered as `namespace - region -  - p95`. Now renders `namespace - region - p95`. Both panel descriptions state the label as a prerequisite for the per-activity breakdown.

### Refactor

- `Action limit`, `Operations limit`, `Service request limit` — values now sit on the panels they qualify.
- `Actions and operations throttled` — metrics now sit with their respective limits.

Related: https://github.com/SigNoz/platform-pod/issues/2595