### PR TITLE
Refresh 22 LLM dashboard templates

### DIFF
--- a/autogen/autogen-dashboard.json
+++ b/autogen/autogen-dashboard.json
@@ -1,1 +1,963 @@
-{"description":"","image":"data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE0Ljk0OTQgMTMuOTQyQzE2LjIzMTggMTIuNDI1OCAxNy4zMjY4IDkuNzAyMiAxNi4xOTU2IDYuNTc0ODdDMTUuNjQ0MyA1LjA1MjQ1IDE1LjAyMTkgNC4yMDI0OSAxNC4yOTY5IDMuNjYyNTJDMTMuODU1NyAzLjMzMzc5IDEyLjA5MzMgMi41MDYzMyA5Ljc1OTY1IDIuODY3NTZDOC4wNTM0OSAzLjEzMjU1IDUuNzc0ODcgNC4yMDg3NCA0LjI5MzY5IDUuOTU5OUMyLjg1NzUyIDcuNjYxMDYgMS43NDg4MyA5LjAwNDc0IDEuNjk3NTggMTAuMzA5N0MxLjYzMTMzIDExLjk4ODMgMi44OTYyNyAxMy40MzA4IDMuMDUwMDEgMTMuNjY0NUMzLjMyMzc0IDE0LjA3OTUgNS4xOTExNSAxNi40NTE4IDguNjk5NzEgMTYuNTczMUMxMS43OTcgMTYuNjc5MyAxMy44MTQ0IDE1LjI4NDQgMTQuOTQ5NCAxMy45NDJaIiBmaWxsPSIjNDAzRDNFIi8+CjxwYXRoIGQ9Ik00LjU1MzYzIDIuNzM3NDdDMi45Mzc0NiAzLjg5MTE2IDEuMTIxMzEgNi4yNTEwMyAxLjQ0NzU0IDkuNTYwODZDMS42MDYyOCAxMS4xNzIgMi4wMDI1MSAxMi4xNDk1IDIuNTcxMjMgMTIuODUwN0MyLjkxNzQ2IDEzLjI3ODIgNC40MTk4OCAxNC41NDkzIDYuNzczNTEgMTQuNzM2OEM5LjE0NTg4IDE0LjkyNTYgMTAuOTQ5NSAxNC4zOTQ0IDEyLjgzMzIgMTMuMDg0NEMxNi42NjE3IDEwLjQyMDggMTYuMDk4IDYuMzkzNTMgMTUuOTM0MyA1LjkyNDhDMTUuNzcwNSA1LjQ1NjA3IDE0LjU0NDQgMi42OTYyMiAxMS4xNzMzIDEuNzE1MDJDOC4xOTg0NCAwLjg1MDA2OCA1Ljk4MzU1IDEuNzE1MDIgNC41NTM2MyAyLjczNzQ3WiIgZmlsbD0iIzVFNjM2NyIvPgo8cGF0aCBkPSJNNy4zOTM1MyAyLjk2MTA5QzUuNjE3MzcgMi44OTczNCAzLjkxOTk2IDQuMjg4NTIgMy43NTYyMiA2LjAwNTkzQzMuNTkyNDggNy43MjIwOSA0LjY1NDkyIDkuMDI5NTIgNi4zMDk4MyA5LjI5NTc2QzcuOTY0NzUgOS41NjA3NCA5Ljg3ODM5IDguNTU1OCAxMC4yNjM0IDYuNDUwOTFDMTAuNjYwOSA0LjI4MjI3IDkuMDg5NjkgMy4wMjIzNCA3LjM5MzUzIDIuOTYxMDlaIiBmaWxsPSJ3aGl0ZSIvPgo8cGF0aCBkPSJNNy45NDIxNyA1LjkwMTE1QzcuOTQyMTcgNS45MDExNSA4LjM2OTY1IDUuODEyNCA4LjQ1NDY1IDUuMTgyNDRDOC41MzgzOSA0LjU2MjQ3IDguMjMwOTEgNC4wMzM3NSA3LjUxMzQ1IDMuODQzNzZDNi43MzM0OSAzLjYzNzUyIDYuMjA0NzcgNC4wNjYyNSA2LjA2NzI3IDQuNTE3NDdDNS44NzYwMyA1LjE0NDk0IDYuMTU4NTIgNS40NDM2NyA2LjE1ODUyIDUuNDQzNjdDNi4xNTg1MiA1LjQ0MzY3IDUuMzkzNTYgNS42Mjc0MSA1LjMzMjMxIDYuNTI5ODdDNS4yNzQ4MSA3LjM4MTA3IDUuODU2MDMgNy44Mzg1NSA2LjQzOTc1IDcuOTc4NTRDNy4xNjA5NiA4LjE1MjI4IDcuOTc4NDIgNy45NTQ3OSA4LjE3ODQxIDcuMDM0ODRDOC4zNDQ2NSA2LjI3NzM4IDcuOTQyMTcgNS45MDExNSA3Ljk0MjE3IDUuOTAxMTVaIiBmaWxsPSIjMzAzMDMwIi8+CjxwYXRoIGQ9Ik02LjczOTgzIDQuNzUzNjJDNi42NzEwOSA1LjAxMjM1IDYuODA4NTggNS4yNjIzNCA3LjA3ODU3IDUuMzMxMDlDNy4zNjk4IDUuNDA0ODMgNy42MzQ3OSA1LjMwODU5IDcuNzA2MDMgNS4wMTExQzcuNzY4NTMgNC43NDczNyA3LjY0MzU0IDQuNTE0ODggNy4zMzYwNSA0LjQzOTg4QzcuMDgzNTcgNC4zNzczOSA2LjgxNDgzIDQuNDcxMTMgNi43Mzk4MyA0Ljc1MzYyWiIgZmlsbD0id2hpdGUiLz4KPHBhdGggZD0iTTYuOTU5NzggNi4wMzk3NEM2LjYzMjMgNS45Mzg0OSA2LjE5OTgyIDYuMDY0NzMgNi4xMzEwNyA2LjUwNDcxQzYuMDYyMzMgNi45NDQ2OSA2LjMyNjA2IDcuMTY5NjggNi42NzEwNCA3LjIzMjE3QzcuMDE2MDMgNy4yOTQ2NyA3LjM0MjI2IDcuMTEzNDMgNy40MDYwMSA2Ljc2MDk1QzcuNDY4NSA2LjQwOTcyIDcuMjg2MDEgNi4xMzk3MyA2Ljk1OTc4IDYuMDM5NzRaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K","layout":[{"h":4,"i":"799913e6-fb95-497e-858a-6490b5f9d10d","moved":false,"static":false,"w":3,"x":0,"y":0},{"h":5,"i":"3633c7ad-203a-4e25-99f4-8cc81bf15d65","moved":false,"static":false,"w":3,"x":3,"y":0},{"h":7,"i":"af79b14b-5e76-47fb-a24e-a4629c642c28","moved":false,"static":false,"w":6,"x":6,"y":0},{"h":6,"i":"74a94376-eeaf-43c1-a273-5d8b98197138","moved":false,"static":false,"w":5,"x":0,"y":5},{"h":1,"i":"__dropping-elem__","isDraggable":true,"moved":false,"static":false,"w":1,"x":5,"y":5},{"h":4,"i":"1439219a-7067-4f3b-9308-1c405844cdab","moved":false,"static":false,"w":7,"x":5,"y":7},{"h":5,"i":"bc6e3017-2b44-4152-a0d7-fe11e6b7a290","moved":false,"static":false,"w":5,"x":0,"y":11},{"h":3,"i":"68d3a601-afac-4c63-b212-61667e0f9d70","moved":false,"static":false,"w":7,"x":5,"y":11},{"h":5,"i":"05e6759b-c460-4618-86c0-5d2bf0b311c1","moved":false,"static":false,"w":6,"x":5,"y":14},{"h":4,"i":"5e66cb8c-2219-47e6-ba71-8f82f9873bc8","moved":false,"static":false,"w":5,"x":0,"y":16}],"panelMap":{},"tags":[],"title":"Autogen","uploadedGrafana":false,"uuid":"019a363f-03d5-7b43-8e72-b24b046aec71","variables":{"10d0eca9-9253-4583-821c-d3c812d78151":{"allSelected":false,"customValue":"","defaultValue":"","description":"The service name using Autogen","dynamicVariablesAttribute":"service.name","dynamicVariablesSource":"All telemetry","id":"10d0eca9-9253-4583-821c-d3c812d78151","key":"10d0eca9-9253-4583-821c-d3c812d78151","modificationUUID":"9b64904e-317f-432d-bed5-7850518fd22d","multiSelect":true,"name":"service_name","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"1b049274-93ae-4bdd-95d4-1838abe22c30":{"allSelected":false,"customValue":"","defaultValue":"","description":"Name of agent being used in Autogen","dynamicVariablesAttribute":"gen_ai.agent.name","dynamicVariablesSource":"All telemetry","id":"1b049274-93ae-4bdd-95d4-1838abe22c30","key":"1b049274-93ae-4bdd-95d4-1838abe22c30","modificationUUID":"3e13f8b5-dee0-4839-a8e5-85c6b8e2b3bc","multiSelect":true,"name":"agent_name","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"be7a68c4-fb97-43ea-bb94-0ded120bd3d7":{"allSelected":false,"customValue":"","defaultValue":"","description":"Model name being used in Autogen call","dynamicVariablesAttribute":"gen_ai.request.model","dynamicVariablesSource":"All telemetry","id":"be7a68c4-fb97-43ea-bb94-0ded120bd3d7","modificationUUID":"f2f846f8-bee7-41c1-844a-124d0db3bdd3","multiSelect":true,"name":"llm_model","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"}},"version":"v5","widgets":[{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"799913e6-fb95-497e-858a-6490b5f9d10d","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"A","filter":{"expression":"has_error = 'true' service.name in $service_name gen_ai.agent.name in $agent_name"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null},{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"B","filter":{"expression":"has_error = 'false' service.name in $service_name gen_ai.agent.name in $agent_name"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"B","source":"","stepInterval":null}],"queryFormulas":[{"disabled":false,"expression":"A / (A+B)","legend":"","queryName":"F1"}],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"b0f836e9-54f3-40dc-9876-954574b0c4e2","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[{"index":"e5e05d41-7479-4d60-a1cf-c433b8b61285","isEditEnabled":false,"keyIndex":1,"selectedGraph":"value","thresholdColor":"Red","thresholdFormat":"Text","thresholdLabel":"","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"percentunit","thresholdValue":10},{"index":"d74bf17b-552a-4636-8fad-c976b090d590","isEditEnabled":false,"keyIndex":0,"selectedGraph":"value","thresholdColor":"Orange","thresholdFormat":"Text","thresholdLabel":"","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"percentunit","thresholdValue":5}],"timePreferance":"GLOBAL_TIME","title":"Error Rate","yAxisUnit":"percentunit"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"3633c7ad-203a-4e25-99f4-8cc81bf15d65","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name gen_ai.request.model EXISTS"},"functions":[],"groupBy":[{"dataType":"string","id":"gen_ai.request.model--string--tag","isColumn":false,"isJSON":false,"key":"gen_ai.request.model","type":"tag"}],"having":{"expression":""},"legend":"{{gen_ai.request.model}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"4abdd467-cee6-4a5c-8044-82c6052b73ee","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Model Distribution","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"af79b14b-5e76-47fb-a24e-a4629c642c28","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"p95(duration_nano) "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name gen_ai.agent.name in $agent_name gen_ai.operation.name = 'invoke_agent'  "},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"1e3cbc04-7096-421a-b4ff-c4846fa53ffa","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Latency (P95)","yAxisUnit":"ns"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"A":"#edce64","count()":"#a403ff"},"description":"","fillSpans":false,"id":"74a94376-eeaf-43c1-a273-5d8b98197138","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name gen_ai.agent.name in $agent_name gen_ai.operation.name = 'invoke_agent'"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"4b4d8745-f50c-496c-8e11-d9bcad1816c3","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Number of Requests","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"date":145,"duration_nano":145,"http_method":145,"name":145,"response_status_code":145,"service.name":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"5e66cb8c-2219-47e6-ba71-8f82f9873bc8","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"has_error = true service.name IN $service_name"},"filters":{"items":[{"id":"9b683b3e-f6ea-4e35-b55c-c548e5fe0feb","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"03ef1925-e21e-4984-9fa0-6a8be914cf17","key":{"id":"has_error","key":"has_error","type":""},"op":"=","value":"true"}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"}],"pageSize":10,"queryName":"A","selectColumns":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"b85f93b2-09b5-4fcd-8aa8-f6a2875a41b5","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Errors","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"A":"#5eddce"},"description":"","fillSpans":false,"id":"bc6e3017-2b44-4152-a0d7-fe11e6b7a290","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"metricName":"http.client.duration.max","reduceTo":"avg","spaceAggregation":"avg","temporality":"","timeAggregation":"avg"}],"dataSource":"metrics","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name"},"filters":{"items":[{"id":"9b683b3e-f6ea-4e35-b55c-c548e5fe0feb","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"5a8ddb76-cef4-4ea4-9185-1b8331ef3b5b","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"HTTP Request Duration","yAxisUnit":"ms"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"body":350,"timestamp":100},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"05e6759b-c460-4618-86c0-5d2bf0b311c1","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"logs","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"},{"columnName":"id","order":"desc"}],"pageSize":10,"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"d0c96eea-6c4d-4c46-92a1-9a9e2b1af925","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Logs","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A.avg(duration_nano)":"ns","A.count()":""},"columnWidths":{"A.avg(duration_nano)":145,"A.count()":145,"gen_ai.agent.name":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"1439219a-7067-4f3b-9308-1c405844cdab","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() as 'Requests' avg(duration_nano) as 'Latency'"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name gen_ai.agent.name EXISTS gen_ai.operation.name = 'invoke_agent'"},"functions":[],"groupBy":[{"dataType":"string","id":"gen_ai.agent.name--string--tag","isColumn":false,"isJSON":false,"key":"gen_ai.agent.name","type":"tag"}],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"89fe6f81-01a1-4995-a398-5750847a338e","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Agents","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A.avg(duration_nano)":"ns","A.count()":""},"columnWidths":{"A.avg(duration_nano)":145,"A.count()":145,"gen_ai.tool.name":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"68d3a601-afac-4c63-b212-61667e0f9d70","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() as 'Requests' avg(duration_nano) as 'Latency'"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name gen_ai.tool.name EXISTS gen_ai.operation.name = 'execute_tool'"},"functions":[],"groupBy":[{"dataType":"string","id":"gen_ai.tool.name--string--tag","isColumn":false,"isJSON":false,"key":"gen_ai.tool.name","type":"tag"}],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"bfc4e2a3-206d-46e7-abff-bafc85a53209","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Tools","yAxisUnit":"none"}]}
+{
+  "spec": {
+    "display": {
+      "name": "Autogen",
+      "description": ""
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "service_name",
+            "description": "The service name using Autogen"
+          },
+          "defaultValue": [
+            "autogen-weather-app",
+            "autogen-research-crew",
+            "autogen-support-bot"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "service.name",
+              "signal": "all"
+            }
+          },
+          "name": "service_name"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "agent_name",
+            "description": "Name of agent being used in Autogen"
+          },
+          "defaultValue": [
+            "weather_agent",
+            "forecast_planner",
+            "research_agent",
+            "critic_agent",
+            "writer_agent",
+            "triage_agent",
+            "resolver_agent"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "gen_ai.agent.name",
+              "signal": "all"
+            }
+          },
+          "name": "agent_name"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "llm_model",
+            "description": "Model name being used in Autogen call"
+          },
+          "defaultValue": [
+            "gpt-5",
+            "gpt-5-mini",
+            "gpt-4.1",
+            "gpt-4.1-mini"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "gen_ai.request.model",
+              "signal": "all"
+            }
+          },
+          "name": "llm_model"
+        }
+      }
+    ],
+    "panels": {
+      "05e6759b-c460-4618-86c0-5d2bf0b311c1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Logs",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "timestamp",
+                  "signal": "logs",
+                  "fieldContext": "log",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "body",
+                  "signal": "logs",
+                  "fieldContext": "log",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "logs",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "1439219a-7067-4f3b-9308-1c405844cdab": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Agents",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A.avg(duration_nano)": "ns",
+                  "A.count()": ""
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()",
+                        "alias": "Requests"
+                      },
+                      {
+                        "expression": "avg(duration_nano)",
+                        "alias": "Latency"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name gen_ai.agent.name EXISTS gen_ai.operation.name = 'invoke_agent'"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "gen_ai.agent.name",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "3633c7ad-203a-4e25-99f4-8cc81bf15d65": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Model Distribution",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "gpt-4.1": "#E8B030",
+                  "gpt-4.1-mini": "#5DE5E2",
+                  "gpt-5": "#5DE56B",
+                  "gpt-5-mini": "#AF8BE4"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name gen_ai.request.model EXISTS"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "gen_ai.request.model",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{gen_ai.request.model}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "5e66cb8c-2219-47e6-ba71-8f82f9873bc8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Errors",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "service.name",
+                  "signal": "traces",
+                  "fieldContext": "resource",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "name",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "duration_nano",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "http_method",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "response_status_code",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "has_error = true service.name IN $service_name"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "name",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "duration_nano",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "http_method",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "response_status_code",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      }
+                    ],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "68d3a601-afac-4c63-b212-61667e0f9d70": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Tools",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A.avg(duration_nano)": "ns",
+                  "A.count()": ""
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()",
+                        "alias": "Requests"
+                      },
+                      {
+                        "expression": "avg(duration_nano)",
+                        "alias": "Latency"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name gen_ai.tool.name EXISTS gen_ai.operation.name = 'execute_tool'"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "gen_ai.tool.name",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "74a94376-eeaf-43c1-a273-5d8b98197138": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Number of Requests",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "autogen-research-crew": "#8BB5E4",
+                  "autogen-support-bot": "#E83052",
+                  "autogen-weather-app": "#C5E55D"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name gen_ai.agent.name in $agent_name gen_ai.operation.name = 'invoke_agent'"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "799913e6-fb95-497e-858a-6490b5f9d10d": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Error Rate",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "percentunit",
+                "decimalPrecision": "2"
+              },
+              "thresholds": [
+                {
+                  "value": 0.1,
+                  "operator": "above",
+                  "unit": "percentunit",
+                  "color": "Red",
+                  "format": "text"
+                },
+                {
+                  "value": 0.05,
+                  "operator": "above",
+                  "unit": "percentunit",
+                  "color": "Orange",
+                  "format": "text"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "has_error = 'true' service.name in $service_name gen_ai.agent.name in $agent_name"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "has_error = 'false' service.name in $service_name gen_ai.agent.name in $agent_name"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "A / (A+B)",
+                          "disabled": false,
+                          "order": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "functions": null,
+                          "legend": ""
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "af79b14b-5e76-47fb-a24e-a4629c642c28": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Latency (P95)",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ns",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "autogen-research-crew": "#8BB5E4",
+                  "autogen-support-bot": "#E83052",
+                  "autogen-weather-app": "#C5E55D"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "p95(duration_nano)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name gen_ai.agent.name in $agent_name gen_ai.operation.name = 'invoke_agent'  "
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "bc6e3017-2b44-4152-a0d7-fe11e6b7a290": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "HTTP Request Duration",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ms",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "autogen-research-crew": "#8BB5E4",
+                  "autogen-support-bot": "#E83052",
+                  "autogen-weather-app": "#C5E55D"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "metrics",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "metricName": "http.client.duration.max",
+                        "temporality": "",
+                        "timeAggregation": "avg",
+                        "spaceAggregation": "avg",
+                        "reduceTo": "avg"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 3,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/3633c7ad-203a-4e25-99f4-8cc81bf15d65"
+              }
+            },
+            {
+              "x": 3,
+              "y": 0,
+              "width": 5,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/af79b14b-5e76-47fb-a24e-a4629c642c28"
+              }
+            },
+            {
+              "x": 3,
+              "y": 4,
+              "width": 5,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/74a94376-eeaf-43c1-a273-5d8b98197138"
+              }
+            },
+            {
+              "x": 8,
+              "y": 0,
+              "width": 4,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/799913e6-fb95-497e-858a-6490b5f9d10d"
+              }
+            },
+            {
+              "x": 8,
+              "y": 4,
+              "width": 4,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/1439219a-7067-4f3b-9308-1c405844cdab"
+              }
+            },
+            {
+              "x": 0,
+              "y": 8,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/bc6e3017-2b44-4152-a0d7-fe11e6b7a290"
+              }
+            },
+            {
+              "x": 6,
+              "y": 8,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/68d3a601-afac-4c63-b212-61667e0f9d70"
+              }
+            },
+            {
+              "x": 0,
+              "y": 14,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/5e66cb8c-2219-47e6-ba71-8f82f9873bc8"
+              }
+            },
+            {
+              "x": 6,
+              "y": 14,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/05e6759b-c460-4618-86c0-5d2bf0b311c1"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "",
+    "refreshInterval": "",
+    "links": []
+  },
+  "tags": [],
+  "image": "/assets/Icons/eight-ball"
+}

--- a/azure-openai/azure-openai-dashboard.json
+++ b/azure-openai/azure-openai-dashboard.json
@@ -1,1 +1,1146 @@
-{"description":"","image":"data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE0Ljk0OTQgMTMuOTQyQzE2LjIzMTggMTIuNDI1OCAxNy4zMjY4IDkuNzAyMiAxNi4xOTU2IDYuNTc0ODdDMTUuNjQ0MyA1LjA1MjQ1IDE1LjAyMTkgNC4yMDI0OSAxNC4yOTY5IDMuNjYyNTJDMTMuODU1NyAzLjMzMzc5IDEyLjA5MzMgMi41MDYzMyA5Ljc1OTY1IDIuODY3NTZDOC4wNTM0OSAzLjEzMjU1IDUuNzc0ODcgNC4yMDg3NCA0LjI5MzY5IDUuOTU5OUMyLjg1NzUyIDcuNjYxMDYgMS43NDg4MyA5LjAwNDc0IDEuNjk3NTggMTAuMzA5N0MxLjYzMTMzIDExLjk4ODMgMi44OTYyNyAxMy40MzA4IDMuMDUwMDEgMTMuNjY0NUMzLjMyMzc0IDE0LjA3OTUgNS4xOTExNSAxNi40NTE4IDguNjk5NzEgMTYuNTczMUMxMS43OTcgMTYuNjc5MyAxMy44MTQ0IDE1LjI4NDQgMTQuOTQ5NCAxMy45NDJaIiBmaWxsPSIjNDAzRDNFIi8+CjxwYXRoIGQ9Ik00LjU1MzYzIDIuNzM3NDdDMi45Mzc0NiAzLjg5MTE2IDEuMTIxMzEgNi4yNTEwMyAxLjQ0NzU0IDkuNTYwODZDMS42MDYyOCAxMS4xNzIgMi4wMDI1MSAxMi4xNDk1IDIuNTcxMjMgMTIuODUwN0MyLjkxNzQ2IDEzLjI3ODIgNC40MTk4OCAxNC41NDkzIDYuNzczNTEgMTQuNzM2OEM5LjE0NTg4IDE0LjkyNTYgMTAuOTQ5NSAxNC4zOTQ0IDEyLjgzMzIgMTMuMDg0NEMxNi42NjE3IDEwLjQyMDggMTYuMDk4IDYuMzkzNTMgMTUuOTM0MyA1LjkyNDhDMTUuNzcwNSA1LjQ1NjA3IDE0LjU0NDQgMi42OTYyMiAxMS4xNzMzIDEuNzE1MDJDOC4xOTg0NCAwLjg1MDA2OCA1Ljk4MzU1IDEuNzE1MDIgNC41NTM2MyAyLjczNzQ3WiIgZmlsbD0iIzVFNjM2NyIvPgo8cGF0aCBkPSJNNy4zOTM1MyAyLjk2MTA5QzUuNjE3MzcgMi44OTczNCAzLjkxOTk2IDQuMjg4NTIgMy43NTYyMiA2LjAwNTkzQzMuNTkyNDggNy43MjIwOSA0LjY1NDkyIDkuMDI5NTIgNi4zMDk4MyA5LjI5NTc2QzcuOTY0NzUgOS41NjA3NCA5Ljg3ODM5IDguNTU1OCAxMC4yNjM0IDYuNDUwOTFDMTAuNjYwOSA0LjI4MjI3IDkuMDg5NjkgMy4wMjIzNCA3LjM5MzUzIDIuOTYxMDlaIiBmaWxsPSJ3aGl0ZSIvPgo8cGF0aCBkPSJNNy45NDIxNyA1LjkwMTE1QzcuOTQyMTcgNS45MDExNSA4LjM2OTY1IDUuODEyNCA4LjQ1NDY1IDUuMTgyNDRDOC41MzgzOSA0LjU2MjQ3IDguMjMwOTEgNC4wMzM3NSA3LjUxMzQ1IDMuODQzNzZDNi43MzM0OSAzLjYzNzUyIDYuMjA0NzcgNC4wNjYyNSA2LjA2NzI3IDQuNTE3NDdDNS44NzYwMyA1LjE0NDk0IDYuMTU4NTIgNS40NDM2NyA2LjE1ODUyIDUuNDQzNjdDNi4xNTg1MiA1LjQ0MzY3IDUuMzkzNTYgNS42Mjc0MSA1LjMzMjMxIDYuNTI5ODdDNS4yNzQ4MSA3LjM4MTA3IDUuODU2MDMgNy44Mzg1NSA2LjQzOTc1IDcuOTc4NTRDNy4xNjA5NiA4LjE1MjI4IDcuOTc4NDIgNy45NTQ3OSA4LjE3ODQxIDcuMDM0ODRDOC4zNDQ2NSA2LjI3NzM4IDcuOTQyMTcgNS45MDExNSA3Ljk0MjE3IDUuOTAxMTVaIiBmaWxsPSIjMzAzMDMwIi8+CjxwYXRoIGQ9Ik02LjczOTgzIDQuNzUzNjJDNi42NzEwOSA1LjAxMjM1IDYuODA4NTggNS4yNjIzNCA3LjA3ODU3IDUuMzMxMDlDNy4zNjk4IDUuNDA0ODMgNy42MzQ3OSA1LjMwODU5IDcuNzA2MDMgNS4wMTExQzcuNzY4NTMgNC43NDczNyA3LjY0MzU0IDQuNTE0ODggNy4zMzYwNSA0LjQzOTg4QzcuMDgzNTcgNC4zNzczOSA2LjgxNDgzIDQuNDcxMTMgNi43Mzk4MyA0Ljc1MzYyWiIgZmlsbD0id2hpdGUiLz4KPHBhdGggZD0iTTYuOTU5NzggNi4wMzk3NEM2LjYzMjMgNS45Mzg0OSA2LjE5OTgyIDYuMDY0NzMgNi4xMzEwNyA2LjUwNDcxQzYuMDYyMzMgNi45NDQ2OSA2LjMyNjA2IDcuMTY5NjggNi42NzEwNCA3LjIzMjE3QzcuMDE2MDMgNy4yOTQ2NyA3LjM0MjI2IDcuMTEzNDMgNy40MDYwMSA2Ljc2MDk1QzcuNDY4NSA2LjQwOTcyIDcuMjg2MDEgNi4xMzk3MyA2Ljk1OTc4IDYuMDM5NzRaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K","layout":[{"h":3,"i":"04247ee1-b408-457d-ac00-47ce45e64291","moved":false,"static":false,"w":3,"x":0,"y":0},{"h":3,"i":"d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570","moved":false,"static":false,"w":3,"x":3,"y":0},{"h":3,"i":"799913e6-fb95-497e-858a-6490b5f9d10d","moved":false,"static":false,"w":3,"x":6,"y":0},{"h":5,"i":"3633c7ad-203a-4e25-99f4-8cc81bf15d65","moved":false,"static":false,"w":3,"x":9,"y":0},{"h":5,"i":"28bb5d45-046d-4980-ad5e-26b1aeecda2b","moved":false,"static":false,"w":4,"x":0,"y":3},{"h":5,"i":"af79b14b-5e76-47fb-a24e-a4629c642c28","moved":false,"static":false,"w":4,"x":4,"y":3},{"h":5,"i":"74a94376-eeaf-43c1-a273-5d8b98197138","moved":false,"static":false,"w":5,"x":0,"y":8},{"h":3,"i":"67a074ee-c46e-4a36-8f5c-10d981cae404","moved":false,"static":false,"w":6,"x":5,"y":8},{"h":6,"i":"5e66cb8c-2219-47e6-ba71-8f82f9873bc8","moved":false,"static":false,"w":7,"x":5,"y":11},{"h":4,"i":"bc6e3017-2b44-4152-a0d7-fe11e6b7a290","moved":false,"static":false,"w":5,"x":0,"y":13},{"h":5,"i":"05e6759b-c460-4618-86c0-5d2bf0b311c1","moved":false,"static":false,"w":6,"x":0,"y":17},{"h":1,"i":"__dropping-elem__","isDraggable":true,"moved":false,"static":false,"w":1,"x":10,"y":17}],"panelMap":{},"tags":[],"title":"Azure OpenAI API","uploadedGrafana":false,"uuid":"0199a0e7-8d65-7090-90dd-5c63e43fbd24","variables":{"10d0eca9-9253-4583-821c-d3c812d78151":{"allSelected":false,"customValue":"","defaultValue":"","description":"The service name using Anthropic API","dynamicVariablesAttribute":"service.name","dynamicVariablesSource":"All telemetry","haveCustomValuesSelected":false,"id":"10d0eca9-9253-4583-821c-d3c812d78151","modificationUUID":"735355f5-c4c7-4969-ad30-eee98eeb36b8","multiSelect":true,"name":"service_name","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"93c33118-5f46-404b-b45e-8a81160c44c4":{"allSelected":true,"customValue":"","defaultValue":"","description":"Language being used for making Anthropic API calls","dynamicVariablesAttribute":"telemetry.sdk.language","dynamicVariablesSource":"All telemetry","id":"93c33118-5f46-404b-b45e-8a81160c44c4","key":"93c33118-5f46-404b-b45e-8a81160c44c4","modificationUUID":"6e679b86-edab-4f06-a5e9-532f69db0f27","multiSelect":true,"name":"language","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"be7a68c4-fb97-43ea-bb94-0ded120bd3d7":{"allSelected":false,"customValue":"","defaultValue":"","description":"Model name being used in Anthropic API call","dynamicVariablesAttribute":"llm.model_name","dynamicVariablesSource":"All telemetry","haveCustomValuesSelected":false,"id":"be7a68c4-fb97-43ea-bb94-0ded120bd3d7","key":"be7a68c4-fb97-43ea-bb94-0ded120bd3d7","modificationUUID":"2ed153af-318b-423e-ac85-9a49aa40b838","multiSelect":true,"name":"llm_model","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"}},"version":"v5","widgets":[{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"04247ee1-b408-457d-ac00-47ce45e64291","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(llm.token_count.prompt) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language llm.model_name in $llm_model"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"c34281f1-117e-4432-acd3-4b2103d20af4","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Input Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(llm.token_count.completion) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language llm.model_name in $llm_model"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"c4ea91b9-3b39-4338-ae67-925fcd5003bd","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Output Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"799913e6-fb95-497e-858a-6490b5f9d10d","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"A","filter":{"expression":"has_error = 'true' service.name in $service_name "},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null},{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"B","filter":{"expression":"has_error = 'false' service.name in $service_name "},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"B","source":"","stepInterval":null}],"queryFormulas":[{"disabled":false,"expression":"A / (A+B)","legend":"","queryName":"F1"}],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"06db8fa1-2559-4a1e-ae05-19f94089cb58","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[{"index":"e5e05d41-7479-4d60-a1cf-c433b8b61285","isEditEnabled":false,"keyIndex":1,"selectedGraph":"value","thresholdColor":"Red","thresholdFormat":"Text","thresholdLabel":"","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"percentunit","thresholdValue":10},{"index":"d74bf17b-552a-4636-8fad-c976b090d590","isEditEnabled":false,"keyIndex":0,"selectedGraph":"value","thresholdColor":"Orange","thresholdFormat":"Text","thresholdLabel":"","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"percentunit","thresholdValue":5}],"timePreferance":"GLOBAL_TIME","title":"Error Rate","yAxisUnit":"percentunit"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"3633c7ad-203a-4e25-99f4-8cc81bf15d65","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"llm.model_name EXISTS service.name in $service_name AND llm.model_name EXISTS"},"functions":[],"groupBy":[{"dataType":"string","id":"llm.model_name--string--tag","isColumn":false,"isJSON":false,"key":"llm.model_name","type":"tag"}],"having":{"expression":""},"legend":"{{llm.model_name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"798200a4-59fd-4d9a-b91f-806e51c3fd1f","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Model Distribution","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"F1":"#eccd03"},"description":"","fillSpans":false,"id":"28bb5d45-046d-4980-ad5e-26b1aeecda2b","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(llm.token_count.prompt) ) )"}],"dataSource":"traces","disabled":true,"expression":"A","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language llm.model_name in $llm_model"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null},{"aggregations":[{"expression":"sum(llm.token_count.completion)"}],"dataSource":"traces","disabled":true,"expression":"B","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language llm.model_name in $llm_model"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"B","source":"","stepInterval":null}],"queryFormulas":[{"disabled":false,"expression":"A + B","legend":"","queryName":"F1"}],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"c9e0c359-c74c-4622-a025-4e11c501cac7","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Token Usage","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"af79b14b-5e76-47fb-a24e-a4629c642c28","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"p95(duration_nano) "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language llm.model_name in $llm_model"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"3c8ad778-697a-4460-a6c0-ed72dc21c482","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Latency (P95)","yAxisUnit":"ns"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"A":"#edce64","count()":"#a403ff"},"description":"","fillSpans":false,"id":"74a94376-eeaf-43c1-a273-5d8b98197138","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language llm.model_name in $llm_model"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"ae136259-a23e-4f98-a4cc-0ceb49e04ce1","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Number of Requests","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"date":145,"duration_nano":145,"http_method":145,"name":145,"response_status_code":145,"service.name":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"5e66cb8c-2219-47e6-ba71-8f82f9873bc8","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"has_error = true service.name IN $service_name"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"}],"pageSize":10,"queryName":"A","selectColumns":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"b85f93b2-09b5-4fcd-8aa8-f6a2875a41b5","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Errors","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A":""},"columnWidths":{"A":145,"service.name":145,"telemetry.sdk.language":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"67a074ee-c46e-4a36-8f5c-10d981cae404","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() as 'Count of Spans' "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = $service_name  AND telemetry.sdk.language EXISTS"},"functions":[],"groupBy":[{"dataType":"string","id":"service.name--string--resource","isColumn":true,"isJSON":false,"key":"service.name","type":"resource"},{"dataType":"string","id":"telemetry.sdk.language--string--resource","isColumn":false,"isJSON":false,"key":"telemetry.sdk.language","type":"resource"}],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"33cb8bea-966e-45cb-926f-6e722fef9ab7","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Services and Languages","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"A":"#5eddce"},"description":"","fillSpans":false,"id":"bc6e3017-2b44-4152-a0d7-fe11e6b7a290","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"metricName":"http.client.duration.max","reduceTo":"avg","spaceAggregation":"avg","temporality":"","timeAggregation":"avg"}],"dataSource":"metrics","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name "},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"3e688253-85e8-4cfc-814d-5ab821a950db","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"HTTP Request Duration","yAxisUnit":"ms"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"body":350,"timestamp":100},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"05e6759b-c460-4618-86c0-5d2bf0b311c1","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"logs","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name telemetry.sdk.language in $language "},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"},{"columnName":"id","order":"desc"}],"pageSize":10,"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"cf4892fd-86f1-4e83-a876-db114e6e125f","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"API Requests","yAxisUnit":"none"}]}
+{
+  "spec": {
+    "display": {
+      "name": "Azure OpenAI API",
+      "description": ""
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "service_name",
+            "description": "The service name using Anthropic API"
+          },
+          "defaultValue": [
+            "azure-openai-otel"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "service.name",
+              "signal": "all"
+            }
+          },
+          "name": "service_name"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "language",
+            "description": "Language being used for making Anthropic API calls"
+          },
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "telemetry.sdk.language",
+              "signal": "all"
+            }
+          },
+          "name": "language"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "llm_model",
+            "description": "Model name being used in Anthropic API call"
+          },
+          "defaultValue": [
+            "gpt-4.1-2025-04-14",
+            "gpt-4.1",
+            "gpt-4.1-nano"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "llm.model_name",
+              "signal": "all"
+            }
+          },
+          "name": "llm_model"
+        }
+      }
+    ],
+    "panels": {
+      "04247ee1-b408-457d-ac00-47ce45e64291": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Input Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(llm.token_count.prompt)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name telemetry.sdk.language in $language llm.model_name in $llm_model"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "05e6759b-c460-4618-86c0-5d2bf0b311c1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "API Requests",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "timestamp",
+                  "signal": "logs",
+                  "fieldContext": "log",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "body",
+                  "signal": "logs",
+                  "fieldContext": "log",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "logs",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name telemetry.sdk.language in $language "
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "28bb5d45-046d-4980-ad5e-26b1aeecda2b": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Token Usage",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "F1": "#eccd03"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "sum(llm.token_count.prompt)"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "service.name in $service_name telemetry.sdk.language in $language llm.model_name in $llm_model"
+                          },
+                          "groupBy": [
+                            {
+                              "name": "service.name",
+                              "signal": "traces",
+                              "fieldContext": "resource",
+                              "fieldDataType": "string"
+                            }
+                          ],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "sum(llm.token_count.completion)"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "service.name in $service_name telemetry.sdk.language in $language llm.model_name in $llm_model"
+                          },
+                          "groupBy": [
+                            {
+                              "name": "service.name",
+                              "signal": "traces",
+                              "fieldContext": "resource",
+                              "fieldDataType": "string"
+                            }
+                          ],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "A + B",
+                          "disabled": false,
+                          "order": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "functions": null,
+                          "legend": "{{service.name}}"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "3633c7ad-203a-4e25-99f4-8cc81bf15d65": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Model Distribution",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": null
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "llm.model_name EXISTS service.name in $service_name AND llm.model_name EXISTS"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "llm.model_name",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{llm.model_name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "5e66cb8c-2219-47e6-ba71-8f82f9873bc8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Errors",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "service.name",
+                  "signal": "traces",
+                  "fieldContext": "resource",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "name",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "duration_nano",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "http_method",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "response_status_code",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "has_error = true service.name IN $service_name"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "name",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "duration_nano",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "http_method",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "response_status_code",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      }
+                    ],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "67a074ee-c46e-4a36-8f5c-10d981cae404": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Services and Languages",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A": ""
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()",
+                              "alias": "Count of Spans"
+                            }
+                          ],
+                          "disabled": false,
+                          "filter": {
+                            "expression": "service.name = $service_name  AND telemetry.sdk.language EXISTS"
+                          },
+                          "groupBy": [
+                            {
+                              "name": "service.name",
+                              "signal": "",
+                              "fieldContext": "resource",
+                              "fieldDataType": "string"
+                            },
+                            {
+                              "name": "telemetry.sdk.language",
+                              "signal": "",
+                              "fieldContext": "resource",
+                              "fieldDataType": "string"
+                            }
+                          ],
+                          "order": null,
+                          "selectFields": null,
+                          "secondaryAggregations": null,
+                          "functions": null,
+                          "legend": ""
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "74a94376-eeaf-43c1-a273-5d8b98197138": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Number of Requests",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "A": "#edce64",
+                  "count()": "#a403ff"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name telemetry.sdk.language in $language llm.model_name in $llm_model"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "traces",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "799913e6-fb95-497e-858a-6490b5f9d10d": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Error Rate",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "percentunit",
+                "decimalPrecision": "2"
+              },
+              "thresholds": [
+                {
+                  "value": 10,
+                  "operator": "above",
+                  "unit": "percentunit",
+                  "color": "Red",
+                  "format": "text"
+                },
+                {
+                  "value": 5,
+                  "operator": "above",
+                  "unit": "percentunit",
+                  "color": "Orange",
+                  "format": "text"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "has_error = 'true' service.name in $service_name "
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "has_error = 'false' service.name in $service_name "
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "A / (A+B)",
+                          "disabled": false,
+                          "order": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "functions": null,
+                          "legend": ""
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "af79b14b-5e76-47fb-a24e-a4629c642c28": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Latency (P95)",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ns",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": null
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "p95(duration_nano)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name telemetry.sdk.language in $language llm.model_name in $llm_model"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "traces",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "bc6e3017-2b44-4152-a0d7-fe11e6b7a290": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "HTTP Request Duration",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ms",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "A": "#5eddce"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "metrics",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "metricName": "http.client.duration.max",
+                        "temporality": "",
+                        "timeAggregation": "avg",
+                        "spaceAggregation": "avg",
+                        "reduceTo": "avg"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name "
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "metrics",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Output Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(llm.token_count.completion)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name telemetry.sdk.language in $language llm.model_name in $llm_model"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/04247ee1-b408-457d-ac00-47ce45e64291"
+              }
+            },
+            {
+              "x": 4,
+              "y": 0,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570"
+              }
+            },
+            {
+              "x": 8,
+              "y": 0,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/799913e6-fb95-497e-858a-6490b5f9d10d"
+              }
+            },
+            {
+              "x": 0,
+              "y": 3,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/28bb5d45-046d-4980-ad5e-26b1aeecda2b"
+              }
+            },
+            {
+              "x": 6,
+              "y": 3,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/74a94376-eeaf-43c1-a273-5d8b98197138"
+              }
+            },
+            {
+              "x": 0,
+              "y": 9,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/af79b14b-5e76-47fb-a24e-a4629c642c28"
+              }
+            },
+            {
+              "x": 6,
+              "y": 9,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/bc6e3017-2b44-4152-a0d7-fe11e6b7a290"
+              }
+            },
+            {
+              "x": 0,
+              "y": 15,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/3633c7ad-203a-4e25-99f4-8cc81bf15d65"
+              }
+            },
+            {
+              "x": 6,
+              "y": 15,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/67a074ee-c46e-4a36-8f5c-10d981cae404"
+              }
+            },
+            {
+              "x": 0,
+              "y": 21,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/5e66cb8c-2219-47e6-ba71-8f82f9873bc8"
+              }
+            },
+            {
+              "x": 0,
+              "y": 27,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/05e6759b-c460-4618-86c0-5d2bf0b311c1"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "",
+    "refreshInterval": "",
+    "links": []
+  },
+  "tags": [],
+  "image": "/assets/Icons/eight-ball"
+}

--- a/bedrock/bedrock-dashboard.json
+++ b/bedrock/bedrock-dashboard.json
@@ -1,1 +1,1060 @@
-{"description":"","image":"data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE0Ljk0OTQgMTMuOTQyQzE2LjIzMTggMTIuNDI1OCAxNy4zMjY4IDkuNzAyMiAxNi4xOTU2IDYuNTc0ODdDMTUuNjQ0MyA1LjA1MjQ1IDE1LjAyMTkgNC4yMDI0OSAxNC4yOTY5IDMuNjYyNTJDMTMuODU1NyAzLjMzMzc5IDEyLjA5MzMgMi41MDYzMyA5Ljc1OTY1IDIuODY3NTZDOC4wNTM0OSAzLjEzMjU1IDUuNzc0ODcgNC4yMDg3NCA0LjI5MzY5IDUuOTU5OUMyLjg1NzUyIDcuNjYxMDYgMS43NDg4MyA5LjAwNDc0IDEuNjk3NTggMTAuMzA5N0MxLjYzMTMzIDExLjk4ODMgMi44OTYyNyAxMy40MzA4IDMuMDUwMDEgMTMuNjY0NUMzLjMyMzc0IDE0LjA3OTUgNS4xOTExNSAxNi40NTE4IDguNjk5NzEgMTYuNTczMUMxMS43OTcgMTYuNjc5MyAxMy44MTQ0IDE1LjI4NDQgMTQuOTQ5NCAxMy45NDJaIiBmaWxsPSIjNDAzRDNFIi8+CjxwYXRoIGQ9Ik00LjU1MzYzIDIuNzM3NDdDMi45Mzc0NiAzLjg5MTE2IDEuMTIxMzEgNi4yNTEwMyAxLjQ0NzU0IDkuNTYwODZDMS42MDYyOCAxMS4xNzIgMi4wMDI1MSAxMi4xNDk1IDIuNTcxMjMgMTIuODUwN0MyLjkxNzQ2IDEzLjI3ODIgNC40MTk4OCAxNC41NDkzIDYuNzczNTEgMTQuNzM2OEM5LjE0NTg4IDE0LjkyNTYgMTAuOTQ5NSAxNC4zOTQ0IDEyLjgzMzIgMTMuMDg0NEMxNi42NjE3IDEwLjQyMDggMTYuMDk4IDYuMzkzNTMgMTUuOTM0MyA1LjkyNDhDMTUuNzcwNSA1LjQ1NjA3IDE0LjU0NDQgMi42OTYyMiAxMS4xNzMzIDEuNzE1MDJDOC4xOTg0NCAwLjg1MDA2OCA1Ljk4MzU1IDEuNzE1MDIgNC41NTM2MyAyLjczNzQ3WiIgZmlsbD0iIzVFNjM2NyIvPgo8cGF0aCBkPSJNNy4zOTM1MyAyLjk2MTA5QzUuNjE3MzcgMi44OTczNCAzLjkxOTk2IDQuMjg4NTIgMy43NTYyMiA2LjAwNTkzQzMuNTkyNDggNy43MjIwOSA0LjY1NDkyIDkuMDI5NTIgNi4zMDk4MyA5LjI5NTc2QzcuOTY0NzUgOS41NjA3NCA5Ljg3ODM5IDguNTU1OCAxMC4yNjM0IDYuNDUwOTFDMTAuNjYwOSA0LjI4MjI3IDkuMDg5NjkgMy4wMjIzNCA3LjM5MzUzIDIuOTYxMDlaIiBmaWxsPSJ3aGl0ZSIvPgo8cGF0aCBkPSJNNy45NDIxNyA1LjkwMTE1QzcuOTQyMTcgNS45MDExNSA4LjM2OTY1IDUuODEyNCA4LjQ1NDY1IDUuMTgyNDRDOC41MzgzOSA0LjU2MjQ3IDguMjMwOTEgNC4wMzM3NSA3LjUxMzQ1IDMuODQzNzZDNi43MzM0OSAzLjYzNzUyIDYuMjA0NzcgNC4wNjYyNSA2LjA2NzI3IDQuNTE3NDdDNS44NzYwMyA1LjE0NDk0IDYuMTU4NTIgNS40NDM2NyA2LjE1ODUyIDUuNDQzNjdDNi4xNTg1MiA1LjQ0MzY3IDUuMzkzNTYgNS42Mjc0MSA1LjMzMjMxIDYuNTI5ODdDNS4yNzQ4MSA3LjM4MTA3IDUuODU2MDMgNy44Mzg1NSA2LjQzOTc1IDcuOTc4NTRDNy4xNjA5NiA4LjE1MjI4IDcuOTc4NDIgNy45NTQ3OSA4LjE3ODQxIDcuMDM0ODRDOC4zNDQ2NSA2LjI3NzM4IDcuOTQyMTcgNS45MDExNSA3Ljk0MjE3IDUuOTAxMTVaIiBmaWxsPSIjMzAzMDMwIi8+CjxwYXRoIGQ9Ik02LjczOTgzIDQuNzUzNjJDNi42NzEwOSA1LjAxMjM1IDYuODA4NTggNS4yNjIzNCA3LjA3ODU3IDUuMzMxMDlDNy4zNjk4IDUuNDA0ODMgNy42MzQ3OSA1LjMwODU5IDcuNzA2MDMgNS4wMTExQzcuNzY4NTMgNC43NDczNyA3LjY0MzU0IDQuNTE0ODggNy4zMzYwNSA0LjQzOTg4QzcuMDgzNTcgNC4zNzczOSA2LjgxNDgzIDQuNDcxMTMgNi43Mzk4MyA0Ljc1MzYyWiIgZmlsbD0id2hpdGUiLz4KPHBhdGggZD0iTTYuOTU5NzggNi4wMzk3NEM2LjYzMjMgNS45Mzg0OSA2LjE5OTgyIDYuMDY0NzMgNi4xMzEwNyA2LjUwNDcxQzYuMDYyMzMgNi45NDQ2OSA2LjMyNjA2IDcuMTY5NjggNi42NzEwNCA3LjIzMjE3QzcuMDE2MDMgNy4yOTQ2NyA3LjM0MjI2IDcuMTEzNDMgNy40MDYwMSA2Ljc2MDk1QzcuNDY4NSA2LjQwOTcyIDcuMjg2MDEgNi4xMzk3MyA2Ljk1OTc4IDYuMDM5NzRaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K","layout":[{"h":3,"i":"04247ee1-b408-457d-ac00-47ce45e64291","moved":false,"static":false,"w":3,"x":0,"y":0},{"h":3,"i":"d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570","moved":false,"static":false,"w":3,"x":3,"y":0},{"h":3,"i":"799913e6-fb95-497e-858a-6490b5f9d10d","moved":false,"static":false,"w":3,"x":6,"y":0},{"h":7,"i":"3633c7ad-203a-4e25-99f4-8cc81bf15d65","moved":false,"static":false,"w":3,"x":9,"y":0},{"h":5,"i":"28bb5d45-046d-4980-ad5e-26b1aeecda2b","moved":false,"static":false,"w":4,"x":0,"y":3},{"h":1,"i":"__dropping-elem__","isDraggable":true,"moved":false,"static":false,"w":1,"x":5,"y":3},{"h":1,"i":"__dropping-elem__","isDraggable":true,"moved":false,"static":false,"w":1,"x":5,"y":3},{"h":1,"i":"__dropping-elem__","isDraggable":true,"moved":false,"static":false,"w":1,"x":5,"y":3},{"h":1,"i":"__dropping-elem__","isDraggable":true,"moved":false,"static":false,"w":1,"x":5,"y":3},{"h":5,"i":"af79b14b-5e76-47fb-a24e-a4629c642c28","moved":false,"static":false,"w":4,"x":4,"y":4},{"h":5,"i":"74a94376-eeaf-43c1-a273-5d8b98197138","moved":false,"static":false,"w":5,"x":0,"y":9},{"h":3,"i":"67a074ee-c46e-4a36-8f5c-10d981cae404","moved":false,"static":false,"w":6,"x":5,"y":9},{"h":6,"i":"5e66cb8c-2219-47e6-ba71-8f82f9873bc8","moved":false,"static":false,"w":7,"x":5,"y":12},{"h":5,"i":"05e6759b-c460-4618-86c0-5d2bf0b311c1","moved":false,"static":false,"w":5,"x":0,"y":14}],"panelMap":{},"tags":[],"title":"Amazon Bedrock","uploadedGrafana":false,"uuid":"0199de4c-39b9-7dba-973c-30472aef6a80","variables":{"10d0eca9-9253-4583-821c-d3c812d78151":{"allSelected":false,"customValue":"","defaultValue":"","description":"The service name using Anthropic API","dynamicVariablesAttribute":"service.name","dynamicVariablesSource":"All telemetry","haveCustomValuesSelected":false,"id":"10d0eca9-9253-4583-821c-d3c812d78151","modificationUUID":"735355f5-c4c7-4969-ad30-eee98eeb36b8","multiSelect":true,"name":"service_name","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"93c33118-5f46-404b-b45e-8a81160c44c4":{"allSelected":true,"customValue":"","defaultValue":"","description":"Language being used for making Anthropic API calls","dynamicVariablesAttribute":"telemetry.sdk.language","dynamicVariablesSource":"All telemetry","id":"93c33118-5f46-404b-b45e-8a81160c44c4","key":"93c33118-5f46-404b-b45e-8a81160c44c4","modificationUUID":"6e679b86-edab-4f06-a5e9-532f69db0f27","multiSelect":true,"name":"language","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"be7a68c4-fb97-43ea-bb94-0ded120bd3d7":{"allSelected":false,"customValue":"","defaultValue":"","description":"Model name being used in Anthropic API call","dynamicVariablesAttribute":"llm.model_name","dynamicVariablesSource":"All telemetry","haveCustomValuesSelected":false,"id":"be7a68c4-fb97-43ea-bb94-0ded120bd3d7","key":"be7a68c4-fb97-43ea-bb94-0ded120bd3d7","modificationUUID":"2ed153af-318b-423e-ac85-9a49aa40b838","multiSelect":true,"name":"llm_model","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"}},"version":"v5","widgets":[{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"04247ee1-b408-457d-ac00-47ce45e64291","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(llm.token_count.prompt) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language llm.model_name in $llm_model"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"c34281f1-117e-4432-acd3-4b2103d20af4","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Input Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(llm.token_count.completion) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language llm.model_name in $llm_model"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"c4ea91b9-3b39-4338-ae67-925fcd5003bd","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Output Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"799913e6-fb95-497e-858a-6490b5f9d10d","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"A","filter":{"expression":"has_error = 'true' service.name in $service_name "},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null},{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"B","filter":{"expression":"has_error = 'false' service.name in $service_name "},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"B","source":"","stepInterval":null}],"queryFormulas":[{"disabled":false,"expression":"A / (A+B)","legend":"","queryName":"F1"}],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"06db8fa1-2559-4a1e-ae05-19f94089cb58","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[{"index":"e5e05d41-7479-4d60-a1cf-c433b8b61285","isEditEnabled":false,"keyIndex":1,"selectedGraph":"value","thresholdColor":"Red","thresholdFormat":"Text","thresholdLabel":"","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"percentunit","thresholdValue":10},{"index":"d74bf17b-552a-4636-8fad-c976b090d590","isEditEnabled":false,"keyIndex":0,"selectedGraph":"value","thresholdColor":"Orange","thresholdFormat":"Text","thresholdLabel":"","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"percentunit","thresholdValue":5}],"timePreferance":"GLOBAL_TIME","title":"Error Rate","yAxisUnit":"percentunit"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"3633c7ad-203a-4e25-99f4-8cc81bf15d65","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"llm.model_name EXISTS service.name in $service_name AND llm.model_name EXISTS has_error = false"},"functions":[],"groupBy":[{"dataType":"string","id":"llm.model_name--string--tag","isColumn":false,"isJSON":false,"key":"llm.model_name","type":"tag"}],"having":{"expression":""},"legend":"{{llm.model_name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"475406e7-bffb-4a1e-88d4-e1e6e3a7e528","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Model Distribution","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"F1":"#eccd03"},"description":"","fillSpans":false,"id":"28bb5d45-046d-4980-ad5e-26b1aeecda2b","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(llm.token_count.prompt) ) )"}],"dataSource":"traces","disabled":true,"expression":"A","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language llm.model_name in $llm_model"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null},{"aggregations":[{"expression":"sum(llm.token_count.completion)"}],"dataSource":"traces","disabled":true,"expression":"B","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language llm.model_name in $llm_model"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"B","source":"","stepInterval":null}],"queryFormulas":[{"disabled":false,"expression":"A + B","legend":"","queryName":"F1"}],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"c9e0c359-c74c-4622-a025-4e11c501cac7","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Token Usage","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"af79b14b-5e76-47fb-a24e-a4629c642c28","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"p95(duration_nano) "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language llm.model_name in $llm_model"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"3c8ad778-697a-4460-a6c0-ed72dc21c482","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Latency (P95)","yAxisUnit":"ns"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"A":"#edce64","count()":"#a403ff"},"description":"","fillSpans":false,"id":"74a94376-eeaf-43c1-a273-5d8b98197138","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language llm.model_name in $llm_model"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"ae136259-a23e-4f98-a4cc-0ceb49e04ce1","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Number of Requests","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"date":145,"duration_nano":145,"http_method":145,"name":145,"response_status_code":145,"service.name":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"5e66cb8c-2219-47e6-ba71-8f82f9873bc8","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"has_error = true service.name IN $service_name"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"}],"pageSize":10,"queryName":"A","selectColumns":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"b85f93b2-09b5-4fcd-8aa8-f6a2875a41b5","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Errors","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A":""},"columnWidths":{"A":145,"service.name":145,"telemetry.sdk.language":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"67a074ee-c46e-4a36-8f5c-10d981cae404","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() as 'Count of Spans' "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = $service_name  AND telemetry.sdk.language EXISTS"},"functions":[],"groupBy":[{"dataType":"string","id":"service.name--string--resource","isColumn":true,"isJSON":false,"key":"service.name","type":"resource"},{"dataType":"string","id":"telemetry.sdk.language--string--resource","isColumn":false,"isJSON":false,"key":"telemetry.sdk.language","type":"resource"}],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"33cb8bea-966e-45cb-926f-6e722fef9ab7","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Services and Languages","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"body":350,"timestamp":100},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"05e6759b-c460-4618-86c0-5d2bf0b311c1","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"logs","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name telemetry.sdk.language in $language "},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"},{"columnName":"id","order":"desc"}],"pageSize":10,"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"cf4892fd-86f1-4e83-a876-db114e6e125f","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Logs","yAxisUnit":"none"}]}
+{
+  "spec": {
+    "display": {
+      "name": "Amazon Bedrock",
+      "description": ""
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "service_name",
+            "description": "The service name using Anthropic API"
+          },
+          "defaultValue": [
+            "bedrock-otel",
+            "claims-intake",
+            "doc-intelligence"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "service.name",
+              "signal": "all"
+            }
+          },
+          "name": "service_name"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "language",
+            "description": "Language being used for making Anthropic API calls"
+          },
+          "defaultValue": [
+            "python"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "telemetry.sdk.language",
+              "signal": "all"
+            }
+          },
+          "name": "language"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "llm_model",
+            "description": "Model name being used in Anthropic API call"
+          },
+          "defaultValue": [
+            "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            "amazon.nova-pro-v1:0",
+            "us.anthropic.claude-opus-4-1-20250805-v1:0",
+            "meta.llama3-3-70b-instruct-v1:0"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "llm.model_name",
+              "signal": "all"
+            }
+          },
+          "name": "llm_model"
+        }
+      }
+    ],
+    "panels": {
+      "04247ee1-b408-457d-ac00-47ce45e64291": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Input Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(llm.token_count.prompt)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name telemetry.sdk.language in $language llm.model_name in $llm_model"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "05e6759b-c460-4618-86c0-5d2bf0b311c1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Logs",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "timestamp",
+                  "signal": "logs",
+                  "fieldContext": "log",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "body",
+                  "signal": "logs",
+                  "fieldContext": "log",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "logs",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name telemetry.sdk.language in $language "
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "28bb5d45-046d-4980-ad5e-26b1aeecda2b": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Token Usage",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "bedrock-otel": "#E55DE5",
+                  "claims-intake": "#CAE48B",
+                  "doc-intelligence": "#307DE8"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "sum(llm.token_count.prompt)"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "service.name in $service_name telemetry.sdk.language in $language llm.model_name in $llm_model"
+                          },
+                          "groupBy": [
+                            {
+                              "name": "service.name",
+                              "signal": "traces",
+                              "fieldContext": "resource",
+                              "fieldDataType": "string"
+                            }
+                          ],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "sum(llm.token_count.completion)"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "service.name in $service_name telemetry.sdk.language in $language llm.model_name in $llm_model"
+                          },
+                          "groupBy": [
+                            {
+                              "name": "service.name",
+                              "signal": "traces",
+                              "fieldContext": "resource",
+                              "fieldDataType": "string"
+                            }
+                          ],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "A + B",
+                          "disabled": false,
+                          "order": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "functions": null,
+                          "legend": "{{service.name}}"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "3633c7ad-203a-4e25-99f4-8cc81bf15d65": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Model Distribution",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "amazon.nova-pro-v1:0": "#8BE49A",
+                  "meta.llama3-3-70b-instruct-v1:0": "#E5C35D",
+                  "us.anthropic.claude-opus-4-1-20250805-v1:0": "#8A3AE9",
+                  "us.anthropic.claude-sonnet-4-5-20250929-v1:0": "#E55D6E"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "llm.model_name EXISTS service.name in $service_name AND llm.model_name EXISTS has_error = false"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "llm.model_name",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{llm.model_name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "5e66cb8c-2219-47e6-ba71-8f82f9873bc8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Errors",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "service.name",
+                  "signal": "traces",
+                  "fieldContext": "resource",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "name",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "duration_nano",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "http_method",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "response_status_code",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "has_error = true service.name IN $service_name"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "name",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "duration_nano",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "http_method",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "response_status_code",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      }
+                    ],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "67a074ee-c46e-4a36-8f5c-10d981cae404": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Services and Languages",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A": ""
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()",
+                        "alias": "Count of Spans"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = $service_name  AND telemetry.sdk.language EXISTS"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "telemetry.sdk.language",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "74a94376-eeaf-43c1-a273-5d8b98197138": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Number of Requests",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "bedrock-otel": "#E55DE5",
+                  "claims-intake": "#CAE48B",
+                  "doc-intelligence": "#307DE8"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name telemetry.sdk.language in $language llm.model_name in $llm_model"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "traces",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "799913e6-fb95-497e-858a-6490b5f9d10d": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Error Rate",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "percentunit",
+                "decimalPrecision": "2"
+              },
+              "thresholds": [
+                {
+                  "value": 10,
+                  "operator": "above",
+                  "unit": "percentunit",
+                  "color": "Red",
+                  "format": "text"
+                },
+                {
+                  "value": 5,
+                  "operator": "above",
+                  "unit": "percentunit",
+                  "color": "Orange",
+                  "format": "text"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "has_error = 'true' service.name in $service_name "
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "has_error = 'false' service.name in $service_name "
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "A / (A+B)",
+                          "disabled": false,
+                          "order": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "functions": null,
+                          "legend": ""
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "af79b14b-5e76-47fb-a24e-a4629c642c28": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Latency (P95)",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ns",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "bedrock-otel": "#E55DE5",
+                  "claims-intake": "#CAE48B",
+                  "doc-intelligence": "#307DE8"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "p95(duration_nano)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name telemetry.sdk.language in $language llm.model_name in $llm_model"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "traces",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Output Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(llm.token_count.completion)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name telemetry.sdk.language in $language llm.model_name in $llm_model"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/04247ee1-b408-457d-ac00-47ce45e64291"
+              }
+            },
+            {
+              "x": 4,
+              "y": 0,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570"
+              }
+            },
+            {
+              "x": 8,
+              "y": 0,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/799913e6-fb95-497e-858a-6490b5f9d10d"
+              }
+            },
+            {
+              "x": 0,
+              "y": 3,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/28bb5d45-046d-4980-ad5e-26b1aeecda2b"
+              }
+            },
+            {
+              "x": 6,
+              "y": 3,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/74a94376-eeaf-43c1-a273-5d8b98197138"
+              }
+            },
+            {
+              "x": 0,
+              "y": 9,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/af79b14b-5e76-47fb-a24e-a4629c642c28"
+              }
+            },
+            {
+              "x": 6,
+              "y": 9,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/3633c7ad-203a-4e25-99f4-8cc81bf15d65"
+              }
+            },
+            {
+              "x": 0,
+              "y": 15,
+              "width": 12,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/67a074ee-c46e-4a36-8f5c-10d981cae404"
+              }
+            },
+            {
+              "x": 0,
+              "y": 20,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/5e66cb8c-2219-47e6-ba71-8f82f9873bc8"
+              }
+            },
+            {
+              "x": 0,
+              "y": 26,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/05e6759b-c460-4618-86c0-5d2bf0b311c1"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "",
+    "refreshInterval": "",
+    "links": []
+  },
+  "tags": [],
+  "image": "/assets/Icons/eight-ball"
+}

--- a/crewai/crewai-dashboard.json
+++ b/crewai/crewai-dashboard.json
@@ -1,1 +1,1113 @@
-{"description":"","image":"data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE0Ljk0OTQgMTMuOTQyQzE2LjIzMTggMTIuNDI1OCAxNy4zMjY4IDkuNzAyMiAxNi4xOTU2IDYuNTc0ODdDMTUuNjQ0MyA1LjA1MjQ1IDE1LjAyMTkgNC4yMDI0OSAxNC4yOTY5IDMuNjYyNTJDMTMuODU1NyAzLjMzMzc5IDEyLjA5MzMgMi41MDYzMyA5Ljc1OTY1IDIuODY3NTZDOC4wNTM0OSAzLjEzMjU1IDUuNzc0ODcgNC4yMDg3NCA0LjI5MzY5IDUuOTU5OUMyLjg1NzUyIDcuNjYxMDYgMS43NDg4MyA5LjAwNDc0IDEuNjk3NTggMTAuMzA5N0MxLjYzMTMzIDExLjk4ODMgMi44OTYyNyAxMy40MzA4IDMuMDUwMDEgMTMuNjY0NUMzLjMyMzc0IDE0LjA3OTUgNS4xOTExNSAxNi40NTE4IDguNjk5NzEgMTYuNTczMUMxMS43OTcgMTYuNjc5MyAxMy44MTQ0IDE1LjI4NDQgMTQuOTQ5NCAxMy45NDJaIiBmaWxsPSIjNDAzRDNFIi8+CjxwYXRoIGQ9Ik00LjU1MzYzIDIuNzM3NDdDMi45Mzc0NiAzLjg5MTE2IDEuMTIxMzEgNi4yNTEwMyAxLjQ0NzU0IDkuNTYwODZDMS42MDYyOCAxMS4xNzIgMi4wMDI1MSAxMi4xNDk1IDIuNTcxMjMgMTIuODUwN0MyLjkxNzQ2IDEzLjI3ODIgNC40MTk4OCAxNC41NDkzIDYuNzczNTEgMTQuNzM2OEM5LjE0NTg4IDE0LjkyNTYgMTAuOTQ5NSAxNC4zOTQ0IDEyLjgzMzIgMTMuMDg0NEMxNi42NjE3IDEwLjQyMDggMTYuMDk4IDYuMzkzNTMgMTUuOTM0MyA1LjkyNDhDMTUuNzcwNSA1LjQ1NjA3IDE0LjU0NDQgMi42OTYyMiAxMS4xNzMzIDEuNzE1MDJDOC4xOTg0NCAwLjg1MDA2OCA1Ljk4MzU1IDEuNzE1MDIgNC41NTM2MyAyLjczNzQ3WiIgZmlsbD0iIzVFNjM2NyIvPgo8cGF0aCBkPSJNNy4zOTM1MyAyLjk2MTA5QzUuNjE3MzcgMi44OTczNCAzLjkxOTk2IDQuMjg4NTIgMy43NTYyMiA2LjAwNTkzQzMuNTkyNDggNy43MjIwOSA0LjY1NDkyIDkuMDI5NTIgNi4zMDk4MyA5LjI5NTc2QzcuOTY0NzUgOS41NjA3NCA5Ljg3ODM5IDguNTU1OCAxMC4yNjM0IDYuNDUwOTFDMTAuNjYwOSA0LjI4MjI3IDkuMDg5NjkgMy4wMjIzNCA3LjM5MzUzIDIuOTYxMDlaIiBmaWxsPSJ3aGl0ZSIvPgo8cGF0aCBkPSJNNy45NDIxNyA1LjkwMTE1QzcuOTQyMTcgNS45MDExNSA4LjM2OTY1IDUuODEyNCA4LjQ1NDY1IDUuMTgyNDRDOC41MzgzOSA0LjU2MjQ3IDguMjMwOTEgNC4wMzM3NSA3LjUxMzQ1IDMuODQzNzZDNi43MzM0OSAzLjYzNzUyIDYuMjA0NzcgNC4wNjYyNSA2LjA2NzI3IDQuNTE3NDdDNS44NzYwMyA1LjE0NDk0IDYuMTU4NTIgNS40NDM2NyA2LjE1ODUyIDUuNDQzNjdDNi4xNTg1MiA1LjQ0MzY3IDUuMzkzNTYgNS42Mjc0MSA1LjMzMjMxIDYuNTI5ODdDNS4yNzQ4MSA3LjM4MTA3IDUuODU2MDMgNy44Mzg1NSA2LjQzOTc1IDcuOTc4NTRDNy4xNjA5NiA4LjE1MjI4IDcuOTc4NDIgNy45NTQ3OSA4LjE3ODQxIDcuMDM0ODRDOC4zNDQ2NSA2LjI3NzM4IDcuOTQyMTcgNS45MDExNSA3Ljk0MjE3IDUuOTAxMTVaIiBmaWxsPSIjMzAzMDMwIi8+CjxwYXRoIGQ9Ik02LjczOTgzIDQuNzUzNjJDNi42NzEwOSA1LjAxMjM1IDYuODA4NTggNS4yNjIzNCA3LjA3ODU3IDUuMzMxMDlDNy4zNjk4IDUuNDA0ODMgNy42MzQ3OSA1LjMwODU5IDcuNzA2MDMgNS4wMTExQzcuNzY4NTMgNC43NDczNyA3LjY0MzU0IDQuNTE0ODggNy4zMzYwNSA0LjQzOTg4QzcuMDgzNTcgNC4zNzczOSA2LjgxNDgzIDQuNDcxMTMgNi43Mzk4MyA0Ljc1MzYyWiIgZmlsbD0id2hpdGUiLz4KPHBhdGggZD0iTTYuOTU5NzggNi4wMzk3NEM2LjYzMjMgNS45Mzg0OSA2LjE5OTgyIDYuMDY0NzMgNi4xMzEwNyA2LjUwNDcxQzYuMDYyMzMgNi45NDQ2OSA2LjMyNjA2IDcuMTY5NjggNi42NzEwNCA3LjIzMjE3QzcuMDE2MDMgNy4yOTQ2NyA3LjM0MjI2IDcuMTEzNDMgNy40MDYwMSA2Ljc2MDk1QzcuNDY4NSA2LjQwOTcyIDcuMjg2MDEgNi4xMzk3MyA2Ljk1OTc4IDYuMDM5NzRaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K","layout":[{"h":2,"i":"c05a9158-b9d9-470e-9cf0-05e70be9fef1","moved":false,"static":false,"w":2,"x":0,"y":0},{"h":2,"i":"903e463c-7a59-4fef-b539-997464a044f8","moved":false,"static":false,"w":2,"x":2,"y":0},{"h":2,"i":"08761443-6932-4ca9-8851-be91b48f4399","moved":false,"static":false,"w":2,"x":4,"y":0},{"h":6,"i":"2971f98d-aaf3-4c47-812e-95da9f211c38","moved":false,"static":false,"w":6,"x":6,"y":0},{"h":6,"i":"6099d2e6-bcfb-44ba-bf40-f0fb401c46c7","moved":false,"static":false,"w":6,"x":0,"y":2},{"h":6,"i":"3c95cd99-9520-4718-8ea5-bcd1b62d6887","moved":false,"static":false,"w":6,"x":6,"y":6},{"h":6,"i":"b989aa24-8014-4b7b-9e6c-2e8f654ba30d","moved":false,"static":false,"w":6,"x":0,"y":8},{"h":5,"i":"37a57837-1351-481f-82d0-d55e3213a6a1","moved":false,"static":false,"w":6,"x":6,"y":12},{"h":3,"i":"63742ffd-8f8c-4c2e-b35f-8f7ffecaf1d8","moved":false,"static":false,"w":6,"x":0,"y":14},{"h":3,"i":"535f0c2f-9ee7-42b7-b688-76f0b3b1e088","moved":false,"static":false,"w":6,"x":0,"y":17},{"h":4,"i":"060a2aac-f239-417e-a50a-62c9fe72af13","moved":false,"static":false,"w":6,"x":6,"y":17},{"h":6,"i":"b9ebaed8-000d-4f77-aa2a-1d2e47c506a0","moved":false,"static":false,"w":6,"x":0,"y":20}],"panelMap":{},"tags":[],"title":"Crew AI","uploadedGrafana":false,"variables":{"2cb3a87e-900c-4f39-aa43-d85e8cf6f34f":{"allSelected":false,"customValue":"","defaultValue":"","description":"The tool name being called","dynamicVariablesAttribute":"tool.name","dynamicVariablesSource":"All telemetry","id":"2cb3a87e-900c-4f39-aa43-d85e8cf6f34f","modificationUUID":"3504baa7-dc7c-4fa7-a333-916c3f5d8c44","multiSelect":true,"name":"tool_name","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"52ecff8a-bd27-4dc5-b734-b1189983a2bd":{"allSelected":false,"customValue":"","defaultValue":"","description":"Service name","dynamicVariablesAttribute":"service.name","dynamicVariablesSource":"All telemetry","id":"52ecff8a-bd27-4dc5-b734-b1189983a2bd","key":"52ecff8a-bd27-4dc5-b734-b1189983a2bd","modificationUUID":"439ae5ed-dd66-4e53-a1bc-2381df1377cf","multiSelect":true,"name":"service_name","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"ef544b76-030b-46af-afbc-a83c3ea6e987":{"allSelected":false,"customValue":"","defaultValue":"","description":"Name of agent being used in crew","dynamicVariablesAttribute":"graph.node.id","dynamicVariablesSource":"All telemetry","id":"ef544b76-030b-46af-afbc-a83c3ea6e987","key":"ef544b76-030b-46af-afbc-a83c3ea6e987","modificationUUID":"c8c36847-14a4-431f-ac2d-6b31ca1b8ae7","multiSelect":true,"name":"agent_name","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"}},"version":"v5","widgets":[{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"date":145,"duration_nano":145,"name":145,"service.name":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"3c95cd99-9520-4718-8ea5-bcd1b62d6887","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = $service_name openinference.span.kind = 'AGENT' graph.node.id IN $agent_name "},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"}],"pageSize":10,"queryName":"A","selectColumns":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"3e5ab6df-f512-445b-8685-0fdc8512281e","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Agents","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"date":145,"duration_nano":145,"name":145,"service.name":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"37a57837-1351-481f-82d0-d55e3213a6a1","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = $service_name name = 'Task Execution' agent_role IN $agent_name"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"}],"pageSize":10,"queryName":"A","selectColumns":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"e042f161-4d03-406a-b284-dfbf474fc30f","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"},{"dataType":"string","name":"duration_ms","type":""}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Tasks","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A":""},"columnWidths":{"A":145,"agent_role":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"63742ffd-8f8c-4c2e-b35f-8f7ffecaf1d8","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() as Tasks"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = $service_name name = 'Task Execution'"},"filters":{"items":[],"op":"AND"},"functions":[],"groupBy":[{"dataType":"string","id":"agent_role--string--tag","isColumn":false,"isJSON":false,"key":"agent_role","type":"tag"}],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"f699e518-0e89-417a-9229-50c5a801c1fa","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Tasks Per Agents","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A":"ns"},"columnWidths":{"A":145,"graph.node.id":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"535f0c2f-9ee7-42b7-b688-76f0b3b1e088","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"avg(duration_nano) as avg_duration"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = $service_name openinference.span.kind = 'AGENT'"},"filters":{"items":[],"op":"AND"},"functions":[],"groupBy":[{"dataType":"string","id":"graph.node.id--string--tag","isColumn":false,"isJSON":false,"key":"graph.node.id","type":"tag"}],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"6904924e-48e2-4a35-bd16-4910bcf45f5c","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Avg Time Per Agent","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"6099d2e6-bcfb-44ba-bf40-f0fb401c46c7","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(llm.token_count.total) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = $service_name openinference.span.kind = 'LLM'"},"filters":{"items":[],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"f9e18cfe-ab28-4803-9f9f-7235187176ec","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Token Usage Over Time","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"2971f98d-aaf3-4c47-812e-95da9f211c38","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"p95(duration_nano) "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name graph.node.id IN $agent_name openinference.span.kind = 'AGENT' "},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"9ffc0fdb-c075-4867-8ebb-0d794bb46dde","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Duration Over Time of Agent","yAxisUnit":"ns"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"c05a9158-b9d9-470e-9cf0-05e70be9fef1","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(llm.token_count.prompt)"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name"},"filters":{"items":[],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"261cdb33-649a-425e-a6c1-6a265943b5ee","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Input Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"903e463c-7a59-4fef-b539-997464a044f8","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(llm.token_count.completion) ) "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name"},"filters":{"items":[],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"279ef5e3-9592-4637-9f17-f17e08fa2d90","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Output Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"08761443-6932-4ca9-8851-be91b48f4399","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"avg(duration_nano)"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = $service_name openinference.span.kind = 'CHAIN'"},"filters":{"items":[],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"6569108d-225b-4bf9-ae6e-043673747464","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Avg Duration of Crew","yAxisUnit":"ns"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A":"ns"},"columnWidths":{"A":145,"tool.name":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"060a2aac-f239-417e-a50a-62c9fe72af13","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"avg(duration_nano) as avg_duration"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name openinference.span.kind = 'TOOL' "},"functions":[],"groupBy":[{"dataType":"","id":"tool.name----","key":"tool.name","type":""}],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"102b444c-ebf1-42f7-a21d-6ceecbb096a0","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Avg Time Per Tool","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"b989aa24-8014-4b7b-9e6c-2e8f654ba30d","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"avg(duration_nano) ) "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = $service_name openinference.span.kind = 'TOOL' tool.name IN $tool_name "},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"f17a4d21-37b2-4174-aa71-636fa57af08b","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Duration Over Time of Tool","yAxisUnit":"ns"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"date":145,"duration_nano":145,"http_method":145,"name":145,"response_status_code":145,"service.name":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"b9ebaed8-000d-4f77-aa2a-1d2e47c506a0","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name openinference.span.kind = 'TOOL' tool.name IN $tool_name"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"}],"pageSize":10,"queryName":"A","selectColumns":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"5b1b4884-422d-4c31-afd1-2e94a3c24de5","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Tool Calls","yAxisUnit":"none"}],"uuid":"0199bac6-1efa-716d-a38a-4e8e52baf2f0"}
+{
+  "spec": {
+    "display": {
+      "name": "Crew AI",
+      "description": ""
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "tool_name",
+            "description": "The tool name being called"
+          },
+          "defaultValue": [
+            "Search the internet with Serper",
+            "Delegate work to coworker",
+            "Ask question to coworker"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "tool.name",
+              "signal": "all"
+            }
+          },
+          "name": "tool_name"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "service_name",
+            "description": "Service name"
+          },
+          "defaultValue": [
+            "crewai-otel"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "service.name",
+              "signal": "all"
+            }
+          },
+          "name": "service_name"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "agent_name",
+            "description": "Name of agent being used in crew"
+          },
+          "defaultValue": [
+            "Senior Research Analyst",
+            "Tech Content Strategist",
+            "Quality Assurance Reviewer"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "graph.node.id",
+              "signal": "all"
+            }
+          },
+          "name": "agent_name"
+        }
+      }
+    ],
+    "panels": {
+      "060a2aac-f239-417e-a50a-62c9fe72af13": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Avg Time Per Tool",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A": "ns"
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "avg(duration_nano)",
+                        "alias": "avg_duration"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name openinference.span.kind = 'TOOL' "
+                    },
+                    "groupBy": [
+                      {
+                        "name": "tool.name",
+                        "signal": "",
+                        "fieldContext": "",
+                        "fieldDataType": ""
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "08761443-6932-4ca9-8851-be91b48f4399": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Avg Duration of Crew",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "ns",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "avg(duration_nano)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = $service_name openinference.span.kind = 'CHAIN'"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "2971f98d-aaf3-4c47-812e-95da9f211c38": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Duration Over Time of Agent",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ns",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": null
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "p95(duration_nano)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name graph.node.id IN $agent_name openinference.span.kind = 'AGENT' "
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "37a57837-1351-481f-82d0-d55e3213a6a1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Tasks",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "service.name",
+                  "signal": "traces",
+                  "fieldContext": "resource",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "name",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "duration_nano",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = $service_name name = 'Task Execution' agent_role IN $agent_name"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "name",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "duration_nano",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "http_method",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "response_status_code",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      }
+                    ],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "3c95cd99-9520-4718-8ea5-bcd1b62d6887": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Agents",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "service.name",
+                  "signal": "traces",
+                  "fieldContext": "resource",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "name",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "duration_nano",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = $service_name openinference.span.kind = 'AGENT' graph.node.id IN $agent_name "
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "name",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "duration_nano",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "http_method",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "response_status_code",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      }
+                    ],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "535f0c2f-9ee7-42b7-b688-76f0b3b1e088": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Avg Time Per Agent",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A": "ns"
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "avg(duration_nano)",
+                        "alias": "avg_duration"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = $service_name openinference.span.kind = 'AGENT'"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "graph.node.id",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "6099d2e6-bcfb-44ba-bf40-f0fb401c46c7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Token Usage Over Time",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": null
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(llm.token_count.total)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = $service_name openinference.span.kind = 'LLM'"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "63742ffd-8f8c-4c2e-b35f-8f7ffecaf1d8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Tasks Per Agents",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A": ""
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()",
+                        "alias": "Tasks"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = $service_name name = 'Task Execution'"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "agent_role",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "903e463c-7a59-4fef-b539-997464a044f8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Output Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(llm.token_count.completion)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "b989aa24-8014-4b7b-9e6c-2e8f654ba30d": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Duration Over Time of Tool",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ns",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": null
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "avg(duration_nano)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = $service_name openinference.span.kind = 'TOOL' tool.name IN $tool_name "
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "b9ebaed8-000d-4f77-aa2a-1d2e47c506a0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Tool Calls",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "service.name",
+                  "signal": "traces",
+                  "fieldContext": "resource",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "name",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "duration_nano",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "http_method",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "response_status_code",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name openinference.span.kind = 'TOOL' tool.name IN $tool_name"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "name",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "duration_nano",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "http_method",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "response_status_code",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      }
+                    ],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "c05a9158-b9d9-470e-9cf0-05e70be9fef1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Input Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(llm.token_count.prompt)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 2,
+              "height": 2,
+              "content": {
+                "$ref": "#/spec/panels/c05a9158-b9d9-470e-9cf0-05e70be9fef1"
+              }
+            },
+            {
+              "x": 2,
+              "y": 0,
+              "width": 2,
+              "height": 2,
+              "content": {
+                "$ref": "#/spec/panels/903e463c-7a59-4fef-b539-997464a044f8"
+              }
+            },
+            {
+              "x": 4,
+              "y": 0,
+              "width": 2,
+              "height": 2,
+              "content": {
+                "$ref": "#/spec/panels/08761443-6932-4ca9-8851-be91b48f4399"
+              }
+            },
+            {
+              "x": 6,
+              "y": 0,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/2971f98d-aaf3-4c47-812e-95da9f211c38"
+              }
+            },
+            {
+              "x": 0,
+              "y": 2,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/6099d2e6-bcfb-44ba-bf40-f0fb401c46c7"
+              }
+            },
+            {
+              "x": 6,
+              "y": 6,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/3c95cd99-9520-4718-8ea5-bcd1b62d6887"
+              }
+            },
+            {
+              "x": 0,
+              "y": 8,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/b989aa24-8014-4b7b-9e6c-2e8f654ba30d"
+              }
+            },
+            {
+              "x": 6,
+              "y": 12,
+              "width": 6,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/37a57837-1351-481f-82d0-d55e3213a6a1"
+              }
+            },
+            {
+              "x": 0,
+              "y": 14,
+              "width": 6,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/63742ffd-8f8c-4c2e-b35f-8f7ffecaf1d8"
+              }
+            },
+            {
+              "x": 0,
+              "y": 17,
+              "width": 6,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/535f0c2f-9ee7-42b7-b688-76f0b3b1e088"
+              }
+            },
+            {
+              "x": 6,
+              "y": 17,
+              "width": 6,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/060a2aac-f239-417e-a50a-62c9fe72af13"
+              }
+            },
+            {
+              "x": 0,
+              "y": 20,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/b9ebaed8-000d-4f77-aa2a-1d2e47c506a0"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "",
+    "refreshInterval": "",
+    "links": []
+  },
+  "tags": [],
+  "image": "/assets/Icons/eight-ball"
+}

--- a/dify/dify-dashboard.json
+++ b/dify/dify-dashboard.json
@@ -1,1 +1,935 @@
-{"description":"Comprehensive monitoring dashboard for the langgenius/dify service. Covers RED metrics (Rate, Errors, Duration), HTTP endpoint performance, LLM/GenAI activity (token usage, model latency, providers), workflow & app activity, and Postgres/Redis dependencies. Built from traces and metrics observed for the service.","layout":[{"h":3,"i":"w-req-rate","moved":false,"static":false,"w":3,"x":0,"y":0},{"h":3,"i":"w-error-count","moved":false,"static":false,"w":3,"x":3,"y":0},{"h":3,"i":"w-p95-overall","moved":false,"static":false,"w":3,"x":6,"y":0},{"h":3,"i":"w-llm-tokens-total","moved":false,"static":false,"w":3,"x":9,"y":0},{"h":6,"i":"w-req-by-op","moved":false,"static":false,"w":6,"x":0,"y":3},{"h":6,"i":"w-p95-by-op","moved":false,"static":false,"w":6,"x":6,"y":3},{"h":6,"i":"w-llm-latency-by-model","moved":false,"static":false,"w":6,"x":0,"y":9},{"h":6,"i":"w-llm-calls-by-model","moved":false,"static":false,"w":6,"x":6,"y":9},{"h":6,"i":"w-tokens-in-out","moved":false,"static":false,"w":6,"x":0,"y":15},{"h":6,"i":"w-app-activity","moved":false,"static":false,"w":6,"x":6,"y":15},{"h":5,"i":"w-streaming-mode","moved":false,"static":false,"w":4,"x":0,"y":21},{"h":5,"i":"w-db-latency","moved":false,"static":false,"w":4,"x":4,"y":21},{"h":5,"i":"w-redis-ops","moved":false,"static":false,"w":4,"x":8,"y":21},{"h":6,"i":"w-slow-endpoints","moved":false,"static":false,"w":12,"x":0,"y":26}],"panelMap":{},"tags":["dify","llm","genai","service-overview"],"title":"Dify Service - Overview & LLM Observability","variables":{},"version":"v5","widgets":[{"contextLinks":{"linksData":[]},"decimalPrecision":2,"description":"Total spans per minute for langgenius/dify - overall traffic level","fillSpans":false,"id":"w-req-rate","isLogScale":false,"legendPosition":"bottom","nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"rate()"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'langgenius/dify'"},"filters":{"items":[],"op":"AND"},"functions":[],"groupBy":[],"having":[],"legend":"","orderBy":[],"queryName":"A","reduceTo":"avg","selectColumns":[],"stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"99b4b831-4b77-49a0-bcf4-64bfdb4534a7","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[],"selectedTracesFields":[],"softMax":0,"softMin":0,"timePreferance":"GLOBAL_TIME","title":"Request Rate (spans/min)","yAxisUnit":"short"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":0,"description":"Count of error spans in the time range","fillMode":"none","fillSpans":false,"id":"w-error-count","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count()"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'langgenius/dify' AND has_error = true"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","selectColumns":[],"source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"cb3a7611-8bb3-4ab7-9a98-b28c19876a09","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[{"index":"t1","selectedGraph":"value","thresholdColor":"Red","thresholdFormat":"Text","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"none","thresholdValue":0}],"timePreferance":"GLOBAL_TIME","title":"Error Spans ","yAxisUnit":"short"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"p95 latency for root HTTP request spans","fillMode":"none","fillSpans":false,"id":"w-p95-overall","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"p95(duration_nano)"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'langgenius/dify' AND parent_span_id = ''"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","selectColumns":[],"source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"bd0fc168-b965-4ce1-92d5-da80e8bbffa1","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"p95 Latency (root spans)","yAxisUnit":"ns"},{"contextLinks":{"linksData":[]},"decimalPrecision":0,"description":"Sum of total tokens consumed (input + output) across all LLM spans","fillSpans":false,"id":"w-llm-tokens-total","isLogScale":false,"legendPosition":"bottom","nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.total_tokens)"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'langgenius/dify'"},"filters":{"items":[],"op":"AND"},"functions":[],"groupBy":[],"having":[],"legend":"","orderBy":[],"queryName":"A","reduceTo":"sum","selectColumns":[],"stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"6d59b168-1cbf-410f-9789-5dbd86357069","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[],"selectedTracesFields":[],"softMax":0,"softMin":0,"timePreferance":"GLOBAL_TIME","title":"Total LLM Tokens","yAxisUnit":"short"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A":""},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"Spans per minute grouped by operation name - shows traffic shape","fillMode":"none","fillSpans":false,"id":"w-req-by-op","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count()"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'langgenius/dify'"},"functions":[],"groupBy":[{"dataType":"string","id":"name--string--","isColumn":true,"isJSON":false,"key":"name","type":""}],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"e8aeace5-af47-4e8a-a72b-5b21dea5c37e","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Requests  by Operation","yAxisUnit":"short"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A":"ns"},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"p95 span duration per operation - spot slow endpoints","fillMode":"none","fillSpans":false,"id":"w-p95-by-op","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"p95(duration_nano) as 'Duration'"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'langgenius/dify'"},"functions":[],"groupBy":[{"dataType":"string","id":"name--string--","isColumn":true,"isJSON":false,"key":"name","type":""}],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"4fced926-0cf2-444d-9765-9dcc55c3b961","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"p95 Latency by Operation","yAxisUnit":"ns"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"p95 latency of LLM/chat operations broken down by model","fillMode":"none","fillSpans":false,"id":"w-llm-latency-by-model","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"p95(duration_nano)"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'langgenius/dify' AND gen_ai.request.model EXISTS"},"functions":[],"groupBy":[{"dataType":"string","id":"gen_ai.request.model--string--tag","isColumn":false,"isJSON":false,"key":"gen_ai.request.model","type":"tag"}],"having":{"expression":""},"legend":"{{gen_ai.request.model}}","limit":null,"orderBy":[],"queryName":"A","selectColumns":[],"source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"17b28e64-f353-40f9-87c0-5490c16dcab3","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"LLM p95 Latency by Model","yAxisUnit":"ns"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":0,"description":"Number of LLM invocations per model over time","fillMode":"none","fillSpans":false,"id":"w-llm-calls-by-model","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"bar","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count()"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'langgenius/dify' AND gen_ai.request.model EXISTS"},"functions":[],"groupBy":[{"dataType":"string","id":"gen_ai.request.model--string--tag","isColumn":false,"isJSON":false,"key":"gen_ai.request.model","type":"tag"}],"having":{"expression":""},"legend":"{{gen_ai.request.model}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"52be08f5-f790-40f6-8329-6a56afe57a63","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"LLM Calls by Model","yAxisUnit":"short"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A":"","B":""},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":0,"description":"Input and output tokens consumed per model. Useful for cost tracking.","fillMode":"none","fillSpans":false,"id":"w-tokens-in-out","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.input_tokens)"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'langgenius/dify' AND gen_ai.request.model EXISTS"},"functions":[],"groupBy":[{"dataType":"string","id":"gen_ai.request.model--string--tag","isColumn":false,"isJSON":false,"key":"gen_ai.request.model","type":"tag"}],"having":{"expression":""},"legend":"Input tokens","limit":null,"orderBy":[],"queryName":"A","selectColumns":[],"source":"","stepInterval":60},{"aggregations":[{"expression":"sum(gen_ai.usage.output_tokens)"}],"dataSource":"traces","disabled":false,"expression":"B","filter":{"expression":"service.name = 'langgenius/dify' AND gen_ai.request.model EXISTS"},"functions":[],"groupBy":[{"dataType":"string","id":"gen_ai.request.model--string--tag","isColumn":false,"isJSON":false,"key":"gen_ai.request.model","type":"tag"}],"having":{"expression":""},"legend":"Output tokens","limit":null,"orderBy":[],"queryName":"B","selectColumns":[],"source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"5de9b150-8682-4de0-9002-132ed7db4be3","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Token Usage: Input vs Output (by model)","yAxisUnit":"short"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A":""},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":0,"description":"Spans grouped by dify.app_id - which apps are most active","fillMode":"none","fillSpans":false,"id":"w-app-activity","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() as '# of Requests'"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'langgenius/dify' AND dify.app_id EXISTS"},"functions":[],"groupBy":[{"dataType":"string","id":"dify.app_id--string--tag","isColumn":false,"isJSON":false,"key":"dify.app_id","type":"tag"}],"having":{"expression":""},"legend":"{{dify.app_id}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"eea805af-150b-4d29-aa84-1e0065faa790","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Activity by Dify App","yAxisUnit":"short"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":0,"description":"Distribution of dify.streaming attribute - how many requests use streaming","fillMode":"none","fillSpans":false,"id":"w-streaming-mode","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count()"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'langgenius/dify' AND dify.streaming EXISTS"},"functions":[],"groupBy":[{"dataType":"bool","id":"dify.streaming--bool--tag","isColumn":false,"isJSON":false,"key":"dify.streaming","type":"tag"}],"having":{"expression":""},"legend":"streaming={{dify.streaming}}","limit":null,"orderBy":[],"queryName":"A","selectColumns":[],"source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"86e0e9da-7642-4529-95d9-0a5ccefa92dc","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Streaming vs Non-Streaming Requests","yAxisUnit":"short"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"p95 latency for postgres operations from the dify service","fillMode":"none","fillSpans":false,"id":"w-db-latency","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"p95(duration_nano)"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'langgenius/dify' AND db.system = 'postgresql'"},"functions":[],"groupBy":[{"dataType":"string","id":"db.operation--string--tag","isColumn":false,"isJSON":false,"key":"db.operation","type":"tag"}],"having":{"expression":""},"legend":"{{db.operation}}","limit":null,"orderBy":[],"queryName":"A","selectColumns":[],"source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"3a956d06-3e93-44a2-b31c-177fcc3dccc8","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Postgres Query p95 Latency","yAxisUnit":"ns"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":0,"description":"Count of Redis ops by name - cache/queue patterns","fillMode":"none","fillSpans":false,"id":"w-redis-ops","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count()"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'langgenius/dify' AND db.system = 'redis'"},"functions":[],"groupBy":[{"dataType":"string","id":"name--string--","isColumn":true,"isJSON":false,"key":"name","type":""}],"having":{"expression":""},"legend":"{{name}}","limit":null,"orderBy":[],"queryName":"A","selectColumns":[],"source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"101231ed-b0a0-4c59-8d1a-ee7b31eaebdc","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Redis Operations by Type","yAxisUnit":"short"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A":"ns","B":""},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"Table of slowest HTTP endpoints by p95 latency with call count and avg duration","fillMode":"none","fillSpans":false,"id":"w-slow-endpoints","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"p95(duration_nano)"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'langgenius/dify' AND http.method EXISTS"},"functions":[],"groupBy":[{"dataType":"string","id":"name--string--","isColumn":true,"isJSON":false,"key":"name","type":""}],"having":{"expression":""},"legend":"p95","limit":null,"orderBy":[],"queryName":"A","selectColumns":[],"source":"","stepInterval":60},{"aggregations":[{"expression":"count()"}],"dataSource":"traces","disabled":false,"expression":"B","filter":{"expression":"service.name = 'langgenius/dify' AND http.method EXISTS"},"functions":[],"groupBy":[{"dataType":"string","id":"name--string--","isColumn":true,"isJSON":false,"key":"name","type":""}],"having":{"expression":""},"legend":"calls","limit":null,"orderBy":[],"queryName":"B","selectColumns":[],"source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"31492f9c-db27-429e-8a76-7cdd1cb7e148","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Slowest Endpoints (by p95)","yAxisUnit":"ns"}],"uuid":"019e186e-0a28-737b-be42-0992b7f47d6c"}
+{
+  "spec": {
+    "display": {
+      "name": "Dify Service - Overview & LLM Observability",
+      "description": "Comprehensive monitoring dashboard for the langgenius/dify service. Covers RED metrics (Rate, Errors, Duration), HTTP endpoint performance, LLM/GenAI activity (token usage, model latency, providers), workflow & app activity, and Postgres/Redis dependencies. Built from traces and metrics observed for the service."
+    },
+    "variables": [],
+    "panels": {
+      "w-app-activity": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Activity by Dify App",
+            "description": "Spans grouped by dify.app_id - which apps are most active"
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A": ""
+                },
+                "decimalPrecision": "0"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()",
+                        "alias": "# of Requests"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = 'langgenius/dify' AND dify.app_id EXISTS"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "dify.app_id",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{dify.app_id}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "w-db-latency": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Postgres Query p95 Latency",
+            "description": "p95 latency for postgres operations from the dify service"
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ns",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "DELETE": "#E5905D",
+                  "INSERT": "#9EE48B",
+                  "SELECT": "#E55DA1",
+                  "UPDATE": "#594CEB"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "p95(duration_nano)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = 'langgenius/dify' AND db.system = 'postgresql'"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "db.operation",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "selectFields": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{db.operation}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "w-error-count": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Error Spans ",
+            "description": "Count of error spans in the time range"
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "short",
+                "decimalPrecision": "0"
+              },
+              "thresholds": [
+                {
+                  "value": 0,
+                  "operator": "above",
+                  "unit": "none",
+                  "color": "Red",
+                  "format": "text"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = 'langgenius/dify' AND has_error = true"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "w-llm-tokens-total": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total LLM Tokens",
+            "description": "Sum of total tokens consumed (input + output) across all LLM spans"
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "short",
+                "decimalPrecision": "0"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(gen_ai.usage.total_tokens)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = 'langgenius/dify'"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "w-p95-by-op": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "p95 Latency by Operation",
+            "description": "p95 span duration per operation - spot slow endpoints"
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A": "ns"
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "p95(duration_nano)",
+                        "alias": "Duration"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = 'langgenius/dify'"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "name",
+                        "signal": "",
+                        "fieldContext": "",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "w-p95-overall": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "p95 Latency (root spans)",
+            "description": "p95 latency for root HTTP request spans"
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "ns",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "p95(duration_nano)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = 'langgenius/dify' AND parent_span_id = ''"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "w-redis-ops": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Redis Operations by Type",
+            "description": "Count of Redis ops by name - cache/queue patterns"
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "short",
+                "decimalPrecision": "0"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "DEL": "#5DE56E",
+                  "EXPIRE": "#8BB4E4",
+                  "GET": "#8BE4C6",
+                  "HGETALL": "#C3E55D",
+                  "LPUSH": "#E8304F",
+                  "SETEX": "#E130E8"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = 'langgenius/dify' AND db.system = 'redis'"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "name",
+                        "signal": "",
+                        "fieldContext": "",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "selectFields": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "w-req-by-op": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Requests  by Operation",
+            "description": "Spans per minute grouped by operation name - shows traffic shape"
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A": ""
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = 'langgenius/dify'"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "name",
+                        "signal": "",
+                        "fieldContext": "",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "w-req-rate": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Request Rate (spans/min)",
+            "description": "Total spans per minute for langgenius/dify - overall traffic level"
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "short",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "rate()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = 'langgenius/dify'"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "w-slow-endpoints": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Slowest Endpoints (by p95)",
+            "description": "Table of slowest HTTP endpoints by p95 latency with call count and avg duration"
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A": "ns",
+                  "B": ""
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 60,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "p95(duration_nano)"
+                            }
+                          ],
+                          "disabled": false,
+                          "filter": {
+                            "expression": "service.name = 'langgenius/dify' AND http.method EXISTS"
+                          },
+                          "groupBy": [
+                            {
+                              "name": "name",
+                              "signal": "",
+                              "fieldContext": "",
+                              "fieldDataType": "string"
+                            }
+                          ],
+                          "order": [],
+                          "selectFields": [],
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": "p95"
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 60,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": false,
+                          "filter": {
+                            "expression": "service.name = 'langgenius/dify' AND http.method EXISTS"
+                          },
+                          "groupBy": [
+                            {
+                              "name": "name",
+                              "signal": "",
+                              "fieldContext": "",
+                              "fieldDataType": "string"
+                            }
+                          ],
+                          "order": [],
+                          "selectFields": [],
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": "calls"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "w-streaming-mode": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Streaming vs Non-Streaming Requests",
+            "description": "Distribution of dify.streaming attribute - how many requests use streaming"
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "short",
+                "decimalPrecision": "0"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "streaming=false": "#E8B330",
+                  "streaming=true": "#B08BE4"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = 'langgenius/dify' AND dify.streaming EXISTS"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "dify.streaming",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "bool"
+                      }
+                    ],
+                    "order": [],
+                    "selectFields": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "streaming={{dify.streaming}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 3,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/w-req-rate"
+              }
+            },
+            {
+              "x": 3,
+              "y": 0,
+              "width": 3,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/w-error-count"
+              }
+            },
+            {
+              "x": 6,
+              "y": 0,
+              "width": 3,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/w-p95-overall"
+              }
+            },
+            {
+              "x": 9,
+              "y": 0,
+              "width": 3,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/w-llm-tokens-total"
+              }
+            },
+            {
+              "x": 0,
+              "y": 3,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/w-db-latency"
+              }
+            },
+            {
+              "x": 6,
+              "y": 3,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/w-redis-ops"
+              }
+            },
+            {
+              "x": 0,
+              "y": 9,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/w-req-by-op"
+              }
+            },
+            {
+              "x": 6,
+              "y": 9,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/w-p95-by-op"
+              }
+            },
+            {
+              "x": 0,
+              "y": 15,
+              "width": 4,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/w-streaming-mode"
+              }
+            },
+            {
+              "x": 4,
+              "y": 15,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/w-app-activity"
+              }
+            },
+            {
+              "x": 0,
+              "y": 21,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/w-slow-endpoints"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "",
+    "refreshInterval": "",
+    "links": []
+  },
+  "tags": [
+    {
+      "key": "tag",
+      "value": "dify"
+    },
+    {
+      "key": "tag",
+      "value": "llm"
+    },
+    {
+      "key": "tag",
+      "value": "genai"
+    },
+    {
+      "key": "tag",
+      "value": "service-overview"
+    }
+  ],
+  "image": ""
+}

--- a/google-adk/google-adk-dashboard.json
+++ b/google-adk/google-adk-dashboard.json
@@ -1,1 +1,1160 @@
-{"description":"","image":"data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE0Ljk0OTQgMTMuOTQyQzE2LjIzMTggMTIuNDI1OCAxNy4zMjY4IDkuNzAyMiAxNi4xOTU2IDYuNTc0ODdDMTUuNjQ0MyA1LjA1MjQ1IDE1LjAyMTkgNC4yMDI0OSAxNC4yOTY5IDMuNjYyNTJDMTMuODU1NyAzLjMzMzc5IDEyLjA5MzMgMi41MDYzMyA5Ljc1OTY1IDIuODY3NTZDOC4wNTM0OSAzLjEzMjU1IDUuNzc0ODcgNC4yMDg3NCA0LjI5MzY5IDUuOTU5OUMyLjg1NzUyIDcuNjYxMDYgMS43NDg4MyA5LjAwNDc0IDEuNjk3NTggMTAuMzA5N0MxLjYzMTMzIDExLjk4ODMgMi44OTYyNyAxMy40MzA4IDMuMDUwMDEgMTMuNjY0NUMzLjMyMzc0IDE0LjA3OTUgNS4xOTExNSAxNi40NTE4IDguNjk5NzEgMTYuNTczMUMxMS43OTcgMTYuNjc5MyAxMy44MTQ0IDE1LjI4NDQgMTQuOTQ5NCAxMy45NDJaIiBmaWxsPSIjNDAzRDNFIi8+CjxwYXRoIGQ9Ik00LjU1MzYzIDIuNzM3NDdDMi45Mzc0NiAzLjg5MTE2IDEuMTIxMzEgNi4yNTEwMyAxLjQ0NzU0IDkuNTYwODZDMS42MDYyOCAxMS4xNzIgMi4wMDI1MSAxMi4xNDk1IDIuNTcxMjMgMTIuODUwN0MyLjkxNzQ2IDEzLjI3ODIgNC40MTk4OCAxNC41NDkzIDYuNzczNTEgMTQuNzM2OEM5LjE0NTg4IDE0LjkyNTYgMTAuOTQ5NSAxNC4zOTQ0IDEyLjgzMzIgMTMuMDg0NEMxNi42NjE3IDEwLjQyMDggMTYuMDk4IDYuMzkzNTMgMTUuOTM0MyA1LjkyNDhDMTUuNzcwNSA1LjQ1NjA3IDE0LjU0NDQgMi42OTYyMiAxMS4xNzMzIDEuNzE1MDJDOC4xOTg0NCAwLjg1MDA2OCA1Ljk4MzU1IDEuNzE1MDIgNC41NTM2MyAyLjczNzQ3WiIgZmlsbD0iIzVFNjM2NyIvPgo8cGF0aCBkPSJNNy4zOTM1MyAyLjk2MTA5QzUuNjE3MzcgMi44OTczNCAzLjkxOTk2IDQuMjg4NTIgMy43NTYyMiA2LjAwNTkzQzMuNTkyNDggNy43MjIwOSA0LjY1NDkyIDkuMDI5NTIgNi4zMDk4MyA5LjI5NTc2QzcuOTY0NzUgOS41NjA3NCA5Ljg3ODM5IDguNTU1OCAxMC4yNjM0IDYuNDUwOTFDMTAuNjYwOSA0LjI4MjI3IDkuMDg5NjkgMy4wMjIzNCA3LjM5MzUzIDIuOTYxMDlaIiBmaWxsPSJ3aGl0ZSIvPgo8cGF0aCBkPSJNNy45NDIxNyA1LjkwMTE1QzcuOTQyMTcgNS45MDExNSA4LjM2OTY1IDUuODEyNCA4LjQ1NDY1IDUuMTgyNDRDOC41MzgzOSA0LjU2MjQ3IDguMjMwOTEgNC4wMzM3NSA3LjUxMzQ1IDMuODQzNzZDNi43MzM0OSAzLjYzNzUyIDYuMjA0NzcgNC4wNjYyNSA2LjA2NzI3IDQuNTE3NDdDNS44NzYwMyA1LjE0NDk0IDYuMTU4NTIgNS40NDM2NyA2LjE1ODUyIDUuNDQzNjdDNi4xNTg1MiA1LjQ0MzY3IDUuMzkzNTYgNS42Mjc0MSA1LjMzMjMxIDYuNTI5ODdDNS4yNzQ4MSA3LjM4MTA3IDUuODU2MDMgNy44Mzg1NSA2LjQzOTc1IDcuOTc4NTRDNy4xNjA5NiA4LjE1MjI4IDcuOTc4NDIgNy45NTQ3OSA4LjE3ODQxIDcuMDM0ODRDOC4zNDQ2NSA2LjI3NzM4IDcuOTQyMTcgNS45MDExNSA3Ljk0MjE3IDUuOTAxMTVaIiBmaWxsPSIjMzAzMDMwIi8+CjxwYXRoIGQ9Ik02LjczOTgzIDQuNzUzNjJDNi42NzEwOSA1LjAxMjM1IDYuODA4NTggNS4yNjIzNCA3LjA3ODU3IDUuMzMxMDlDNy4zNjk4IDUuNDA0ODMgNy42MzQ3OSA1LjMwODU5IDcuNzA2MDMgNS4wMTExQzcuNzY4NTMgNC43NDczNyA3LjY0MzU0IDQuNTE0ODggNy4zMzYwNSA0LjQzOTg4QzcuMDgzNTcgNC4zNzczOSA2LjgxNDgzIDQuNDcxMTMgNi43Mzk4MyA0Ljc1MzYyWiIgZmlsbD0id2hpdGUiLz4KPHBhdGggZD0iTTYuOTU5NzggNi4wMzk3NEM2LjYzMjMgNS45Mzg0OSA2LjE5OTgyIDYuMDY0NzMgNi4xMzEwNyA2LjUwNDcxQzYuMDYyMzMgNi45NDQ2OSA2LjMyNjA2IDcuMTY5NjggNi42NzEwNCA3LjIzMjE3QzcuMDE2MDMgNy4yOTQ2NyA3LjM0MjI2IDcuMTEzNDMgNy40MDYwMSA2Ljc2MDk1QzcuNDY4NSA2LjQwOTcyIDcuMjg2MDEgNi4xMzk3MyA2Ljk1OTc4IDYuMDM5NzRaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K","layout":[{"h":4,"i":"04247ee1-b408-457d-ac00-47ce45e64291","moved":false,"static":false,"w":3,"x":0,"y":0},{"h":4,"i":"d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570","moved":false,"static":false,"w":3,"x":3,"y":0},{"h":7,"i":"28409661-48e9-454c-ba5a-890e5268ef4e","moved":false,"static":false,"w":3,"x":6,"y":0},{"h":7,"i":"3633c7ad-203a-4e25-99f4-8cc81bf15d65","moved":false,"static":false,"w":3,"x":9,"y":0},{"h":4,"i":"799913e6-fb95-497e-858a-6490b5f9d10d","moved":false,"static":false,"w":3,"x":0,"y":4},{"h":7,"i":"aa807025-f8ce-4fe7-964b-4089bcc0fe5a","moved":false,"static":false,"w":3,"x":3,"y":4},{"h":5,"i":"af79b14b-5e76-47fb-a24e-a4629c642c28","moved":false,"static":false,"w":6,"x":6,"y":7},{"h":5,"i":"28bb5d45-046d-4980-ad5e-26b1aeecda2b","moved":false,"static":false,"w":6,"x":0,"y":11},{"h":5,"i":"74a94376-eeaf-43c1-a273-5d8b98197138","moved":false,"static":false,"w":6,"x":6,"y":12},{"h":4,"i":"67a074ee-c46e-4a36-8f5c-10d981cae404","moved":false,"static":false,"w":6,"x":0,"y":16},{"h":8,"i":"05e6759b-c460-4618-86c0-5d2bf0b311c1","moved":false,"static":false,"w":6,"x":6,"y":17},{"h":5,"i":"5e66cb8c-2219-47e6-ba71-8f82f9873bc8","moved":false,"static":false,"w":6,"x":0,"y":20}],"panelMap":{},"tags":[],"title":"Google ADK","uploadedGrafana":false,"uuid":"019bc30a-f8f7-781d-9eec-f1158182c8a3","variables":{"10d0eca9-9253-4583-821c-d3c812d78151":{"allSelected":false,"customValue":"","defaultValue":"","description":"The service name using Google adk","dynamicVariablesAttribute":"service.name","dynamicVariablesSource":"All telemetry","id":"10d0eca9-9253-4583-821c-d3c812d78151","key":"10d0eca9-9253-4583-821c-d3c812d78151","modificationUUID":"98dce680-36b6-4703-9cdc-769da48cf6b0","multiSelect":true,"name":"service_name","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"93c33118-5f46-404b-b45e-8a81160c44c4":{"allSelected":false,"customValue":"","defaultValue":"","description":"Agents being used ","dynamicVariablesAttribute":"agent.name","dynamicVariablesSource":"All telemetry","id":"93c33118-5f46-404b-b45e-8a81160c44c4","key":"93c33118-5f46-404b-b45e-8a81160c44c4","modificationUUID":"5915d1d6-ca86-40f5-b9a6-cf1fca889dfe","multiSelect":true,"name":"agent.name","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"be7a68c4-fb97-43ea-bb94-0ded120bd3d7":{"allSelected":false,"customValue":"","defaultValue":"","description":"LLM Model name being used for Google adk agent","dynamicVariablesAttribute":"gen_ai.request.model","dynamicVariablesSource":"All telemetry","id":"be7a68c4-fb97-43ea-bb94-0ded120bd3d7","modificationUUID":"2add4a1c-c79a-4e9d-ac9c-b48cf155e8ed","multiSelect":true,"name":"llm_model","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"}},"version":"v5","widgets":[{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"04247ee1-b408-457d-ac00-47ce45e64291","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.input_tokens) "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name AND gen_ai.request.model IN $llm_model "},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"2e6e2bbf-4621-4689-8188-9577cae63ebe","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Input Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(llm.token_count.completion) ) ) ) ) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND gen_ai.request.model IN $llm_model "},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"a01ebf51-68b5-44a3-a0b7-f06ecfe956c9","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Output Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"799913e6-fb95-497e-858a-6490b5f9d10d","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"A","filter":{"expression":"has_error = 'true' service.name in $service_name"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null},{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"B","filter":{"expression":"has_error = 'false' service.name in $service_name"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"B","source":"","stepInterval":null}],"queryFormulas":[{"disabled":false,"expression":"A / (A+B)","legend":"","queryName":"F1"}],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"9cc3440a-bf7b-42ed-9c8c-a4a187de6d23","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[{"index":"e5e05d41-7479-4d60-a1cf-c433b8b61285","isEditEnabled":false,"keyIndex":1,"selectedGraph":"value","thresholdColor":"Red","thresholdFormat":"Text","thresholdLabel":"","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"percentunit","thresholdValue":10},{"index":"d74bf17b-552a-4636-8fad-c976b090d590","isEditEnabled":false,"keyIndex":0,"selectedGraph":"value","thresholdColor":"Orange","thresholdFormat":"Text","thresholdLabel":"","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"percentunit","thresholdValue":5}],"timePreferance":"GLOBAL_TIME","title":"Error Rate","yAxisUnit":"percentunit"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"3633c7ad-203a-4e25-99f4-8cc81bf15d65","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND gen_ai.request.model EXISTS AND has_error = false"},"functions":[],"groupBy":[{"dataType":"string","id":"gen_ai.request.model--string--tag","isColumn":false,"isJSON":false,"key":"gen_ai.request.model","type":"tag"}],"having":{"expression":""},"legend":"{{gen_ai.request.model}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"5bc601ab-4225-4317-9fdf-ddc863321600","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Model Calls","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"F1":"#eccd03"},"decimalPrecision":2,"description":"","fillSpans":false,"id":"28bb5d45-046d-4980-ad5e-26b1aeecda2b","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(llm.token_count.total)"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND gen_ai.request.model in $llm_model"},"functions":[],"groupBy":[{"dataType":"string","id":"service.name--string--resource","isColumn":true,"isJSON":false,"key":"service.name","type":"resource"}],"having":{"expression":""},"legend":"{{service.name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"1adef5c0-3c63-41c7-a5c5-fa37188a2a92","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Token Usage","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"af79b14b-5e76-47fb-a24e-a4629c642c28","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"p95(duration_nano) "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND openinference.span.kind = 'CHAIN' "},"functions":[],"groupBy":[{"dataType":"string","id":"service.name--string--resource","isColumn":true,"isJSON":false,"key":"service.name","type":"resource"}],"having":{"expression":""},"legend":"{{service.name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"d4714339-acdb-4e05-89e7-910c28140091","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Request Duration (P95)","yAxisUnit":"ns"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"A":"#edce64","count()":"#a403ff"},"decimalPrecision":2,"description":"","fillSpans":false,"id":"74a94376-eeaf-43c1-a273-5d8b98197138","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND openinference.span.kind = 'CHAIN' "},"functions":[],"groupBy":[{"dataType":"string","id":"service.name--string--resource","isColumn":true,"isJSON":false,"key":"service.name","type":"resource"}],"having":{"expression":""},"legend":"{{service.name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"a5968adf-9388-428b-8b32-fdf9982cfeaa","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Number of Requests","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"date":145,"duration_nano":145,"http_method":145,"name":145,"response_status_code":145,"service.name":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"5e66cb8c-2219-47e6-ba71-8f82f9873bc8","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"has_error = 'true' service.name IN $service_name"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"}],"pageSize":10,"queryName":"A","selectColumns":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"b85f93b2-09b5-4fcd-8aa8-f6a2875a41b5","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Errors","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A":""},"columnWidths":{"A":145,"service.name":145,"telemetry.sdk.language":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"67a074ee-c46e-4a36-8f5c-10d981cae404","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() as 'Count'"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name AND openinference.span.kind = 'CHAIN' "},"functions":[],"groupBy":[{"dataType":"string","id":"service.name--string--resource","isColumn":true,"isJSON":false,"key":"service.name","type":"resource"},{"dataType":"string","id":"telemetry.sdk.language--string--resource","isColumn":false,"isJSON":false,"key":"telemetry.sdk.language","type":"resource"}],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"02e68ff0-0dd8-442a-8f76-db6ca9370c1f","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Services and Languages","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"body":350,"timestamp":100},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"05e6759b-c460-4618-86c0-5d2bf0b311c1","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"logs","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name "},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"},{"columnName":"id","order":"desc"}],"pageSize":10,"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"418fb9a8-ca2d-4dd2-a405-e90a3f9f9b85","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Logs","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"{llm.model_name=\"gpt-4.1-2025-04-14\"}":"#ce93ce","{llm.model_name=\"gpt-5-2025-08-07\"}":"#69aedd"},"decimalPrecision":2,"description":"","fillSpans":false,"id":"28409661-48e9-454c-ba5a-890e5268ef4e","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(llm.token_count.total) ) ) ) "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name"},"functions":[],"groupBy":[{"dataType":"string","id":"gen_ai.request.model--string--tag","isColumn":false,"isJSON":false,"key":"gen_ai.request.model","type":"tag"}],"having":{"expression":""},"legend":"{{gen_ai.request.model}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"51ff9ea6-0a65-401e-84fa-3a0bf21aa748","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Token Distribution by Models","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"{llm.model_name=\"gpt-4.1-2025-04-14\"}":"#ce93ce","{llm.model_name=\"gpt-5-2025-08-07\"}":"#69aedd"},"decimalPrecision":2,"description":"","fillSpans":false,"id":"aa807025-f8ce-4fe7-964b-4089bcc0fe5a","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count(agent.name)"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name"},"functions":[],"groupBy":[{"dataType":"","id":"agent.name----","key":"agent.name","type":""}],"having":{"expression":""},"legend":"{{agent.name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"0add26c8-3e40-4193-a01c-2912c0e8cea4","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Agent Call Distribution","yAxisUnit":"none"}]}
+{
+  "spec": {
+    "display": {
+      "name": "Google ADK",
+      "description": ""
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "service_name",
+            "description": "The service name using Google adk"
+          },
+          "defaultValue": [
+            "adk-planner-agent",
+            "adk-investment-agent",
+            "adk-travel-agent"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "service.name",
+              "signal": "all"
+            }
+          },
+          "name": "service_name"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "agent.name",
+            "description": "Agents being used "
+          },
+          "defaultValue": [
+            "travel_agent",
+            "planner_agent",
+            "investment_agent"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "agent.name",
+              "signal": "all"
+            }
+          },
+          "name": "agent.name"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "llm_model",
+            "description": "LLM Model name being used for Google adk agent"
+          },
+          "defaultValue": [
+            "gemini-2.5-flash",
+            "gemini-3-flash-preview"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "gen_ai.request.model",
+              "signal": "all"
+            }
+          },
+          "name": "llm_model"
+        }
+      }
+    ],
+    "panels": {
+      "04247ee1-b408-457d-ac00-47ce45e64291": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Input Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(gen_ai.usage.input_tokens)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name AND gen_ai.request.model IN $llm_model "
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "05e6759b-c460-4618-86c0-5d2bf0b311c1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Logs",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "timestamp",
+                  "signal": "logs",
+                  "fieldContext": "log",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "body",
+                  "signal": "logs",
+                  "fieldContext": "log",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "logs",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name "
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "28409661-48e9-454c-ba5a-890e5268ef4e": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Token Distribution by Models",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "gemini-2.5-flash": "#5D9BE5",
+                  "gemini-2.5-pro": "#E48B9A",
+                  "gemini-3-flash-preview": "#30E848"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(llm.token_count.total)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "gen_ai.request.model",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{gen_ai.request.model}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "28bb5d45-046d-4980-ad5e-26b1aeecda2b": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Token Usage",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "adk-investment-agent": "#E08BE4",
+                  "adk-planner-agent": "#5DE5B7",
+                  "adk-travel-agent": "#BAE830"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(llm.token_count.total)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND gen_ai.request.model in $llm_model"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "3633c7ad-203a-4e25-99f4-8cc81bf15d65": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Model Calls",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "gemini-2.5-flash": "#5D9BE5",
+                  "gemini-2.5-pro": "#E48B9A",
+                  "gemini-3-flash-preview": "#30E848"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND gen_ai.request.model EXISTS AND has_error = false"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "gen_ai.request.model",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{gen_ai.request.model}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "5e66cb8c-2219-47e6-ba71-8f82f9873bc8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Errors",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "service.name",
+                  "signal": "traces",
+                  "fieldContext": "resource",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "name",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "duration_nano",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "http_method",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "response_status_code",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "has_error = 'true' service.name IN $service_name"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "name",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "duration_nano",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "http_method",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "response_status_code",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      }
+                    ],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "67a074ee-c46e-4a36-8f5c-10d981cae404": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Services and Languages",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A": ""
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()",
+                        "alias": "Count"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name AND openinference.span.kind = 'CHAIN' "
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "telemetry.sdk.language",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "74a94376-eeaf-43c1-a273-5d8b98197138": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Number of Requests",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "adk-investment-agent": "#E08BE4",
+                  "adk-planner-agent": "#5DE5B7",
+                  "adk-travel-agent": "#BAE830"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND openinference.span.kind = 'CHAIN' "
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "799913e6-fb95-497e-858a-6490b5f9d10d": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Error Rate",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "percentunit",
+                "decimalPrecision": "2"
+              },
+              "thresholds": [
+                {
+                  "value": 10,
+                  "operator": "above",
+                  "unit": "percentunit",
+                  "color": "Red",
+                  "format": "text"
+                },
+                {
+                  "value": 5,
+                  "operator": "above",
+                  "unit": "percentunit",
+                  "color": "Orange",
+                  "format": "text"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "has_error = 'true' service.name in $service_name"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "has_error = 'false' service.name in $service_name"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "A / (A+B)",
+                          "disabled": false,
+                          "order": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "functions": null,
+                          "legend": ""
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "aa807025-f8ce-4fe7-964b-4089bcc0fe5a": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Agent Call Distribution",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "investment_agent": "#E4CA8B",
+                  "planner_agent": "#955DE5",
+                  "travel_agent": "#30E8E8"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count(agent.name)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "agent.name",
+                        "signal": "",
+                        "fieldContext": "",
+                        "fieldDataType": ""
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{agent.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "af79b14b-5e76-47fb-a24e-a4629c642c28": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Request Duration (P95)",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ns",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "adk-investment-agent": "#E08BE4",
+                  "adk-planner-agent": "#5DE5B7",
+                  "adk-travel-agent": "#BAE830"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "p95(duration_nano)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND openinference.span.kind = 'CHAIN' "
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Output Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(llm.token_count.completion)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND gen_ai.request.model IN $llm_model "
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/04247ee1-b408-457d-ac00-47ce45e64291"
+              }
+            },
+            {
+              "x": 4,
+              "y": 0,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570"
+              }
+            },
+            {
+              "x": 8,
+              "y": 0,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/799913e6-fb95-497e-858a-6490b5f9d10d"
+              }
+            },
+            {
+              "x": 0,
+              "y": 3,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/28bb5d45-046d-4980-ad5e-26b1aeecda2b"
+              }
+            },
+            {
+              "x": 6,
+              "y": 3,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/74a94376-eeaf-43c1-a273-5d8b98197138"
+              }
+            },
+            {
+              "x": 0,
+              "y": 9,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/af79b14b-5e76-47fb-a24e-a4629c642c28"
+              }
+            },
+            {
+              "x": 0,
+              "y": 15,
+              "width": 4,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/28409661-48e9-454c-ba5a-890e5268ef4e"
+              }
+            },
+            {
+              "x": 4,
+              "y": 15,
+              "width": 4,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/3633c7ad-203a-4e25-99f4-8cc81bf15d65"
+              }
+            },
+            {
+              "x": 8,
+              "y": 15,
+              "width": 4,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/aa807025-f8ce-4fe7-964b-4089bcc0fe5a"
+              }
+            },
+            {
+              "x": 0,
+              "y": 21,
+              "width": 12,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/67a074ee-c46e-4a36-8f5c-10d981cae404"
+              }
+            },
+            {
+              "x": 0,
+              "y": 26,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/5e66cb8c-2219-47e6-ba71-8f82f9873bc8"
+              }
+            },
+            {
+              "x": 0,
+              "y": 32,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/05e6759b-c460-4618-86c0-5d2bf0b311c1"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "",
+    "refreshInterval": "",
+    "links": []
+  },
+  "tags": [],
+  "image": "/assets/Icons/eight-ball"
+}

--- a/google-gemini/google-gemini-template.json
+++ b/google-gemini/google-gemini-template.json
@@ -1,1 +1,1031 @@
-{"description":"","image":"data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE0Ljk0OTQgMTMuOTQyQzE2LjIzMTggMTIuNDI1OCAxNy4zMjY4IDkuNzAyMiAxNi4xOTU2IDYuNTc0ODdDMTUuNjQ0MyA1LjA1MjQ1IDE1LjAyMTkgNC4yMDI0OSAxNC4yOTY5IDMuNjYyNTJDMTMuODU1NyAzLjMzMzc5IDEyLjA5MzMgMi41MDYzMyA5Ljc1OTY1IDIuODY3NTZDOC4wNTM0OSAzLjEzMjU1IDUuNzc0ODcgNC4yMDg3NCA0LjI5MzY5IDUuOTU5OUMyLjg1NzUyIDcuNjYxMDYgMS43NDg4MyA5LjAwNDc0IDEuNjk3NTggMTAuMzA5N0MxLjYzMTMzIDExLjk4ODMgMi44OTYyNyAxMy40MzA4IDMuMDUwMDEgMTMuNjY0NUMzLjMyMzc0IDE0LjA3OTUgNS4xOTExNSAxNi40NTE4IDguNjk5NzEgMTYuNTczMUMxMS43OTcgMTYuNjc5MyAxMy44MTQ0IDE1LjI4NDQgMTQuOTQ5NCAxMy45NDJaIiBmaWxsPSIjNDAzRDNFIi8+CjxwYXRoIGQ9Ik00LjU1MzYzIDIuNzM3NDdDMi45Mzc0NiAzLjg5MTE2IDEuMTIxMzEgNi4yNTEwMyAxLjQ0NzU0IDkuNTYwODZDMS42MDYyOCAxMS4xNzIgMi4wMDI1MSAxMi4xNDk1IDIuNTcxMjMgMTIuODUwN0MyLjkxNzQ2IDEzLjI3ODIgNC40MTk4OCAxNC41NDkzIDYuNzczNTEgMTQuNzM2OEM5LjE0NTg4IDE0LjkyNTYgMTAuOTQ5NSAxNC4zOTQ0IDEyLjgzMzIgMTMuMDg0NEMxNi42NjE3IDEwLjQyMDggMTYuMDk4IDYuMzkzNTMgMTUuOTM0MyA1LjkyNDhDMTUuNzcwNSA1LjQ1NjA3IDE0LjU0NDQgMi42OTYyMiAxMS4xNzMzIDEuNzE1MDJDOC4xOTg0NCAwLjg1MDA2OCA1Ljk4MzU1IDEuNzE1MDIgNC41NTM2MyAyLjczNzQ3WiIgZmlsbD0iIzVFNjM2NyIvPgo8cGF0aCBkPSJNNy4zOTM1MyAyLjk2MTA5QzUuNjE3MzcgMi44OTczNCAzLjkxOTk2IDQuMjg4NTIgMy43NTYyMiA2LjAwNTkzQzMuNTkyNDggNy43MjIwOSA0LjY1NDkyIDkuMDI5NTIgNi4zMDk4MyA5LjI5NTc2QzcuOTY0NzUgOS41NjA3NCA5Ljg3ODM5IDguNTU1OCAxMC4yNjM0IDYuNDUwOTFDMTAuNjYwOSA0LjI4MjI3IDkuMDg5NjkgMy4wMjIzNCA3LjM5MzUzIDIuOTYxMDlaIiBmaWxsPSJ3aGl0ZSIvPgo8cGF0aCBkPSJNNy45NDIxNyA1LjkwMTE1QzcuOTQyMTcgNS45MDExNSA4LjM2OTY1IDUuODEyNCA4LjQ1NDY1IDUuMTgyNDRDOC41MzgzOSA0LjU2MjQ3IDguMjMwOTEgNC4wMzM3NSA3LjUxMzQ1IDMuODQzNzZDNi43MzM0OSAzLjYzNzUyIDYuMjA0NzcgNC4wNjYyNSA2LjA2NzI3IDQuNTE3NDdDNS44NzYwMyA1LjE0NDk0IDYuMTU4NTIgNS40NDM2NyA2LjE1ODUyIDUuNDQzNjdDNi4xNTg1MiA1LjQ0MzY3IDUuMzkzNTYgNS42Mjc0MSA1LjMzMjMxIDYuNTI5ODdDNS4yNzQ4MSA3LjM4MTA3IDUuODU2MDMgNy44Mzg1NSA2LjQzOTc1IDcuOTc4NTRDNy4xNjA5NiA4LjE1MjI4IDcuOTc4NDIgNy45NTQ3OSA4LjE3ODQxIDcuMDM0ODRDOC4zNDQ2NSA2LjI3NzM4IDcuOTQyMTcgNS45MDExNSA3Ljk0MjE3IDUuOTAxMTVaIiBmaWxsPSIjMzAzMDMwIi8+CjxwYXRoIGQ9Ik02LjczOTgzIDQuNzUzNjJDNi42NzEwOSA1LjAxMjM1IDYuODA4NTggNS4yNjIzNCA3LjA3ODU3IDUuMzMxMDlDNy4zNjk4IDUuNDA0ODMgNy42MzQ3OSA1LjMwODU5IDcuNzA2MDMgNS4wMTExQzcuNzY4NTMgNC43NDczNyA3LjY0MzU0IDQuNTE0ODggNy4zMzYwNSA0LjQzOTg4QzcuMDgzNTcgNC4zNzczOSA2LjgxNDgzIDQuNDcxMTMgNi43Mzk4MyA0Ljc1MzYyWiIgZmlsbD0id2hpdGUiLz4KPHBhdGggZD0iTTYuOTU5NzggNi4wMzk3NEM2LjYzMjMgNS45Mzg0OSA2LjE5OTgyIDYuMDY0NzMgNi4xMzEwNyA2LjUwNDcxQzYuMDYyMzMgNi45NDQ2OSA2LjMyNjA2IDcuMTY5NjggNi42NzEwNCA3LjIzMjE3QzcuMDE2MDMgNy4yOTQ2NyA3LjM0MjI2IDcuMTEzNDMgNy40MDYwMSA2Ljc2MDk1QzcuNDY4NSA2LjQwOTcyIDcuMjg2MDEgNi4xMzk3MyA2Ljk1OTc4IDYuMDM5NzRaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K","layout":[{"h":3,"i":"8c5325f2-e80e-4bb8-ae07-873a69f87185","moved":false,"static":false,"w":2,"x":0,"y":0},{"h":3,"i":"861abc64-ec28-48c1-9cc4-20dde2d7a6de","moved":false,"static":false,"w":2,"x":2,"y":0},{"h":3,"i":"15c734e6-0e53-4354-abff-fc2aafa3efbf","moved":false,"static":false,"w":2,"x":4,"y":0},{"h":5,"i":"3a983f6a-2c28-4254-a29c-56f7bafcf1d7","moved":false,"static":false,"w":4,"x":6,"y":0},{"h":6,"i":"46ec0c81-4974-4ad2-b8ff-cd176c162658","moved":false,"static":false,"w":6,"x":0,"y":3},{"h":6,"i":"0487e7d2-dfc0-4cb9-b6b6-059937ec123c","moved":false,"static":false,"w":6,"x":6,"y":5},{"h":6,"i":"f6848ddb-e62a-4855-b047-7563279bb8b8","moved":false,"static":false,"w":6,"x":0,"y":9},{"h":5,"i":"31bd2e96-09b9-479d-ad02-362366cad0c8","moved":false,"static":false,"w":6,"x":6,"y":11},{"h":3,"i":"15e1c411-c54a-49ea-832a-e3b947b0a589","moved":false,"static":false,"w":6,"x":0,"y":15},{"h":6,"i":"729b9d2d-6ae0-4ca2-9df8-1424c50205f5","moved":false,"static":false,"w":6,"x":6,"y":16}],"panelMap":{},"tags":[],"title":"Gemini Dashboard","uploadedGrafana":false,"variables":{"5d8f1d15-8f2d-464c-9681-8e6a0829ce64":{"allSelected":true,"customValue":"","defaultValue":"","description":"Gemini API SDK Languagelanguage","dynamicVariablesAttribute":"telemetry.sdk.language","dynamicVariablesSource":"All telemetry","id":"5d8f1d15-8f2d-464c-9681-8e6a0829ce64","modificationUUID":"db5edad5-b7fb-4706-9f8c-fb0498ec97da","multiSelect":true,"name":"Language","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"a804055f-a0c9-4af2-89db-fa831f2dd15a":{"allSelected":false,"customValue":"","defaultValue":"","description":"Gemini API llm model","dynamicVariablesAttribute":"llm.model_name","dynamicVariablesSource":"All telemetry","id":"a804055f-a0c9-4af2-89db-fa831f2dd15a","key":"a804055f-a0c9-4af2-89db-fa831f2dd15a","modificationUUID":"76b0324e-66bc-4895-bdf9-1f2449b4a9f3","multiSelect":true,"name":"llm_model","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"f5804749-8dd9-44ad-a141-fc357911c843":{"allSelected":false,"customValue":"","defaultValue":"","description":"Service name that is using Gemini API","dynamicVariablesAttribute":"service.name","dynamicVariablesSource":"All telemetry","id":"f5804749-8dd9-44ad-a141-fc357911c843","key":"f5804749-8dd9-44ad-a141-fc357911c843","modificationUUID":"289f968f-feb2-4552-8727-dbf6bcdb36e2","multiSelect":true,"name":"service_name","order":0,"queryValue":"SELECT DISTINCT serviceName \nFROM signoz_traces.distributed_signoz_index_v3\n","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"}},"version":"v5","widgets":[{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"46ec0c81-4974-4ad2-b8ff-cd176c162658","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(llm.token_count.total)"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name AND llm.model_name in $llm_model telemetry.sdk.language in $Language"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"Tokens","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"8a44bf9b-8532-42fd-b8d1-f5d1d3959c52","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Token Usage","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"f6848ddb-e62a-4855-b047-7563279bb8b8","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"p95(duration_nano) "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name AND llm.model_name in $llm_model telemetry.sdk.language in $Language"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"54c1166e-9e9d-4eab-bf5a-18be6e1d7d87","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Latency (p95)","yAxisUnit":"ns"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"customLegendColors":{},"description":"","fillSpans":false,"id":"3a983f6a-2c28-4254-a29c-56f7bafcf1d7","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name AND llm.provider = 'google'  AND llm.model_name EXISTS"},"filters":{"items":[{"id":"33425e3f-8512-449a-b55d-e912d9cf0888","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"44ab0b97-66bc-4a56-b494-48f78a5c4312","key":{"id":"llm.provider","key":"llm.provider","type":""},"op":"=","value":"google"},{"id":"100b0089-5419-42f9-b949-cee73c36acb6","key":{"id":"llm.model_name","key":"llm.model_name","type":""},"op":"exists","value":"undefined"}],"op":"AND"},"functions":[],"groupBy":[{"dataType":"string","id":"llm.model_name--string--tag","isColumn":false,"isJSON":false,"key":"llm.model_name","type":"tag"}],"having":{"expression":""},"legend":"{{llm.model_name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"0aceeb88-7ab6-4a0a-bec4-502e305f8ba5","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Model Distribution","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"8c5325f2-e80e-4bb8-ae07-873a69f87185","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(llm.token_count.prompt)"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name AND llm.model_name in $llm_model telemetry.sdk.language in $Language"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"1a685481-42b0-4872-a32d-0540107a688b","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Input Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"861abc64-ec28-48c1-9cc4-20dde2d7a6de","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(llm.token_count.completion)"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name AND llm.model_name in $llm_model telemetry.sdk.language in $Language"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"0ba83d61-5a24-4eb0-8ec6-d9ae8e2c510a","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Output Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A":""},"columnWidths":{"A":145,"service.name":145,"telemetry.sdk.language":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"15e1c411-c54a-49ea-832a-e3b947b0a589","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() as 'Count of Spans' "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"llm.provider = 'google' AND telemetry.sdk.language EXISTS"},"functions":[],"groupBy":[{"dataType":"string","id":"service.name--string--resource","isColumn":true,"isJSON":false,"key":"service.name","type":"resource"},{"dataType":"string","id":"telemetry.sdk.language--string--resource","isColumn":false,"isJSON":false,"key":"telemetry.sdk.language","type":"resource"}],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"f218c1fe-d8fe-4efe-8d21-a5623e219491","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Services and Languages Using Gemini","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"0487e7d2-dfc0-4cb9-b6b6-059937ec123c","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name IN '$service_name' AND llm.model_name in $llm_model telemetry.sdk.language in $Language"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"02d7a1c6-3398-4f9c-87d1-c7bfd1eea573","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Number of Requests","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"15c734e6-0e53-4354-abff-fc2aafa3efbf","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"A","filter":{"expression":"service.name IN $service_name and has_error = 'true'"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null},{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"B","filter":{"expression":"service.name = $service_name and has_error = 'false' "},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"B","source":"","stepInterval":null}],"queryFormulas":[{"disabled":false,"expression":"A / (A + B)","legend":"","queryName":"F1"}]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"0b3503e6-569f-4fd8-a0ce-668b98f4781c","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[{"index":"71b7b951-8d9c-4008-818e-fcddeffaa1c0","isEditEnabled":false,"keyIndex":0,"selectedGraph":"value","thresholdColor":"Red","thresholdFormat":"Text","thresholdLabel":"","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"percentunit","thresholdValue":10},{"index":"0f729fed-ac08-404f-ad6d-6fba65801155","isEditEnabled":false,"keyIndex":1,"selectedGraph":"value","thresholdColor":"Orange","thresholdFormat":"Text","thresholdLabel":"","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"percentunit","thresholdValue":5}],"timePreferance":"GLOBAL_TIME","title":"Error Rate","yAxisUnit":"percentunit"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"date":145,"duration_nano":145,"http_method":145,"name":145,"response_status_code":145,"service.name":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"31bd2e96-09b9-479d-ad02-362366cad0c8","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name and has_error = 'true'"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"}],"pageSize":10,"queryName":"A","selectColumns":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"source":"","stepInterval":null}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"d319b4e1-fca7-43a6-b04c-d807c4170df7","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Errors","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"729b9d2d-6ae0-4ca2-9df8-1424c50205f5","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"metricName":"http.client.duration.max","reduceTo":"avg","spaceAggregation":"avg","temporality":"","timeAggregation":"avg"}],"dataSource":"metrics","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name "},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"acfa95bd-4c67-4891-aa8e-8e66338c4212","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"HTTP Request Duration","yAxisUnit":"ms"}],"uuid":"01991143-648b-732a-af57-b22fc4c9df77"}
+{
+  "spec": {
+    "display": {
+      "name": "Gemini Dashboard",
+      "description": ""
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Language",
+            "description": "Gemini API SDK Languagelanguage"
+          },
+          "defaultValue": [
+            "ip-172-31-43-59"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "telemetry.sdk.language",
+              "signal": "all"
+            }
+          },
+          "name": "Language"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "llm_model",
+            "description": "Gemini API llm model"
+          },
+          "defaultValue": [
+            "gemini-1.5-pro-002",
+            "gemini-2.5-flash"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "llm.model_name",
+              "signal": "all"
+            }
+          },
+          "name": "llm_model"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "service_name",
+            "description": "Service name that is using Gemini API"
+          },
+          "defaultValue": [
+            "gemini-openinference"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "service.name",
+              "signal": "all"
+            }
+          },
+          "name": "service_name"
+        }
+      }
+    ],
+    "panels": {
+      "0487e7d2-dfc0-4cb9-b6b6-059937ec123c": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Number of Requests",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": null
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": false,
+                          "filter": {
+                            "expression": "service.name IN '$service_name' AND llm.model_name in $llm_model telemetry.sdk.language in $Language"
+                          },
+                          "groupBy": [
+                            {
+                              "name": "service.name",
+                              "signal": "",
+                              "fieldContext": "resource",
+                              "fieldDataType": "string"
+                            }
+                          ],
+                          "order": null,
+                          "selectFields": null,
+                          "secondaryAggregations": null,
+                          "functions": null,
+                          "legend": "{{service.name}}"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "15c734e6-0e53-4354-abff-fc2aafa3efbf": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Error Rate",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "percentunit",
+                "decimalPrecision": "2"
+              },
+              "thresholds": [
+                {
+                  "value": 10,
+                  "operator": "above",
+                  "unit": "percentunit",
+                  "color": "Red",
+                  "format": "text"
+                },
+                {
+                  "value": 5,
+                  "operator": "above",
+                  "unit": "percentunit",
+                  "color": "Orange",
+                  "format": "text"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "service.name IN $service_name and has_error = 'true'"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "service.name = $service_name and has_error = 'false' "
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "A / (A + B)",
+                          "disabled": false,
+                          "order": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "functions": null,
+                          "legend": ""
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "15e1c411-c54a-49ea-832a-e3b947b0a589": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Services and Languages Using Gemini",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A": ""
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()",
+                        "alias": "Count of Spans"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "llm.provider = 'google' AND telemetry.sdk.language EXISTS"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "telemetry.sdk.language",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "31bd2e96-09b9-479d-ad02-362366cad0c8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Errors",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "service.name",
+                  "signal": "traces",
+                  "fieldContext": "resource",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "name",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "duration_nano",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "http_method",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "response_status_code",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name and has_error = 'true'"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "name",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "duration_nano",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "http_method",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "response_status_code",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      }
+                    ],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "3a983f6a-2c28-4254-a29c-56f7bafcf1d7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Model Distribution",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": null
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name AND llm.provider = 'google'  AND llm.model_name EXISTS"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "llm.model_name",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{llm.model_name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "46ec0c81-4974-4ad2-b8ff-cd176c162658": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Token Usage",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": null
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "sum(llm.token_count.total)"
+                            }
+                          ],
+                          "disabled": false,
+                          "filter": {
+                            "expression": "service.name IN $service_name AND llm.model_name in $llm_model telemetry.sdk.language in $Language"
+                          },
+                          "groupBy": [
+                            {
+                              "name": "service.name",
+                              "signal": "traces",
+                              "fieldContext": "resource",
+                              "fieldDataType": "string"
+                            }
+                          ],
+                          "order": null,
+                          "selectFields": null,
+                          "secondaryAggregations": null,
+                          "functions": null,
+                          "legend": "{{service.name}}"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "729b9d2d-6ae0-4ca2-9df8-1424c50205f5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "HTTP Request Duration",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ms",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": null
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "metrics",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "metricName": "http.client.duration.max",
+                              "temporality": "",
+                              "timeAggregation": "avg",
+                              "spaceAggregation": "avg",
+                              "reduceTo": ""
+                            }
+                          ],
+                          "disabled": false,
+                          "filter": {
+                            "expression": "service.name in $service_name "
+                          },
+                          "groupBy": [
+                            {
+                              "name": "service.name",
+                              "signal": "metrics",
+                              "fieldContext": "resource",
+                              "fieldDataType": "string"
+                            }
+                          ],
+                          "order": null,
+                          "selectFields": null,
+                          "secondaryAggregations": null,
+                          "functions": null,
+                          "legend": "{{service.name}}"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "861abc64-ec28-48c1-9cc4-20dde2d7a6de": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Output Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(llm.token_count.completion)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name AND llm.model_name in $llm_model telemetry.sdk.language in $Language"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "8c5325f2-e80e-4bb8-ae07-873a69f87185": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Input Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(llm.token_count.prompt)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name AND llm.model_name in $llm_model telemetry.sdk.language in $Language"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "f6848ddb-e62a-4855-b047-7563279bb8b8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Latency (p95)",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ns",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": null
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "p95(duration_nano)"
+                            }
+                          ],
+                          "disabled": false,
+                          "filter": {
+                            "expression": "service.name IN $service_name AND llm.model_name in $llm_model telemetry.sdk.language in $Language"
+                          },
+                          "groupBy": [
+                            {
+                              "name": "service.name",
+                              "signal": "",
+                              "fieldContext": "resource",
+                              "fieldDataType": "string"
+                            }
+                          ],
+                          "order": null,
+                          "selectFields": null,
+                          "secondaryAggregations": null,
+                          "functions": null,
+                          "legend": "{{service.name}}"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 2,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/8c5325f2-e80e-4bb8-ae07-873a69f87185"
+              }
+            },
+            {
+              "x": 2,
+              "y": 0,
+              "width": 2,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/861abc64-ec28-48c1-9cc4-20dde2d7a6de"
+              }
+            },
+            {
+              "x": 4,
+              "y": 0,
+              "width": 2,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/15c734e6-0e53-4354-abff-fc2aafa3efbf"
+              }
+            },
+            {
+              "x": 6,
+              "y": 0,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/3a983f6a-2c28-4254-a29c-56f7bafcf1d7"
+              }
+            },
+            {
+              "x": 0,
+              "y": 3,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/46ec0c81-4974-4ad2-b8ff-cd176c162658"
+              }
+            },
+            {
+              "x": 6,
+              "y": 6,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/0487e7d2-dfc0-4cb9-b6b6-059937ec123c"
+              }
+            },
+            {
+              "x": 0,
+              "y": 9,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/f6848ddb-e62a-4855-b047-7563279bb8b8"
+              }
+            },
+            {
+              "x": 6,
+              "y": 18,
+              "width": 6,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/31bd2e96-09b9-479d-ad02-362366cad0c8"
+              }
+            },
+            {
+              "x": 0,
+              "y": 15,
+              "width": 6,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/15e1c411-c54a-49ea-832a-e3b947b0a589"
+              }
+            },
+            {
+              "x": 6,
+              "y": 12,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/729b9d2d-6ae0-4ca2-9df8-1424c50205f5"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "",
+    "refreshInterval": "",
+    "links": []
+  },
+  "tags": [],
+  "image": "/assets/Icons/eight-ball"
+}

--- a/grok/grok-dashboard.json
+++ b/grok/grok-dashboard.json
@@ -1,1 +1,1315 @@
-{"description":"","image":"data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE0Ljk0OTQgMTMuOTQyQzE2LjIzMTggMTIuNDI1OCAxNy4zMjY4IDkuNzAyMiAxNi4xOTU2IDYuNTc0ODdDMTUuNjQ0MyA1LjA1MjQ1IDE1LjAyMTkgNC4yMDI0OSAxNC4yOTY5IDMuNjYyNTJDMTMuODU1NyAzLjMzMzc5IDEyLjA5MzMgMi41MDYzMyA5Ljc1OTY1IDIuODY3NTZDOC4wNTM0OSAzLjEzMjU1IDUuNzc0ODcgNC4yMDg3NCA0LjI5MzY5IDUuOTU5OUMyLjg1NzUyIDcuNjYxMDYgMS43NDg4MyA5LjAwNDc0IDEuNjk3NTggMTAuMzA5N0MxLjYzMTMzIDExLjk4ODMgMi44OTYyNyAxMy40MzA4IDMuMDUwMDEgMTMuNjY0NUMzLjMyMzc0IDE0LjA3OTUgNS4xOTExNSAxNi40NTE4IDguNjk5NzEgMTYuNTczMUMxMS43OTcgMTYuNjc5MyAxMy44MTQ0IDE1LjI4NDQgMTQuOTQ5NCAxMy45NDJaIiBmaWxsPSIjNDAzRDNFIi8+CjxwYXRoIGQ9Ik00LjU1MzYzIDIuNzM3NDdDMi45Mzc0NiAzLjg5MTE2IDEuMTIxMzEgNi4yNTEwMyAxLjQ0NzU0IDkuNTYwODZDMS42MDYyOCAxMS4xNzIgMi4wMDI1MSAxMi4xNDk1IDIuNTcxMjMgMTIuODUwN0MyLjkxNzQ2IDEzLjI3ODIgNC40MTk4OCAxNC41NDkzIDYuNzczNTEgMTQuNzM2OEM5LjE0NTg4IDE0LjkyNTYgMTAuOTQ5NSAxNC4zOTQ0IDEyLjgzMzIgMTMuMDg0NEMxNi42NjE3IDEwLjQyMDggMTYuMDk4IDYuMzkzNTMgMTUuOTM0MyA1LjkyNDhDMTUuNzcwNSA1LjQ1NjA3IDE0LjU0NDQgMi42OTYyMiAxMS4xNzMzIDEuNzE1MDJDOC4xOTg0NCAwLjg1MDA2OCA1Ljk4MzU1IDEuNzE1MDIgNC41NTM2MyAyLjczNzQ3WiIgZmlsbD0iIzVFNjM2NyIvPgo8cGF0aCBkPSJNNy4zOTM1MyAyLjk2MTA5QzUuNjE3MzcgMi44OTczNCAzLjkxOTk2IDQuMjg4NTIgMy43NTYyMiA2LjAwNTkzQzMuNTkyNDggNy43MjIwOSA0LjY1NDkyIDkuMDI5NTIgNi4zMDk4MyA5LjI5NTc2QzcuOTY0NzUgOS41NjA3NCA5Ljg3ODM5IDguNTU1OCAxMC4yNjM0IDYuNDUwOTFDMTAuNjYwOSA0LjI4MjI3IDkuMDg5NjkgMy4wMjIzNCA3LjM5MzUzIDIuOTYxMDlaIiBmaWxsPSJ3aGl0ZSIvPgo8cGF0aCBkPSJNNy45NDIxNyA1LjkwMTE1QzcuOTQyMTcgNS45MDExNSA4LjM2OTY1IDUuODEyNCA4LjQ1NDY1IDUuMTgyNDRDOC41MzgzOSA0LjU2MjQ3IDguMjMwOTEgNC4wMzM3NSA3LjUxMzQ1IDMuODQzNzZDNi43MzM0OSAzLjYzNzUyIDYuMjA0NzcgNC4wNjYyNSA2LjA2NzI3IDQuNTE3NDdDNS44NzYwMyA1LjE0NDk0IDYuMTU4NTIgNS40NDM2NyA2LjE1ODUyIDUuNDQzNjdDNi4xNTg1MiA1LjQ0MzY3IDUuMzkzNTYgNS42Mjc0MSA1LjMzMjMxIDYuNTI5ODdDNS4yNzQ4MSA3LjM4MTA3IDUuODU2MDMgNy44Mzg1NSA2LjQzOTc1IDcuOTc4NTRDNy4xNjA5NiA4LjE1MjI4IDcuOTc4NDIgNy45NTQ3OSA4LjE3ODQxIDcuMDM0ODRDOC4zNDQ2NSA2LjI3NzM4IDcuOTQyMTcgNS45MDExNSA3Ljk0MjE3IDUuOTAxMTVaIiBmaWxsPSIjMzAzMDMwIi8+CjxwYXRoIGQ9Ik02LjczOTgzIDQuNzUzNjJDNi42NzEwOSA1LjAxMjM1IDYuODA4NTggNS4yNjIzNCA3LjA3ODU3IDUuMzMxMDlDNy4zNjk4IDUuNDA0ODMgNy42MzQ3OSA1LjMwODU5IDcuNzA2MDMgNS4wMTExQzcuNzY4NTMgNC43NDczNyA3LjY0MzU0IDQuNTE0ODggNy4zMzYwNSA0LjQzOTg4QzcuMDgzNTcgNC4zNzczOSA2LjgxNDgzIDQuNDcxMTMgNi43Mzk4MyA0Ljc1MzYyWiIgZmlsbD0id2hpdGUiLz4KPHBhdGggZD0iTTYuOTU5NzggNi4wMzk3NEM2LjYzMjMgNS45Mzg0OSA2LjE5OTgyIDYuMDY0NzMgNi4xMzEwNyA2LjUwNDcxQzYuMDYyMzMgNi45NDQ2OSA2LjMyNjA2IDcuMTY5NjggNi42NzEwNCA3LjIzMjE3QzcuMDE2MDMgNy4yOTQ2NyA3LjM0MjI2IDcuMTEzNDMgNy40MDYwMSA2Ljc2MDk1QzcuNDY4NSA2LjQwOTcyIDcuMjg2MDEgNi4xMzk3MyA2Ljk1OTc4IDYuMDM5NzRaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K","layout":[{"h":4,"i":"04247ee1-b408-457d-ac00-47ce45e64291","moved":false,"static":false,"w":3,"x":0,"y":0},{"h":4,"i":"d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570","moved":false,"static":false,"w":3,"x":3,"y":0},{"h":7,"i":"28409661-48e9-454c-ba5a-890e5268ef4e","moved":false,"static":false,"w":3,"x":6,"y":0},{"h":7,"i":"3633c7ad-203a-4e25-99f4-8cc81bf15d65","moved":false,"static":false,"w":3,"x":9,"y":0},{"h":3,"i":"01c76dbd-5af0-4dcc-9693-006d589112d5","moved":false,"static":false,"w":3,"x":0,"y":4},{"h":1,"i":"__dropping-elem__","isDraggable":true,"moved":false,"static":false,"w":1,"x":3,"y":4},{"h":3,"i":"799913e6-fb95-497e-858a-6490b5f9d10d","moved":false,"static":false,"w":3,"x":3,"y":5},{"h":5,"i":"af79b14b-5e76-47fb-a24e-a4629c642c28","moved":false,"static":false,"w":6,"x":6,"y":7},{"h":5,"i":"c0b61678-57d0-439f-8b7b-d7708442a53c","moved":false,"static":false,"w":6,"x":0,"y":8},{"h":5,"i":"74a94376-eeaf-43c1-a273-5d8b98197138","moved":false,"static":false,"w":6,"x":6,"y":12},{"h":5,"i":"28bb5d45-046d-4980-ad5e-26b1aeecda2b","moved":false,"static":false,"w":6,"x":0,"y":13},{"h":8,"i":"05e6759b-c460-4618-86c0-5d2bf0b311c1","moved":false,"static":false,"w":6,"x":6,"y":17},{"h":4,"i":"67a074ee-c46e-4a36-8f5c-10d981cae404","moved":false,"static":false,"w":6,"x":0,"y":18},{"h":5,"i":"5e66cb8c-2219-47e6-ba71-8f82f9873bc8","moved":false,"static":false,"w":6,"x":0,"y":22}],"panelMap":{},"tags":[],"title":"Grok","uploadedGrafana":false,"uuid":"019b67f6-8921-70f7-ab80-2d67f7300fcd","variables":{"10d0eca9-9253-4583-821c-d3c812d78151":{"allSelected":false,"customValue":"","defaultValue":"","description":"The service name using Grok","dynamicVariablesAttribute":"service.name","dynamicVariablesSource":"All telemetry","id":"10d0eca9-9253-4583-821c-d3c812d78151","key":"10d0eca9-9253-4583-821c-d3c812d78151","modificationUUID":"d324da6e-2b14-40b7-bf0a-8746d35cabb2","multiSelect":true,"name":"service_name","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"93c33118-5f46-404b-b45e-8a81160c44c4":{"allSelected":true,"customValue":"","defaultValue":"","description":"Language being used for making Grok calls","dynamicVariablesAttribute":"telemetry.sdk.language","dynamicVariablesSource":"All telemetry","id":"93c33118-5f46-404b-b45e-8a81160c44c4","key":"93c33118-5f46-404b-b45e-8a81160c44c4","modificationUUID":"bf30f33e-72c4-4546-98d2-6a845cd98cbc","multiSelect":true,"name":"language","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"be7a68c4-fb97-43ea-bb94-0ded120bd3d7":{"allSelected":true,"customValue":"","defaultValue":"","description":"LLM Model name being used for Grok","dynamicVariablesAttribute":"gen_ai.request.model","dynamicVariablesSource":"All telemetry","id":"be7a68c4-fb97-43ea-bb94-0ded120bd3d7","modificationUUID":"3d32a193-6f73-406a-9ae4-ce1975f2d08d","multiSelect":true,"name":"llm_model","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"}},"version":"v5","widgets":[{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"04247ee1-b408-457d-ac00-47ce45e64291","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.input_tokens) ) ) ) ) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND telemetry.sdk.language in $language AND  gen_ai.request.model  in $llm_model"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"148d19c1-5f9c-44d6-bc54-220a8321f9a5","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Input Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.output_tokens) ) ) ) ) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND telemetry.sdk.language in $language AND  gen_ai.request.model  in $llm_model"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"be2f496b-8879-4cdc-a048-bdf351b9e9f8","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Output Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"799913e6-fb95-497e-858a-6490b5f9d10d","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"A","filter":{"expression":"has_error = 'true' service.name in $service_name AND gen_ai.request.model IN $llm_model "},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null},{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"B","filter":{"expression":"has_error = 'false' service.name in $service_name AND gen_ai.request.model IN $llm_model "},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"B","source":"","stepInterval":null}],"queryFormulas":[{"disabled":false,"expression":"A / (A+B)","legend":"","queryName":"F1"}],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"68ee10e6-25cf-4631-9220-deba91b95570","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[{"index":"e5e05d41-7479-4d60-a1cf-c433b8b61285","isEditEnabled":false,"keyIndex":1,"selectedGraph":"value","thresholdColor":"Red","thresholdFormat":"Text","thresholdLabel":"","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"percentunit","thresholdValue":10},{"index":"d74bf17b-552a-4636-8fad-c976b090d590","isEditEnabled":false,"keyIndex":0,"selectedGraph":"value","thresholdColor":"Orange","thresholdFormat":"Text","thresholdLabel":"","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"percentunit","thresholdValue":5}],"timePreferance":"GLOBAL_TIME","title":"Error Rate","yAxisUnit":"percentunit"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"3633c7ad-203a-4e25-99f4-8cc81bf15d65","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND gen_ai.request.model EXISTS AND has_error = false"},"functions":[],"groupBy":[{"dataType":"string","id":"gen_ai.request.model--string--tag","isColumn":false,"isJSON":false,"key":"gen_ai.request.model","type":"tag"}],"having":{"expression":""},"legend":"{{gen_ai.request.model}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"5bc601ab-4225-4317-9fdf-ddc863321600","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Model Calls","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"F1":"#eccd03"},"decimalPrecision":2,"description":"","fillSpans":false,"id":"28bb5d45-046d-4980-ad5e-26b1aeecda2b","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.total_tokens) ) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND telemetry.sdk.language in $language AND gen_ai.request.model in $llm_model"},"functions":[],"groupBy":[{"dataType":"string","id":"service.name--string--resource","isColumn":true,"isJSON":false,"key":"service.name","type":"resource"}],"having":{"expression":""},"legend":"{{service.name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"fcca0878-7a36-4e17-8b09-5d62d7ca8ca5","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Token Usage","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"af79b14b-5e76-47fb-a24e-a4629c642c28","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"p95(duration_nano) "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND telemetry.sdk.language in $language AND gen_ai.request.model IN $llm_model "},"functions":[],"groupBy":[{"dataType":"string","id":"service.name--string--resource","isColumn":true,"isJSON":false,"key":"service.name","type":"resource"}],"having":{"expression":""},"legend":"{{service.name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"9c6a8373-7c37-4d76-a2fd-5287a122223e","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Request Duration (P95)","yAxisUnit":"ns"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"A":"#edce64","count()":"#a403ff"},"decimalPrecision":2,"description":"","fillSpans":false,"id":"74a94376-eeaf-43c1-a273-5d8b98197138","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND telemetry.sdk.language in $language AND gen_ai.request.model in $llm_model  "},"functions":[],"groupBy":[{"dataType":"string","id":"service.name--string--resource","isColumn":true,"isJSON":false,"key":"service.name","type":"resource"}],"having":{"expression":""},"legend":"{{service.name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"dd8853e1-d021-4ecf-80ac-1546a85c7590","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Number of Requests","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"date":145,"duration_nano":145,"http_method":145,"name":145,"response_status_code":145,"service.name":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"5e66cb8c-2219-47e6-ba71-8f82f9873bc8","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"has_error = 'true' service.name IN $service_name"},"filters":{"items":[{"id":"45f6077f-8492-46fe-b146-4a31f92cd1bd","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"cd7bce73-6b30-45bb-bd0a-0e93316a2ddd","key":{"id":"has_error","key":"has_error","type":""},"op":"=","value":"true"}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"}],"pageSize":10,"queryName":"A","selectColumns":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"b85f93b2-09b5-4fcd-8aa8-f6a2875a41b5","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Errors","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A":""},"columnWidths":{"A":145,"service.name":145,"telemetry.sdk.language":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"67a074ee-c46e-4a36-8f5c-10d981cae404","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() as 'Count' "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name AND gen_ai.request.model EXISTS "},"functions":[],"groupBy":[{"dataType":"string","id":"service.name--string--resource","isColumn":true,"isJSON":false,"key":"service.name","type":"resource"},{"dataType":"string","id":"telemetry.sdk.language--string--resource","isColumn":false,"isJSON":false,"key":"telemetry.sdk.language","type":"resource"}],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"b232e0fb-f5b6-4e7a-ad57-efa8f862086b","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Services and Languages","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"body":350,"timestamp":100},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"05e6759b-c460-4618-86c0-5d2bf0b311c1","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"logs","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name telemetry.sdk.language in $language"},"filters":{"items":[{"id":"14ee9f15-cd4f-453a-bc1f-90aa6c67ed49","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"ad1c34b3-c49a-43e3-8ff0-d54a4fd6b6db","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"},{"columnName":"id","order":"desc"}],"pageSize":10,"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"cf4892fd-86f1-4e83-a876-db114e6e125f","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Logs","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"01c76dbd-5af0-4dcc-9693-006d589112d5","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.input_tokens) )"}],"dataSource":"traces","disabled":true,"expression":"A","filter":{"expression":"service.name in $service_name AND telemetry.sdk.language in $language AND gen_ai.request.model in $llm_model"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null},{"aggregations":[{"expression":"sum(gen_ai.usage.cached_prompt_text_tokens) )"}],"dataSource":"traces","disabled":true,"expression":"B","filter":{"expression":"service.name in $service_name AND telemetry.sdk.language in $language AND gen_ai.request.model in $llm_model"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"B","source":"","stepInterval":null}],"queryFormulas":[{"disabled":false,"expression":"(B/A) * 100","legend":"","queryName":"F1"}],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"2f0417b5-028f-4024-8de8-2a01e73a0033","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Cache Utilization Rate","yAxisUnit":"percent"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"{llm.model_name=\"gpt-4.1-2025-04-14\"}":"#ce93ce","{llm.model_name=\"gpt-5-2025-08-07\"}":"#69aedd"},"decimalPrecision":2,"description":"","fillSpans":false,"id":"28409661-48e9-454c-ba5a-890e5268ef4e","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.total_tokens) ) ) "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name"},"functions":[],"groupBy":[{"dataType":"string","id":"gen_ai.request.model--string--tag","isColumn":false,"isJSON":false,"key":"gen_ai.request.model","type":"tag"}],"having":{"expression":""},"legend":"{{gen_ai.request.model}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"32b38b4b-f484-480c-9155-e441d2efbede","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Token Distribution by Models","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"c0b61678-57d0-439f-8b7b-d7708442a53c","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.input_tokens) )"}],"dataSource":"traces","disabled":true,"expression":"A","filter":{"expression":"service.name in $service_name AND telemetry.sdk.language in $language AND gen_ai.request.model in $llm_model"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null},{"aggregations":[{"expression":"sum(gen_ai.usage.cached_prompt_text_tokens) )"}],"dataSource":"traces","disabled":true,"expression":"B","filter":{"expression":"service.name in $service_name AND telemetry.sdk.language in $language AND gen_ai.request.model in $llm_model"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"B","source":"","stepInterval":null}],"queryFormulas":[{"disabled":false,"expression":"(B/A) * 100","legend":"Cache Util Rate(%)","queryName":"F1"}],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"925b2c5f-2d79-4da7-aa8d-c84b4ff49656","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Cache Utilization Rate","yAxisUnit":"percent"}]}
+{
+  "spec": {
+    "display": {
+      "name": "Grok",
+      "description": ""
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "service_name",
+            "description": "The service name using Grok"
+          },
+          "defaultValue": [
+            "llm-app",
+            "planner-app",
+            "grok-otel"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "service.name",
+              "signal": "all"
+            }
+          },
+          "name": "service_name"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "language",
+            "description": "Language being used for making Grok calls"
+          },
+          "defaultValue": [
+            "python"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "telemetry.sdk.language",
+              "signal": "all"
+            }
+          },
+          "name": "language"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "llm_model",
+            "description": "LLM Model name being used for Grok"
+          },
+          "defaultValue": [
+            "grok-4"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "gen_ai.request.model",
+              "signal": "all"
+            }
+          },
+          "name": "llm_model"
+        }
+      }
+    ],
+    "panels": {
+      "01c76dbd-5af0-4dcc-9693-006d589112d5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cache Utilization Rate",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "percent",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "sum(gen_ai.usage.input_tokens)"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "service.name in $service_name AND telemetry.sdk.language in $language AND gen_ai.request.model in $llm_model"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "sum(gen_ai.usage.cached_prompt_text_tokens)"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "service.name in $service_name AND telemetry.sdk.language in $language AND gen_ai.request.model in $llm_model"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "(B/A) * 100",
+                          "disabled": false,
+                          "order": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "functions": null,
+                          "legend": ""
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "04247ee1-b408-457d-ac00-47ce45e64291": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Input Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(gen_ai.usage.input_tokens)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND telemetry.sdk.language in $language AND  gen_ai.request.model  in $llm_model"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "05e6759b-c460-4618-86c0-5d2bf0b311c1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Logs",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "timestamp",
+                  "signal": "logs",
+                  "fieldContext": "log",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "body",
+                  "signal": "logs",
+                  "fieldContext": "log",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "logs",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name telemetry.sdk.language in $language"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "28409661-48e9-454c-ba5a-890e5268ef4e": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Token Distribution by Models",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "{llm.model_name=\"gpt-4.1-2025-04-14\"}": "#ce93ce",
+                  "{llm.model_name=\"gpt-5-2025-08-07\"}": "#69aedd"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(gen_ai.usage.total_tokens)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "gen_ai.request.model",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{gen_ai.request.model}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "28bb5d45-046d-4980-ad5e-26b1aeecda2b": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Token Usage",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "F1": "#eccd03"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(gen_ai.usage.total_tokens)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND telemetry.sdk.language in $language AND gen_ai.request.model in $llm_model"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "3633c7ad-203a-4e25-99f4-8cc81bf15d65": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Model Calls",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": null
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND gen_ai.request.model EXISTS AND has_error = false"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "gen_ai.request.model",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{gen_ai.request.model}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "5e66cb8c-2219-47e6-ba71-8f82f9873bc8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Errors",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "service.name",
+                  "signal": "traces",
+                  "fieldContext": "resource",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "name",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "duration_nano",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "http_method",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "response_status_code",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "has_error = 'true' service.name IN $service_name"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "name",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "duration_nano",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "http_method",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "response_status_code",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      }
+                    ],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "67a074ee-c46e-4a36-8f5c-10d981cae404": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Services and Languages",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A": ""
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()",
+                        "alias": "Count"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name AND gen_ai.request.model EXISTS "
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "telemetry.sdk.language",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "74a94376-eeaf-43c1-a273-5d8b98197138": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Number of Requests",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "A": "#edce64",
+                  "count()": "#a403ff"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND telemetry.sdk.language in $language AND gen_ai.request.model in $llm_model  "
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "799913e6-fb95-497e-858a-6490b5f9d10d": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Error Rate",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "percentunit",
+                "decimalPrecision": "2"
+              },
+              "thresholds": [
+                {
+                  "value": 10,
+                  "operator": "above",
+                  "unit": "percentunit",
+                  "color": "Red",
+                  "format": "text"
+                },
+                {
+                  "value": 5,
+                  "operator": "above",
+                  "unit": "percentunit",
+                  "color": "Orange",
+                  "format": "text"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "has_error = 'true' service.name in $service_name AND gen_ai.request.model IN $llm_model "
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "has_error = 'false' service.name in $service_name AND gen_ai.request.model IN $llm_model "
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "A / (A+B)",
+                          "disabled": false,
+                          "order": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "functions": null,
+                          "legend": ""
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "af79b14b-5e76-47fb-a24e-a4629c642c28": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Request Duration (P95)",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ns",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": null
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "p95(duration_nano)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND telemetry.sdk.language in $language AND gen_ai.request.model IN $llm_model "
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "c0b61678-57d0-439f-8b7b-d7708442a53c": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cache Utilization Rate",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "percent",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": null
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "sum(gen_ai.usage.input_tokens)"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "service.name in $service_name AND telemetry.sdk.language in $language AND gen_ai.request.model in $llm_model"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "sum(gen_ai.usage.cached_prompt_text_tokens)"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "service.name in $service_name AND telemetry.sdk.language in $language AND gen_ai.request.model in $llm_model"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "(B/A) * 100",
+                          "disabled": false,
+                          "order": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "functions": null,
+                          "legend": "Cache Util Rate(%)"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Output Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(gen_ai.usage.output_tokens)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND telemetry.sdk.language in $language AND  gen_ai.request.model  in $llm_model"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 3,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/04247ee1-b408-457d-ac00-47ce45e64291"
+              }
+            },
+            {
+              "x": 3,
+              "y": 0,
+              "width": 3,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570"
+              }
+            },
+            {
+              "x": 6,
+              "y": 0,
+              "width": 3,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/28409661-48e9-454c-ba5a-890e5268ef4e"
+              }
+            },
+            {
+              "x": 9,
+              "y": 0,
+              "width": 3,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/3633c7ad-203a-4e25-99f4-8cc81bf15d65"
+              }
+            },
+            {
+              "x": 0,
+              "y": 4,
+              "width": 3,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/01c76dbd-5af0-4dcc-9693-006d589112d5"
+              }
+            },
+            {
+              "x": 3,
+              "y": 4,
+              "width": 3,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/799913e6-fb95-497e-858a-6490b5f9d10d"
+              }
+            },
+            {
+              "x": 6,
+              "y": 7,
+              "width": 6,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/af79b14b-5e76-47fb-a24e-a4629c642c28"
+              }
+            },
+            {
+              "x": 0,
+              "y": 7,
+              "width": 6,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/c0b61678-57d0-439f-8b7b-d7708442a53c"
+              }
+            },
+            {
+              "x": 6,
+              "y": 12,
+              "width": 6,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/74a94376-eeaf-43c1-a273-5d8b98197138"
+              }
+            },
+            {
+              "x": 0,
+              "y": 12,
+              "width": 6,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/28bb5d45-046d-4980-ad5e-26b1aeecda2b"
+              }
+            },
+            {
+              "x": 6,
+              "y": 17,
+              "width": 6,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/05e6759b-c460-4618-86c0-5d2bf0b311c1"
+              }
+            },
+            {
+              "x": 0,
+              "y": 17,
+              "width": 6,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/67a074ee-c46e-4a36-8f5c-10d981cae404"
+              }
+            },
+            {
+              "x": 0,
+              "y": 22,
+              "width": 6,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/5e66cb8c-2219-47e6-ba71-8f82f9873bc8"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "",
+    "refreshInterval": "",
+    "links": []
+  },
+  "tags": [],
+  "image": "/assets/Icons/eight-ball"
+}

--- a/groq/groq-dashboard.json
+++ b/groq/groq-dashboard.json
@@ -1,1 +1,1186 @@
-{"description":"","image":"data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE0Ljk0OTQgMTMuOTQyQzE2LjIzMTggMTIuNDI1OCAxNy4zMjY4IDkuNzAyMiAxNi4xOTU2IDYuNTc0ODdDMTUuNjQ0MyA1LjA1MjQ1IDE1LjAyMTkgNC4yMDI0OSAxNC4yOTY5IDMuNjYyNTJDMTMuODU1NyAzLjMzMzc5IDEyLjA5MzMgMi41MDYzMyA5Ljc1OTY1IDIuODY3NTZDOC4wNTM0OSAzLjEzMjU1IDUuNzc0ODcgNC4yMDg3NCA0LjI5MzY5IDUuOTU5OUMyLjg1NzUyIDcuNjYxMDYgMS43NDg4MyA5LjAwNDc0IDEuNjk3NTggMTAuMzA5N0MxLjYzMTMzIDExLjk4ODMgMi44OTYyNyAxMy40MzA4IDMuMDUwMDEgMTMuNjY0NUMzLjMyMzc0IDE0LjA3OTUgNS4xOTExNSAxNi40NTE4IDguNjk5NzEgMTYuNTczMUMxMS43OTcgMTYuNjc5MyAxMy44MTQ0IDE1LjI4NDQgMTQuOTQ5NCAxMy45NDJaIiBmaWxsPSIjNDAzRDNFIi8+CjxwYXRoIGQ9Ik00LjU1MzYzIDIuNzM3NDdDMi45Mzc0NiAzLjg5MTE2IDEuMTIxMzEgNi4yNTEwMyAxLjQ0NzU0IDkuNTYwODZDMS42MDYyOCAxMS4xNzIgMi4wMDI1MSAxMi4xNDk1IDIuNTcxMjMgMTIuODUwN0MyLjkxNzQ2IDEzLjI3ODIgNC40MTk4OCAxNC41NDkzIDYuNzczNTEgMTQuNzM2OEM5LjE0NTg4IDE0LjkyNTYgMTAuOTQ5NSAxNC4zOTQ0IDEyLjgzMzIgMTMuMDg0NEMxNi42NjE3IDEwLjQyMDggMTYuMDk4IDYuMzkzNTMgMTUuOTM0MyA1LjkyNDhDMTUuNzcwNSA1LjQ1NjA3IDE0LjU0NDQgMi42OTYyMiAxMS4xNzMzIDEuNzE1MDJDOC4xOTg0NCAwLjg1MDA2OCA1Ljk4MzU1IDEuNzE1MDIgNC41NTM2MyAyLjczNzQ3WiIgZmlsbD0iIzVFNjM2NyIvPgo8cGF0aCBkPSJNNy4zOTM1MyAyLjk2MTA5QzUuNjE3MzcgMi44OTczNCAzLjkxOTk2IDQuMjg4NTIgMy43NTYyMiA2LjAwNTkzQzMuNTkyNDggNy43MjIwOSA0LjY1NDkyIDkuMDI5NTIgNi4zMDk4MyA5LjI5NTc2QzcuOTY0NzUgOS41NjA3NCA5Ljg3ODM5IDguNTU1OCAxMC4yNjM0IDYuNDUwOTFDMTAuNjYwOSA0LjI4MjI3IDkuMDg5NjkgMy4wMjIzNCA3LjM5MzUzIDIuOTYxMDlaIiBmaWxsPSJ3aGl0ZSIvPgo8cGF0aCBkPSJNNy45NDIxNyA1LjkwMTE1QzcuOTQyMTcgNS45MDExNSA4LjM2OTY1IDUuODEyNCA4LjQ1NDY1IDUuMTgyNDRDOC41MzgzOSA0LjU2MjQ3IDguMjMwOTEgNC4wMzM3NSA3LjUxMzQ1IDMuODQzNzZDNi43MzM0OSAzLjYzNzUyIDYuMjA0NzcgNC4wNjYyNSA2LjA2NzI3IDQuNTE3NDdDNS44NzYwMyA1LjE0NDk0IDYuMTU4NTIgNS40NDM2NyA2LjE1ODUyIDUuNDQzNjdDNi4xNTg1MiA1LjQ0MzY3IDUuMzkzNTYgNS42Mjc0MSA1LjMzMjMxIDYuNTI5ODdDNS4yNzQ4MSA3LjM4MTA3IDUuODU2MDMgNy44Mzg1NSA2LjQzOTc1IDcuOTc4NTRDNy4xNjA5NiA4LjE1MjI4IDcuOTc4NDIgNy45NTQ3OSA4LjE3ODQxIDcuMDM0ODRDOC4zNDQ2NSA2LjI3NzM4IDcuOTQyMTcgNS45MDExNSA3Ljk0MjE3IDUuOTAxMTVaIiBmaWxsPSIjMzAzMDMwIi8+CjxwYXRoIGQ9Ik02LjczOTgzIDQuNzUzNjJDNi42NzEwOSA1LjAxMjM1IDYuODA4NTggNS4yNjIzNCA3LjA3ODU3IDUuMzMxMDlDNy4zNjk4IDUuNDA0ODMgNy42MzQ3OSA1LjMwODU5IDcuNzA2MDMgNS4wMTExQzcuNzY4NTMgNC43NDczNyA3LjY0MzU0IDQuNTE0ODggNy4zMzYwNSA0LjQzOTg4QzcuMDgzNTcgNC4zNzczOSA2LjgxNDgzIDQuNDcxMTMgNi43Mzk4MyA0Ljc1MzYyWiIgZmlsbD0id2hpdGUiLz4KPHBhdGggZD0iTTYuOTU5NzggNi4wMzk3NEM2LjYzMjMgNS45Mzg0OSA2LjE5OTgyIDYuMDY0NzMgNi4xMzEwNyA2LjUwNDcxQzYuMDYyMzMgNi45NDQ2OSA2LjMyNjA2IDcuMTY5NjggNi42NzEwNCA3LjIzMjE3QzcuMDE2MDMgNy4yOTQ2NyA3LjM0MjI2IDcuMTEzNDMgNy40MDYwMSA2Ljc2MDk1QzcuNDY4NSA2LjQwOTcyIDcuMjg2MDEgNi4xMzk3MyA2Ljk1OTc4IDYuMDM5NzRaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K","layout":[{"h":4,"i":"04247ee1-b408-457d-ac00-47ce45e64291","moved":false,"static":false,"w":3,"x":0,"y":0},{"h":4,"i":"d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570","moved":false,"static":false,"w":3,"x":3,"y":0},{"h":7,"i":"28409661-48e9-454c-ba5a-890e5268ef4e","moved":false,"static":false,"w":3,"x":6,"y":0},{"h":7,"i":"3633c7ad-203a-4e25-99f4-8cc81bf15d65","moved":false,"static":false,"w":3,"x":9,"y":0},{"h":3,"i":"799913e6-fb95-497e-858a-6490b5f9d10d","moved":false,"static":false,"w":6,"x":0,"y":4},{"h":5,"i":"28bb5d45-046d-4980-ad5e-26b1aeecda2b","moved":false,"static":false,"w":6,"x":0,"y":7},{"h":5,"i":"af79b14b-5e76-47fb-a24e-a4629c642c28","moved":false,"static":false,"w":6,"x":6,"y":7},{"h":5,"i":"0e68b48b-431c-4b52-b2f4-08ba521aa755","moved":false,"static":false,"w":6,"x":0,"y":12},{"h":5,"i":"74a94376-eeaf-43c1-a273-5d8b98197138","moved":false,"static":false,"w":6,"x":6,"y":12},{"h":4,"i":"67a074ee-c46e-4a36-8f5c-10d981cae404","moved":false,"static":false,"w":6,"x":0,"y":17},{"h":8,"i":"05e6759b-c460-4618-86c0-5d2bf0b311c1","moved":false,"static":false,"w":6,"x":6,"y":17},{"h":5,"i":"5e66cb8c-2219-47e6-ba71-8f82f9873bc8","moved":false,"static":false,"w":6,"x":0,"y":21}],"panelMap":{},"tags":[],"title":"Groq","uploadedGrafana":false,"uuid":"019bdc84-4652-7436-af41-900f06bf05de","variables":{"10d0eca9-9253-4583-821c-d3c812d78151":{"allSelected":false,"customValue":"","defaultValue":"","description":"The service name using Groq","dynamicVariablesAttribute":"service.name","dynamicVariablesSource":"All telemetry","haveCustomValuesSelected":false,"id":"10d0eca9-9253-4583-821c-d3c812d78151","key":"10d0eca9-9253-4583-821c-d3c812d78151","modificationUUID":"6ff719c7-a633-4983-bf28-c554898abdb0","multiSelect":true,"name":"service_name","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"93c33118-5f46-404b-b45e-8a81160c44c4":{"allSelected":true,"customValue":"","defaultValue":"","description":"Language being used for making groq calls","dynamicVariablesAttribute":"telemetry.sdk.language","dynamicVariablesSource":"All telemetry","id":"93c33118-5f46-404b-b45e-8a81160c44c4","key":"93c33118-5f46-404b-b45e-8a81160c44c4","modificationUUID":"d5f501ad-f115-4401-a240-245d1f9bdfdc","multiSelect":true,"name":"language","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"be7a68c4-fb97-43ea-bb94-0ded120bd3d7":{"allSelected":true,"customValue":"","defaultValue":"","description":"LLM Model name being used for Groq","dynamicVariablesAttribute":"gen_ai.request.model","dynamicVariablesSource":"All telemetry","id":"be7a68c4-fb97-43ea-bb94-0ded120bd3d7","modificationUUID":"b7e05ea2-c8a3-4a7c-afa7-a8051dcf5247","multiSelect":true,"name":"llm_model","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"}},"version":"v5","widgets":[{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"04247ee1-b408-457d-ac00-47ce45e64291","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(llm.token_count.prompt) ) ) ) ) ) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND telemetry.sdk.language in $language AND  llm.model_name   in $llm_model"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"3ae51395-6a0c-44c9-b078-204de094eedb","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Input Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(llm.token_count.completion) ) ) ) ) ) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND telemetry.sdk.language in $language AND  llm.model_name   in $llm_model"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"df8ab838-3301-4a3b-be11-355c91b73cb5","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Output Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"799913e6-fb95-497e-858a-6490b5f9d10d","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"A","filter":{"expression":"has_error = 'true' service.name in $service_name AND gen_ai.request.model IN $llm_model"},"filters":{"items":[{"id":"c8977f8d-3312-47ca-99e6-4b39c40820ca","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"26f85e2b-6a9e-419d-999d-bf92570d57c1","key":{"id":"has_error","key":"has_error","type":""},"op":"=","value":"true"},{"id":"ff1b161c-3a84-406f-97bc-d0fcae8fd4d6","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"in","value":["$llm_model"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null},{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"B","filter":{"expression":"has_error = 'false' service.name in $service_name AND gen_ai.request.model IN $llm_model"},"filters":{"items":[{"id":"c8977f8d-3312-47ca-99e6-4b39c40820ca","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"7eae92b2-adf7-470b-bc3f-a454bdd7d5fd","key":{"id":"has_error","key":"has_error","type":""},"op":"=","value":"false"},{"id":"dc499d48-0620-474c-9225-908e27b5ac7e","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"in","value":["$llm_model"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"B","source":"","stepInterval":null}],"queryFormulas":[{"disabled":false,"expression":"A / (A+B)","legend":"","queryName":"F1"}],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"68ee10e6-25cf-4631-9220-deba91b95570","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[{"index":"e5e05d41-7479-4d60-a1cf-c433b8b61285","isEditEnabled":false,"keyIndex":1,"selectedGraph":"value","thresholdColor":"Red","thresholdFormat":"Text","thresholdLabel":"","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"percentunit","thresholdValue":10},{"index":"d74bf17b-552a-4636-8fad-c976b090d590","isEditEnabled":false,"keyIndex":0,"selectedGraph":"value","thresholdColor":"Orange","thresholdFormat":"Text","thresholdLabel":"","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"percentunit","thresholdValue":5}],"timePreferance":"GLOBAL_TIME","title":"Error Rate","yAxisUnit":"percentunit"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"3633c7ad-203a-4e25-99f4-8cc81bf15d65","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND llm.model_name EXISTS AND has_error = false"},"functions":[],"groupBy":[{"dataType":"string","id":"llm.model_name--string--tag","isColumn":false,"isJSON":false,"key":"llm.model_name","type":"tag"}],"having":{"expression":""},"legend":"{{llm.model_name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"ecb2b59d-afb1-425e-8708-5f8ce4c63ef3","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Model Calls","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"F1":"#eccd03"},"decimalPrecision":2,"description":"","fillSpans":false,"id":"28bb5d45-046d-4980-ad5e-26b1aeecda2b","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(llm.token_count.total) ) ) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND telemetry.sdk.language in $language AND llm.model_name  in $llm_model"},"functions":[],"groupBy":[{"dataType":"string","id":"service.name--string--resource","isColumn":true,"isJSON":false,"key":"service.name","type":"resource"}],"having":{"expression":""},"legend":"{{service.name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"a74213ef-942b-413c-a253-154b935e8845","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Token Usage","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"af79b14b-5e76-47fb-a24e-a4629c642c28","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"p95(duration_nano) "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND telemetry.sdk.language in $language AND llm.model_name  IN $llm_model "},"functions":[],"groupBy":[{"dataType":"string","id":"service.name--string--resource","isColumn":true,"isJSON":false,"key":"service.name","type":"resource"}],"having":{"expression":""},"legend":"{{service.name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"9c04c4e7-5ec3-4129-b579-70d3814a6bf6","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Request Duration (P95)","yAxisUnit":"ns"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"A":"#edce64","count()":"#a403ff"},"decimalPrecision":2,"description":"","fillSpans":false,"id":"74a94376-eeaf-43c1-a273-5d8b98197138","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND telemetry.sdk.language in $language AND gen_ai.request.model in $llm_model  "},"filters":{"items":[{"id":"c8977f8d-3312-47ca-99e6-4b39c40820ca","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"07903048-0293-4ec6-a884-07932b07c667","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]},{"id":"35abdb92-da0e-4e4b-ac13-042388a730b4","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"in","value":["$llm_model"]}],"op":"AND"},"functions":[],"groupBy":[{"dataType":"string","id":"service.name--string--resource","isColumn":true,"isJSON":false,"key":"service.name","type":"resource"}],"having":{"expression":""},"legend":"{{service.name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"dd8853e1-d021-4ecf-80ac-1546a85c7590","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Number of Requests","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"date":145,"duration_nano":145,"http_method":145,"name":145,"response_status_code":145,"service.name":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"5e66cb8c-2219-47e6-ba71-8f82f9873bc8","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"has_error = 'true' service.name IN $service_name"},"filters":{"items":[{"id":"45f6077f-8492-46fe-b146-4a31f92cd1bd","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"cd7bce73-6b30-45bb-bd0a-0e93316a2ddd","key":{"id":"has_error","key":"has_error","type":""},"op":"=","value":"true"}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"}],"pageSize":10,"queryName":"A","selectColumns":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"b85f93b2-09b5-4fcd-8aa8-f6a2875a41b5","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Errors","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A":""},"columnWidths":{"A":145,"service.name":145,"telemetry.sdk.language":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"67a074ee-c46e-4a36-8f5c-10d981cae404","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() as 'Count' "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name AND openinference.span.kind = 'LLM' \n"},"functions":[],"groupBy":[{"dataType":"string","id":"service.name--string--resource","isColumn":true,"isJSON":false,"key":"service.name","type":"resource"},{"dataType":"string","id":"telemetry.sdk.language--string--resource","isColumn":false,"isJSON":false,"key":"telemetry.sdk.language","type":"resource"}],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"1f1903f3-70f9-4b2b-abbf-e6d66978b32c","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Services and Languages","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"body":350,"timestamp":100},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"05e6759b-c460-4618-86c0-5d2bf0b311c1","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"logs","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name telemetry.sdk.language in $language"},"filters":{"items":[{"id":"14ee9f15-cd4f-453a-bc1f-90aa6c67ed49","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"ad1c34b3-c49a-43e3-8ff0-d54a4fd6b6db","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"},{"columnName":"id","order":"desc"}],"pageSize":10,"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"cf4892fd-86f1-4e83-a876-db114e6e125f","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Logs","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"{llm.model_name=\"gpt-4.1-2025-04-14\"}":"#ce93ce","{llm.model_name=\"gpt-5-2025-08-07\"}":"#69aedd"},"decimalPrecision":2,"description":"","fillSpans":false,"id":"28409661-48e9-454c-ba5a-890e5268ef4e","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(llm.token_count.total) ) ) "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name"},"functions":[],"groupBy":[{"dataType":"string","id":"llm.model_name--string--tag","isColumn":false,"isJSON":false,"key":"llm.model_name","type":"tag"}],"having":{"expression":""},"legend":"{{llm.model_name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"df10b92a-b710-4485-a3d5-f03df9a268ca","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Token Distribution by Models","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"F1":"#eccd03"},"decimalPrecision":2,"description":"","fillSpans":false,"id":"0e68b48b-431c-4b52-b2f4-08ba521aa755","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"metricName":"http.client.duration.max","reduceTo":"avg","spaceAggregation":"avg","temporality":"","timeAggregation":"avg"}],"dataSource":"metrics","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name "},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"http.client.duration","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"025c0425-ab38-4fbb-93ac-aaa7987ab392","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"HTTP Request Duration","yAxisUnit":"ms"}]}
+{
+  "spec": {
+    "display": {
+      "name": "Groq",
+      "description": ""
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "service_name",
+            "description": "The service name using Groq"
+          },
+          "defaultValue": [
+            "travel-app",
+            "assistant-app",
+            "research-app"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "service.name",
+              "signal": "all"
+            }
+          },
+          "name": "service_name"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "language",
+            "description": "Language being used for making groq calls"
+          },
+          "defaultValue": [
+            "python"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "telemetry.sdk.language",
+              "signal": "all"
+            }
+          },
+          "name": "language"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "llm_model",
+            "description": "LLM Model name being used for Groq"
+          },
+          "defaultValue": [
+            "llama-3.1-8b-instant",
+            "llama-3.3-70b-versatile",
+            "openai/gpt-oss-120b",
+            "openai/gpt-oss-20b",
+            "groq/compound-mini"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "gen_ai.request.model",
+              "signal": "all"
+            }
+          },
+          "name": "llm_model"
+        }
+      }
+    ],
+    "panels": {
+      "04247ee1-b408-457d-ac00-47ce45e64291": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Input Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(llm.token_count.prompt)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND telemetry.sdk.language in $language AND  llm.model_name   in $llm_model"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "05e6759b-c460-4618-86c0-5d2bf0b311c1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Logs",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "timestamp",
+                  "signal": "logs",
+                  "fieldContext": "log",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "body",
+                  "signal": "logs",
+                  "fieldContext": "log",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "logs",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name telemetry.sdk.language in $language"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "0e68b48b-431c-4b52-b2f4-08ba521aa755": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "HTTP Request Duration",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ms",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "assistant-app": "#8BD6E4",
+                  "research-app": "#E83095",
+                  "travel-app": "#E5D25D"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "metrics",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "metricName": "http.client.duration.max",
+                        "temporality": "",
+                        "timeAggregation": "avg",
+                        "spaceAggregation": "avg",
+                        "reduceTo": "avg"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name "
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "28409661-48e9-454c-ba5a-890e5268ef4e": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Token Distribution by Models",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "groq/compound-mini": "#5DE5B1",
+                  "llama-3.1-8b-instant": "#80E55D",
+                  "llama-3.3-70b-versatile": "#8E8BE4",
+                  "openai/gpt-oss-120b": "#E86C30",
+                  "openai/gpt-oss-20b": "#DC8BE4"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(llm.token_count.total)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "llm.model_name",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{llm.model_name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "28bb5d45-046d-4980-ad5e-26b1aeecda2b": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Token Usage",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "assistant-app": "#8BD6E4",
+                  "research-app": "#E83095",
+                  "travel-app": "#E5D25D"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(llm.token_count.total)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND telemetry.sdk.language in $language AND llm.model_name  in $llm_model"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "3633c7ad-203a-4e25-99f4-8cc81bf15d65": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Model Calls",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "groq/compound-mini": "#5DE5B1",
+                  "llama-3.1-8b-instant": "#80E55D",
+                  "llama-3.3-70b-versatile": "#8E8BE4",
+                  "openai/gpt-oss-120b": "#E86C30",
+                  "openai/gpt-oss-20b": "#DC8BE4"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND llm.model_name EXISTS AND has_error = false"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "llm.model_name",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{llm.model_name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "5e66cb8c-2219-47e6-ba71-8f82f9873bc8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Errors",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "service.name",
+                  "signal": "traces",
+                  "fieldContext": "resource",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "name",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "duration_nano",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "http_method",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "response_status_code",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "has_error = 'true' service.name IN $service_name"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "name",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "duration_nano",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "http_method",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "response_status_code",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      }
+                    ],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "67a074ee-c46e-4a36-8f5c-10d981cae404": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Services and Languages",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A": ""
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()",
+                        "alias": "Count"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name AND openinference.span.kind = 'LLM' \n"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "telemetry.sdk.language",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "74a94376-eeaf-43c1-a273-5d8b98197138": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Number of Requests",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "assistant-app": "#8BD6E4",
+                  "research-app": "#E83095",
+                  "travel-app": "#E5D25D"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND telemetry.sdk.language in $language AND gen_ai.request.model in $llm_model  "
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "799913e6-fb95-497e-858a-6490b5f9d10d": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Error Rate",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "percentunit",
+                "decimalPrecision": "2"
+              },
+              "thresholds": [
+                {
+                  "value": 10,
+                  "operator": "above",
+                  "unit": "percentunit",
+                  "color": "Red",
+                  "format": "text"
+                },
+                {
+                  "value": 5,
+                  "operator": "above",
+                  "unit": "percentunit",
+                  "color": "Orange",
+                  "format": "text"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "has_error = 'true' service.name in $service_name AND gen_ai.request.model IN $llm_model"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "has_error = 'false' service.name in $service_name AND gen_ai.request.model IN $llm_model"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "A / (A+B)",
+                          "disabled": false,
+                          "order": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "functions": null,
+                          "legend": ""
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "af79b14b-5e76-47fb-a24e-a4629c642c28": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Request Duration (P95)",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ns",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "assistant-app": "#8BD6E4",
+                  "research-app": "#E83095",
+                  "travel-app": "#E5D25D"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "p95(duration_nano)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND telemetry.sdk.language in $language AND llm.model_name  IN $llm_model "
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Output Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(llm.token_count.completion)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND telemetry.sdk.language in $language AND  llm.model_name   in $llm_model"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 3,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/04247ee1-b408-457d-ac00-47ce45e64291"
+              }
+            },
+            {
+              "x": 3,
+              "y": 0,
+              "width": 3,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570"
+              }
+            },
+            {
+              "x": 6,
+              "y": 0,
+              "width": 3,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/28409661-48e9-454c-ba5a-890e5268ef4e"
+              }
+            },
+            {
+              "x": 9,
+              "y": 0,
+              "width": 3,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/3633c7ad-203a-4e25-99f4-8cc81bf15d65"
+              }
+            },
+            {
+              "x": 0,
+              "y": 4,
+              "width": 6,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/799913e6-fb95-497e-858a-6490b5f9d10d"
+              }
+            },
+            {
+              "x": 0,
+              "y": 7,
+              "width": 6,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/28bb5d45-046d-4980-ad5e-26b1aeecda2b"
+              }
+            },
+            {
+              "x": 6,
+              "y": 7,
+              "width": 6,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/af79b14b-5e76-47fb-a24e-a4629c642c28"
+              }
+            },
+            {
+              "x": 0,
+              "y": 12,
+              "width": 6,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/0e68b48b-431c-4b52-b2f4-08ba521aa755"
+              }
+            },
+            {
+              "x": 6,
+              "y": 12,
+              "width": 6,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/74a94376-eeaf-43c1-a273-5d8b98197138"
+              }
+            },
+            {
+              "x": 0,
+              "y": 17,
+              "width": 6,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/67a074ee-c46e-4a36-8f5c-10d981cae404"
+              }
+            },
+            {
+              "x": 6,
+              "y": 17,
+              "width": 6,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/05e6759b-c460-4618-86c0-5d2bf0b311c1"
+              }
+            },
+            {
+              "x": 0,
+              "y": 21,
+              "width": 6,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/5e66cb8c-2219-47e6-ba71-8f82f9873bc8"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "",
+    "refreshInterval": "",
+    "links": []
+  },
+  "tags": [],
+  "image": "/assets/Icons/eight-ball"
+}

--- a/hermes/hermes-dashboard.json
+++ b/hermes/hermes-dashboard.json
@@ -1,1 +1,2416 @@
-{"description":"Comprehensive monitoring for the Hermes coding agent: agent sessions/turns, LLM API calls & token usage, tool-call activity, latency, and errors. Built from OTel traces (service: hermes-agent) using gen_ai.* and hermes.* span attributes. Panels are grouped top-to-bottom: Overview (scorecards), LLM/Model, Agent/Turns, Tool Calls, Errors.","layout":[{"h":3,"i":"sessions","moved":false,"static":false,"w":2,"x":0,"y":0},{"h":3,"i":"turns","moved":false,"static":false,"w":2,"x":2,"y":0},{"h":3,"i":"apicalls","moved":false,"static":false,"w":2,"x":4,"y":0},{"h":3,"i":"toolcalls","moved":false,"static":false,"w":2,"x":6,"y":0},{"h":3,"i":"totaltokens","moved":false,"static":false,"w":2,"x":8,"y":0},{"h":3,"i":"errorrate","moved":false,"static":false,"w":2,"x":10,"y":0},{"h":6,"i":"llm-calls-by-model","moved":false,"static":false,"w":6,"x":0,"y":3},{"h":6,"i":"llm-tokens-stacked","moved":false,"static":false,"w":6,"x":6,"y":3},{"h":6,"i":"llm-tokens-by-model","moved":false,"static":false,"w":6,"x":0,"y":9},{"h":6,"i":"agent-turn-latency","moved":false,"static":false,"w":6,"x":6,"y":9},{"h":6,"i":"llm-latency","moved":false,"static":false,"w":6,"x":0,"y":15},{"h":6,"i":"agent-api-per-turn","moved":false,"static":false,"w":6,"x":6,"y":15},{"h":6,"i":"llm-cost","moved":false,"static":false,"w":6,"x":0,"y":21},{"h":6,"i":"agent-session-kind","moved":false,"static":false,"w":6,"x":6,"y":21},{"h":6,"i":"llm-finish","moved":false,"static":false,"w":6,"x":0,"y":27},{"h":6,"i":"tool-latency","moved":false,"static":false,"w":6,"x":6,"y":27},{"h":6,"i":"agent-turns-time","moved":false,"static":false,"w":6,"x":0,"y":33},{"h":6,"i":"tool-genai-names","moved":false,"static":false,"w":6,"x":6,"y":33},{"h":6,"i":"agent-tools-per-turn","moved":false,"static":false,"w":6,"x":0,"y":39},{"h":6,"i":"tool-outcomes","moved":false,"static":false,"w":6,"x":6,"y":39},{"h":6,"i":"agent-final-status","moved":false,"static":false,"w":6,"x":0,"y":45},{"h":6,"i":"tool-calls-by-type","moved":false,"static":false,"w":6,"x":6,"y":45},{"h":6,"i":"tool-table","moved":false,"static":false,"w":12,"x":0,"y":51},{"h":6,"i":"errors-time","moved":false,"static":false,"w":6,"x":0,"y":57},{"h":6,"i":"errors-by-op","moved":false,"static":false,"w":6,"x":6,"y":57},{"h":7,"i":"recent-errors","moved":false,"static":false,"w":12,"x":0,"y":63}],"panelMap":{},"tags":["hermes","agent","llm","observability","traces"],"title":"Hermes Coding Agent — Observability","variables":{},"version":"v5","widgets":[{"contextLinks":{"linksData":[]},"description":"Count of root agent spans (turns/sessions)","id":"sessions","nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count()"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'hermes-agent' AND name = 'agent'"},"filters":{"items":[],"op":"AND"},"functions":[],"groupBy":[],"having":[],"legend":"sessions","orderBy":[],"queryName":"A","reduceTo":"sum","selectColumns":[],"stepInterval":60}],"queryFormulas":[]},"id":"7ac19859-eba2-47dd-90d2-a29c172e8e9e","queryType":"builder"},"selectedLogFields":[],"selectedTracesFields":[],"softMax":0,"softMin":0,"timePreferance":"GLOBAL_TIME","title":"Agent Turns"},{"contextLinks":{"linksData":[]},"description":"Count of llm.* wrapper spans","id":"turns","nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count()"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'hermes-agent' AND name LIKE 'llm.%'"},"filters":{"items":[],"op":"AND"},"functions":[],"groupBy":[],"having":[],"legend":"llm turns","orderBy":[],"queryName":"A","reduceTo":"sum","selectColumns":[],"stepInterval":60}],"queryFormulas":[]},"id":"7c822f98-bb00-412d-94f2-97a83a57252d","queryType":"builder"},"selectedLogFields":[],"selectedTracesFields":[],"softMax":0,"softMin":0,"timePreferance":"GLOBAL_TIME","title":"LLM Turns"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"Individual gen_ai chat completions","fillMode":"none","fillSpans":false,"id":"apicalls","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count()"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'hermes-agent' AND llm.model_name EXISTS"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"api calls","limit":null,"orderBy":[],"queryName":"A","selectColumns":[],"source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"d46c2049-1844-4b5f-bcb0-de1e3b388be3","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"LLM API Calls","yAxisUnit":"none"},{"contextLinks":{"linksData":[]},"description":"Count of tool.* spans","id":"toolcalls","nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count()"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'hermes-agent' AND name LIKE 'tool.%'"},"filters":{"items":[],"op":"AND"},"functions":[],"groupBy":[],"having":[],"legend":"tool calls","orderBy":[],"queryName":"A","reduceTo":"sum","selectColumns":[],"stepInterval":60}],"queryFormulas":[]},"id":"4922504b-8416-4079-8f3a-43268de6f99a","queryType":"builder"},"selectedLogFields":[],"selectedTracesFields":[],"softMax":0,"softMin":0,"timePreferance":"GLOBAL_TIME","title":"Tool Calls"},{"contextLinks":{"linksData":[]},"description":"Sum of gen_ai total tokens","id":"totaltokens","nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.total_tokens)"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'hermes-agent'"},"filters":{"items":[],"op":"AND"},"functions":[],"groupBy":[],"having":[],"legend":"total tokens","orderBy":[],"queryName":"A","reduceTo":"sum","selectColumns":[],"stepInterval":60}],"queryFormulas":[]},"id":"788ea110-5ece-4cc4-b257-586eb13b73f5","queryType":"builder"},"selectedLogFields":[],"selectedTracesFields":[],"softMax":0,"softMin":0,"timePreferance":"GLOBAL_TIME","title":"Total Tokens"},{"contextLinks":{"linksData":[]},"description":"Count of spans with hasError = true","id":"errorrate","nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count()"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'hermes-agent' AND hasError = true"},"filters":{"items":[],"op":"AND"},"functions":[],"groupBy":[],"having":[],"legend":"errors","orderBy":[],"queryName":"A","reduceTo":"sum","selectColumns":[],"stepInterval":60}],"queryFormulas":[]},"id":"119684c3-a90e-4c4a-b00d-43718fd60229","queryType":"builder"},"selectedLogFields":[],"selectedTracesFields":[],"softMax":0,"softMin":0,"thresholds":[{"index":"0","selectedGraph":"value","thresholdColor":"Red","thresholdFormat":"Text","thresholdOperator":">","thresholdUnit":"none","thresholdValue":0}],"timePreferance":"GLOBAL_TIME","title":"Error Spans"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"gpt-5.4-mini":"#e0750f","gpt-5.5":"#8fccce"},"decimalPrecision":2,"description":"Chat completion call count grouped by requested model","fillMode":"none","fillSpans":false,"id":"llm-calls-by-model","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count()"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'hermes-agent' AND llm.model_name EXISTS"},"functions":[],"groupBy":[{"dataType":"","id":"llm.model_name----","key":"llm.model_name","type":""}],"having":{"expression":""},"legend":"{{llm.model_name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"4a8dbe3d-0677-44ce-bac0-927bccccf93e","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"LLM API Calls by Model","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"input tokens":"#e9c8d0"},"decimalPrecision":2,"description":"Stacked token totals over time","fillMode":"none","fillSpans":false,"id":"llm-tokens-stacked","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.input_tokens)"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'hermes-agent'"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"input tokens","limit":null,"orderBy":[],"queryName":"A","selectColumns":[],"source":"","stepInterval":60},{"aggregations":[{"expression":"sum(gen_ai.usage.output_tokens)"}],"dataSource":"traces","disabled":false,"expression":"B","filter":{"expression":"service.name = 'hermes-agent'"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"output tokens","limit":null,"orderBy":[],"queryName":"B","selectColumns":[],"source":"","stepInterval":60},{"aggregations":[{"expression":"sum(gen_ai.usage.cache_read_input_tokens)"}],"dataSource":"traces","disabled":false,"expression":"C","filter":{"expression":"service.name = 'hermes-agent'"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"cache-read tokens","limit":null,"orderBy":[],"queryName":"C","selectColumns":[],"source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"17a1fdbc-f39f-4f73-abcf-446548ba380d","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Token Usage Over Time","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"Duration percentiles of chat completion spans","fillMode":"none","fillSpans":false,"id":"llm-latency","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"p50(durationNano)"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'hermes-agent' AND llm.model_name EXISTS"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"p50","limit":null,"orderBy":[],"queryName":"A","selectColumns":[],"source":"","stepInterval":60},{"aggregations":[{"expression":"p95(durationNano)"}],"dataSource":"traces","disabled":false,"expression":"B","filter":{"expression":"service.name = 'hermes-agent' AND llm.model_name EXISTS"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"p95","limit":null,"orderBy":[],"queryName":"B","selectColumns":[],"source":"","stepInterval":60},{"aggregations":[{"expression":"p99(durationNano)"}],"dataSource":"traces","disabled":false,"expression":"C","filter":{"expression":"service.name = 'hermes-agent' AND llm.model_name EXISTS"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"p99","limit":null,"orderBy":[],"queryName":"C","selectColumns":[],"source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"dd18f81f-a04d-4baf-900f-0dd17d005f6d","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"LLM API Call Latency (p50 / p95 / p99)","yAxisUnit":"ns"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"gpt-5.4-mini":"#e0750f","gpt-5.5":"#8fccce"},"decimalPrecision":2,"description":"Sum of total tokens grouped by model","fillMode":"none","fillSpans":false,"id":"llm-tokens-by-model","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.total_tokens)"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"  service.name = 'hermes-agent' llm.model_name EXISTS"},"functions":[],"groupBy":[{"dataType":"string","id":"llm.model_name--string--tag","isColumn":false,"isJSON":false,"key":"llm.model_name","type":"tag"}],"having":{"expression":""},"legend":"{{llm.model_name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"b943110d-222a-4f4b-ad05-3b3f57da84cf","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Total Tokens by Model","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"Token volume as a cost proxy by model — no native cost attribute exists; scale by your per-model pricing","fillMode":"none","fillSpans":false,"id":"llm-cost","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.input_tokens)"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'hermes-agent'"},"functions":[],"groupBy":[{"dataType":"string","id":"llm.model_name--string--tag","isColumn":false,"isJSON":false,"key":"llm.model_name","type":"tag"}],"having":{"expression":""},"legend":"in {{llm.model_name}}","limit":null,"orderBy":[],"queryName":"A","selectColumns":[],"source":"","stepInterval":60},{"aggregations":[{"expression":"sum(gen_ai.usage.output_tokens)"}],"dataSource":"traces","disabled":false,"expression":"B","filter":{"expression":"service.name = 'hermes-agent'"},"functions":[],"groupBy":[{"dataType":"","id":"llm.model_name----","key":"llm.model_name","type":""}],"having":{"expression":""},"legend":"out {{llm.model_name}}","limit":null,"orderBy":[],"queryName":"B","selectColumns":[],"source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"3fdb586a-97f7-4be2-ad3e-cc14be3f4a25","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Cost Proxy: Input vs Output Tokens by Model","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"stop":"#bacc5f"},"decimalPrecision":2,"description":"Distribution of gen_ai.response.finish_reasons","fillMode":"none","fillSpans":false,"id":"llm-finish","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count()"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'hermes-agent' AND llm.response.finish_reason EXISTS"},"functions":[],"groupBy":[{"dataType":"","id":"llm.response.finish_reason----","key":"llm.response.finish_reason","type":""}],"having":{"expression":""},"legend":"{{llm.response.finish_reason}}","limit":null,"orderBy":[],"queryName":"A","selectColumns":[],"source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"09b1a122-b28a-4a7f-a20f-e1a7a33ffb62","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Responses by Finish Reason","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"Root agent span count over time","fillMode":"none","fillSpans":false,"id":"agent-turns-time","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count()"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'hermes-agent' AND name = 'agent'"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"agent turns","limit":null,"orderBy":[],"queryName":"A","selectColumns":[],"source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"1a1a1fcc-d820-4b22-9097-722c63b6e832","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Agent Turns Over Time","yAxisUnit":"none"},{"contextLinks":{"linksData":[]},"description":"End-to-end agent turn latency","id":"agent-turn-latency","nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"p50(durationNano)"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'hermes-agent' AND name = 'agent'"},"filters":{"items":[],"op":"AND"},"functions":[],"groupBy":[],"having":[],"legend":"p50","orderBy":[],"queryName":"A","reduceTo":"avg","selectColumns":[],"stepInterval":60},{"aggregations":[{"expression":"p95(durationNano)"}],"dataSource":"traces","disabled":false,"expression":"B","filter":{"expression":"service.name = 'hermes-agent' AND name = 'agent'"},"filters":{"items":[],"op":"AND"},"functions":[],"groupBy":[],"having":[],"legend":"p95","orderBy":[],"queryName":"B","reduceTo":"avg","selectColumns":[],"stepInterval":60}],"queryFormulas":[]},"id":"11b780cc-ad89-4494-aad7-7033bf4b14a6","queryType":"builder"},"selectedLogFields":[],"selectedTracesFields":[],"softMax":0,"softMin":0,"timePreferance":"GLOBAL_TIME","title":"Agent Turn Duration (p50 / p95)","yAxisUnit":"ns"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"Average of hermes.turn.tool_count","fillMode":"none","fillSpans":false,"id":"agent-tools-per-turn","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"avg(hermes.turn.tool_count)"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'hermes-agent'"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"avg tools/turn","limit":null,"orderBy":[],"queryName":"A","selectColumns":[],"source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"9da5c4de-0a7f-48d2-bd30-788105ad707a","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Avg Tools per Turn","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillMode":"none","fillSpans":false,"id":"agent-api-per-turn","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"avg(hermes.turn.api_call_count)"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'hermes-agent' name = 'agent'"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"avg api calls/turn","limit":null,"orderBy":[],"queryName":"A","selectColumns":[],"source":"","stepInterval":60},{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"B","filter":{"expression":"service.name = 'hermes-agent' AND name = 'agent'"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"B","source":"","stepInterval":null}],"queryFormulas":[{"disabled":true,"expression":"A / B","legend":"avg api calls/turn","queryName":"F1"}]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"0587ffab-ce2e-4a20-a520-c0b0611f21a6","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Avg API Calls per Turn","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"Distribution of hermes.turn.final_status","fillMode":"none","fillSpans":false,"id":"agent-final-status","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count()"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'hermes-agent' AND hermes.turn.final_status EXISTS"},"functions":[],"groupBy":[{"dataType":"string","id":"hermes.turn.final_status--string--tag","key":"hermes.turn.final_status","type":"tag"}],"having":{"expression":""},"legend":"{{hermes.turn.final_status}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"8d827f76-e6c7-4d04-a39d-beb0f9c7ec52","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Turn Final Status","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"Grouped by hermes.session.kind","fillMode":"none","fillSpans":false,"id":"agent-session-kind","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count()"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'hermes-agent' AND hermes.session.kind EXISTS"},"functions":[],"groupBy":[{"dataType":"string","id":"hermes.session.kind--string--tag","key":"hermes.session.kind","type":"tag"}],"having":{"expression":""},"legend":"{{hermes.session.kind}}","limit":null,"orderBy":[],"queryName":"A","selectColumns":[],"source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"670e84f9-4037-481b-84a3-ac3a0cbc0489","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Sessions by Kind","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"tool.* span count grouped by operation name","fillMode":"none","fillSpans":false,"id":"tool-calls-by-type","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count()"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'hermes-agent' AND name LIKE 'tool.%'"},"functions":[],"groupBy":[{"dataType":"string","id":"name--string--","isColumn":true,"isJSON":false,"key":"name","type":""}],"having":{"expression":""},"legend":"{{name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"da43c70c-a6a4-4ba6-ba08-f01d93f0fe88","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Tool Calls by Type","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"p95 duration per tool","fillMode":"none","fillSpans":false,"id":"tool-latency","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"p95(durationNano)"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'hermes-agent' AND name LIKE 'tool.%'"},"functions":[],"groupBy":[{"dataType":"string","id":"name--string--","isColumn":true,"isJSON":false,"key":"name","type":""}],"having":{"expression":""},"legend":"{{name}}","limit":null,"orderBy":[],"queryName":"A","selectColumns":[],"source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"a0a7b7e3-a508-4511-95bf-96ad83f6c846","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Tool Call Latency (p95) by Type","yAxisUnit":"ns"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"Grouped by hermes.tool.outcome","fillMode":"none","fillSpans":false,"id":"tool-outcomes","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count()"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'hermes-agent' AND hermes.tool.outcome EXISTS"},"functions":[],"groupBy":[{"dataType":"string","id":"hermes.tool.outcome--string--tag","key":"hermes.tool.outcome","type":"tag"}],"having":{"expression":""},"legend":"{{hermes.tool.outcome}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"d9585ba1-8be9-48ac-8d07-3d88f71de708","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Tool Outcomes (completed vs error)","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"Grouped by gen_ai.tool.name (model-requested tools)","fillMode":"none","fillSpans":false,"id":"tool-genai-names","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count()"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'hermes-agent' AND name like 'tool%'"},"functions":[],"groupBy":[{"dataType":"","id":"tool.name----","key":"tool.name","type":""}],"having":{"expression":""},"legend":"{{tool.name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"7fe4407c-eaa2-4711-b10b-aa160f28afde","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"GenAI Tool Invocations by Name","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A":"","B":"ns"},"columnWidths":{"A":145,"B":145,"name":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"Count and p95 latency per tool type","fillMode":"none","fillSpans":false,"id":"tool-table","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count()"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'hermes-agent' AND name LIKE 'tool.%'"},"functions":[],"groupBy":[{"dataType":"string","id":"name--string--","isColumn":true,"isJSON":false,"key":"name","type":""}],"having":{"expression":""},"legend":"calls","limit":null,"orderBy":[{"columnName":"count()","order":"desc"}],"queryName":"A","selectColumns":[],"source":"","stepInterval":60},{"aggregations":[{"expression":"p95(durationNano)"}],"dataSource":"traces","disabled":false,"expression":"B","filter":{"expression":"service.name = 'hermes-agent' AND name LIKE 'tool.%'"},"functions":[],"groupBy":[{"dataType":"string","id":"name--string--","isColumn":true,"isJSON":false,"key":"name","type":""}],"having":{"expression":""},"legend":"p95 latency","limit":null,"orderBy":[],"queryName":"B","selectColumns":[],"source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"57f1af61-7c94-4d59-85da-ceb5afbcbb45","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Tool Usage Summary","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"Spans with hasError = true over time, by span name","fillMode":"none","fillSpans":false,"id":"errors-time","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count()"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'hermes-agent' AND hasError = true"},"functions":[],"groupBy":[{"dataType":"string","id":"name--string--","isColumn":true,"isJSON":false,"key":"name","type":""}],"having":{"expression":""},"legend":"{{name}}","limit":null,"orderBy":[],"queryName":"A","selectColumns":[],"source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"14936680-e0df-4ed7-bfa9-d57f59febcd0","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Errors Over Time","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A":""},"columnWidths":{"A":145,"name":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"Top failing span names","fillMode":"none","fillSpans":false,"id":"errors-by-op","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count()"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'hermes-agent' AND hasError = true"},"functions":[],"groupBy":[{"dataType":"string","id":"name--string--","isColumn":true,"isJSON":false,"key":"name","type":""}],"having":{"expression":""},"legend":"errors","limit":null,"orderBy":[{"columnName":"count()","order":"desc"}],"queryName":"A","selectColumns":[],"source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"89cbeb64-d1b7-4e36-97b4-efc2a5b7d5e4","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Error Count by Operation","yAxisUnit":"none"},{"columnWidths":{"date":145,"durationNano":145,"hermes.tool.outcome":145,"name":145,"statusMessage":145},"contextLinks":{"linksData":[]},"description":"Latest failing spans with status message","id":"recent-errors","nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":""}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = 'hermes-agent' AND hasError = true"},"filters":{"items":[],"op":"AND"},"functions":[],"groupBy":[],"having":[],"limit":25,"orderBy":[{"columnName":"timestamp","order":"desc"}],"pageSize":25,"queryName":"A","reduceTo":"sum","selectColumns":[],"stepInterval":60}],"queryFormulas":[]},"id":"6fe0a5e7-4451-4571-a883-91ad350b6b9b","queryType":"builder"},"selectedLogFields":[],"selectedTracesFields":[{"dataType":"string","key":"name","type":"tag"},{"dataType":"string","key":"statusMessage","type":"tag"},{"dataType":"string","key":"hermes.tool.outcome","type":"tag"},{"dataType":"number","key":"durationNano","type":"tag"}],"softMax":0,"softMin":0,"timePreferance":"GLOBAL_TIME","title":"Recent Error Spans"}],"uuid":"019eb3b8-673d-7738-9f5c-a31264dfbf77"}
+{
+  "spec": {
+    "display": {
+      "name": "Hermes Coding Agent — Observability",
+      "description": "Comprehensive monitoring for the Hermes coding agent: agent sessions/turns, LLM API calls & token usage, tool-call activity, latency, and errors. Built from OTel traces (service: hermes-agent) using gen_ai.* and hermes.* span attributes. Panels are grouped top-to-bottom: Overview (scorecards), LLM/Model, Agent/Turns, Tool Calls, Errors."
+    },
+    "variables": [],
+    "panels": {
+      "agent-api-per-turn": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Avg API Calls per Turn",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": null
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 60,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "avg(hermes.turn.api_call_count)"
+                            }
+                          ],
+                          "disabled": false,
+                          "filter": {
+                            "expression": "service.name = 'hermes-agent' name = 'agent'"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": [],
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": "avg api calls/turn"
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "service.name = 'hermes-agent' AND name = 'agent'"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "A / B",
+                          "disabled": true,
+                          "order": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "functions": null,
+                          "legend": "avg api calls/turn"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "agent-final-status": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Turn Final Status",
+            "description": "Distribution of hermes.turn.final_status"
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": null
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = 'hermes-agent' AND hermes.turn.final_status EXISTS"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "hermes.turn.final_status",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{hermes.turn.final_status}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "agent-session-kind": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Sessions by Kind",
+            "description": "Grouped by hermes.session.kind"
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": null
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = 'hermes-agent' AND hermes.session.kind EXISTS"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "hermes.session.kind",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "selectFields": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{hermes.session.kind}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "agent-tools-per-turn": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Avg Tools per Turn",
+            "description": "Average of hermes.turn.tool_count"
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": null
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "avg(hermes.turn.tool_count)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = 'hermes-agent'"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "avg tools/turn"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "agent-turn-latency": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Agent Turn Duration (p50 / p95)",
+            "description": "End-to-end agent turn latency"
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ns",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": null
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 60,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "p50(durationNano)"
+                            }
+                          ],
+                          "disabled": false,
+                          "filter": {
+                            "expression": "service.name = 'hermes-agent' AND name = 'agent'"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": [],
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": "p50"
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 60,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "p95(durationNano)"
+                            }
+                          ],
+                          "disabled": false,
+                          "filter": {
+                            "expression": "service.name = 'hermes-agent' AND name = 'agent'"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": [],
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": "p95"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "agent-turns-time": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Agent Turns Over Time",
+            "description": "Root agent span count over time"
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": null
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = 'hermes-agent' AND name = 'agent'"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "agent turns"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "apicalls": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "LLM API Calls",
+            "description": "Individual gen_ai chat completions"
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = 'hermes-agent' AND llm.model_name EXISTS"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "api calls"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "errorrate": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Error Spans",
+            "description": "Count of spans with hasError = true"
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "",
+                "decimalPrecision": "2"
+              },
+              "thresholds": [
+                {
+                  "value": 0,
+                  "operator": "above",
+                  "unit": "none",
+                  "color": "Red",
+                  "format": "text"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = 'hermes-agent' AND hasError = true"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "errors"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "errors-by-op": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Error Count by Operation",
+            "description": "Top failing span names"
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A": ""
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = 'hermes-agent' AND hasError = true"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "name",
+                        "signal": "",
+                        "fieldContext": "",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [
+                      {
+                        "key": {
+                          "name": "count()",
+                          "signal": "",
+                          "fieldContext": "",
+                          "fieldDataType": ""
+                        },
+                        "direction": "desc"
+                      }
+                    ],
+                    "selectFields": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "errors"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "errors-time": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Errors Over Time",
+            "description": "Spans with hasError = true over time, by span name"
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": null
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = 'hermes-agent' AND hasError = true"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "name",
+                        "signal": "",
+                        "fieldContext": "",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "selectFields": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "llm-calls-by-model": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "LLM API Calls by Model",
+            "description": "Chat completion call count grouped by requested model"
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "gpt-5.4-mini": "#e0750f",
+                  "gpt-5.5": "#8fccce"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = 'hermes-agent' AND llm.model_name EXISTS"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "llm.model_name",
+                        "signal": "",
+                        "fieldContext": "",
+                        "fieldDataType": ""
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{llm.model_name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "llm-cost": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cost Proxy: Input vs Output Tokens by Model",
+            "description": "Token volume as a cost proxy by model — no native cost attribute exists; scale by your per-model pricing"
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": null
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 60,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "sum(gen_ai.usage.input_tokens)"
+                            }
+                          ],
+                          "disabled": false,
+                          "filter": {
+                            "expression": "service.name = 'hermes-agent'"
+                          },
+                          "groupBy": [
+                            {
+                              "name": "llm.model_name",
+                              "signal": "",
+                              "fieldContext": "attribute",
+                              "fieldDataType": "string"
+                            }
+                          ],
+                          "order": [],
+                          "selectFields": [],
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": "in {{llm.model_name}}"
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 60,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "sum(gen_ai.usage.output_tokens)"
+                            }
+                          ],
+                          "disabled": false,
+                          "filter": {
+                            "expression": "service.name = 'hermes-agent'"
+                          },
+                          "groupBy": [
+                            {
+                              "name": "llm.model_name",
+                              "signal": "",
+                              "fieldContext": "",
+                              "fieldDataType": ""
+                            }
+                          ],
+                          "order": [],
+                          "selectFields": [],
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": "out {{llm.model_name}}"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "llm-finish": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Responses by Finish Reason",
+            "description": "Distribution of gen_ai.response.finish_reasons"
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "stop": "#bacc5f"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = 'hermes-agent' AND llm.response.finish_reason EXISTS"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "llm.response.finish_reason",
+                        "signal": "",
+                        "fieldContext": "",
+                        "fieldDataType": ""
+                      }
+                    ],
+                    "order": [],
+                    "selectFields": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{llm.response.finish_reason}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "llm-latency": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "LLM API Call Latency (p50 / p95 / p99)",
+            "description": "Duration percentiles of chat completion spans"
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ns",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": null
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 60,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "p50(durationNano)"
+                            }
+                          ],
+                          "disabled": false,
+                          "filter": {
+                            "expression": "service.name = 'hermes-agent' AND llm.model_name EXISTS"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": [],
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": "p50"
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 60,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "p95(durationNano)"
+                            }
+                          ],
+                          "disabled": false,
+                          "filter": {
+                            "expression": "service.name = 'hermes-agent' AND llm.model_name EXISTS"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": [],
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": "p95"
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "C",
+                          "stepInterval": 60,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "p99(durationNano)"
+                            }
+                          ],
+                          "disabled": false,
+                          "filter": {
+                            "expression": "service.name = 'hermes-agent' AND llm.model_name EXISTS"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": [],
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": "p99"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "llm-tokens-by-model": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total Tokens by Model",
+            "description": "Sum of total tokens grouped by model"
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "gpt-5.4-mini": "#e0750f",
+                  "gpt-5.5": "#8fccce"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(gen_ai.usage.total_tokens)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "  service.name = 'hermes-agent' llm.model_name EXISTS"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "llm.model_name",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{llm.model_name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "llm-tokens-stacked": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Token Usage Over Time",
+            "description": "Stacked token totals over time"
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "input tokens": "#e9c8d0"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 60,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "sum(gen_ai.usage.input_tokens)"
+                            }
+                          ],
+                          "disabled": false,
+                          "filter": {
+                            "expression": "service.name = 'hermes-agent'"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": [],
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": "input tokens"
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 60,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "sum(gen_ai.usage.output_tokens)"
+                            }
+                          ],
+                          "disabled": false,
+                          "filter": {
+                            "expression": "service.name = 'hermes-agent'"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": [],
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": "output tokens"
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "C",
+                          "stepInterval": 60,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "sum(gen_ai.usage.cache_read_input_tokens)"
+                            }
+                          ],
+                          "disabled": false,
+                          "filter": {
+                            "expression": "service.name = 'hermes-agent'"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": [],
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": "cache-read tokens"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "recent-errors": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Recent Error Spans",
+            "description": "Latest failing spans with status message"
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "name",
+                  "signal": "",
+                  "fieldContext": "attribute",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "statusMessage",
+                  "signal": "",
+                  "fieldContext": "attribute",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "hermes.tool.outcome",
+                  "signal": "",
+                  "fieldContext": "attribute",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "durationNano",
+                  "signal": "",
+                  "fieldContext": "attribute",
+                  "fieldDataType": "number"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = 'hermes-agent' AND hasError = true"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [],
+                    "limit": 25,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "sessions": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Agent Turns",
+            "description": "Count of root agent spans (turns/sessions)"
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = 'hermes-agent' AND name = 'agent'"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "sessions"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "tool-calls-by-type": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Tool Calls by Type",
+            "description": "tool.* span count grouped by operation name"
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": null
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = 'hermes-agent' AND name LIKE 'tool.%'"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "name",
+                        "signal": "",
+                        "fieldContext": "",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "tool-genai-names": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "GenAI Tool Invocations by Name",
+            "description": "Grouped by gen_ai.tool.name (model-requested tools)"
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": null
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = 'hermes-agent' AND name like 'tool%'"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "tool.name",
+                        "signal": "",
+                        "fieldContext": "",
+                        "fieldDataType": ""
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{tool.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "tool-latency": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Tool Call Latency (p95) by Type",
+            "description": "p95 duration per tool"
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ns",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": null
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "p95(durationNano)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = 'hermes-agent' AND name LIKE 'tool.%'"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "name",
+                        "signal": "",
+                        "fieldContext": "",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "selectFields": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "tool-outcomes": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Tool Outcomes (completed vs error)",
+            "description": "Grouped by hermes.tool.outcome"
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": null
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = 'hermes-agent' AND hermes.tool.outcome EXISTS"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "hermes.tool.outcome",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{hermes.tool.outcome}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "tool-table": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Tool Usage Summary",
+            "description": "Count and p95 latency per tool type"
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A": "",
+                  "B": "ns"
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 60,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": false,
+                          "filter": {
+                            "expression": "service.name = 'hermes-agent' AND name LIKE 'tool.%'"
+                          },
+                          "groupBy": [
+                            {
+                              "name": "name",
+                              "signal": "",
+                              "fieldContext": "",
+                              "fieldDataType": "string"
+                            }
+                          ],
+                          "order": [
+                            {
+                              "key": {
+                                "name": "count()",
+                                "signal": "",
+                                "fieldContext": "",
+                                "fieldDataType": ""
+                              },
+                              "direction": "desc"
+                            }
+                          ],
+                          "selectFields": [],
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": "calls"
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 60,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "p95(durationNano)"
+                            }
+                          ],
+                          "disabled": false,
+                          "filter": {
+                            "expression": "service.name = 'hermes-agent' AND name LIKE 'tool.%'"
+                          },
+                          "groupBy": [
+                            {
+                              "name": "name",
+                              "signal": "",
+                              "fieldContext": "",
+                              "fieldDataType": "string"
+                            }
+                          ],
+                          "order": [],
+                          "selectFields": [],
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": "p95 latency"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "toolcalls": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Tool Calls",
+            "description": "Count of tool.* spans"
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = 'hermes-agent' AND name LIKE 'tool.%'"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "tool calls"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "totaltokens": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total Tokens",
+            "description": "Sum of gen_ai total tokens"
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(gen_ai.usage.total_tokens)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = 'hermes-agent'"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "total tokens"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "turns": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "LLM Turns",
+            "description": "Count of llm.* wrapper spans"
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = 'hermes-agent' AND name LIKE 'llm.%'"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "llm turns"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 2,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/sessions"
+              }
+            },
+            {
+              "x": 2,
+              "y": 0,
+              "width": 2,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/turns"
+              }
+            },
+            {
+              "x": 4,
+              "y": 0,
+              "width": 2,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/apicalls"
+              }
+            },
+            {
+              "x": 6,
+              "y": 0,
+              "width": 2,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/toolcalls"
+              }
+            },
+            {
+              "x": 8,
+              "y": 0,
+              "width": 2,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/totaltokens"
+              }
+            },
+            {
+              "x": 10,
+              "y": 0,
+              "width": 2,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/errorrate"
+              }
+            },
+            {
+              "x": 0,
+              "y": 3,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/llm-calls-by-model"
+              }
+            },
+            {
+              "x": 6,
+              "y": 3,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/llm-tokens-stacked"
+              }
+            },
+            {
+              "x": 0,
+              "y": 9,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/llm-tokens-by-model"
+              }
+            },
+            {
+              "x": 6,
+              "y": 9,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/agent-turn-latency"
+              }
+            },
+            {
+              "x": 0,
+              "y": 15,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/llm-latency"
+              }
+            },
+            {
+              "x": 6,
+              "y": 15,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/agent-api-per-turn"
+              }
+            },
+            {
+              "x": 0,
+              "y": 21,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/llm-cost"
+              }
+            },
+            {
+              "x": 6,
+              "y": 21,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/agent-session-kind"
+              }
+            },
+            {
+              "x": 0,
+              "y": 27,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/llm-finish"
+              }
+            },
+            {
+              "x": 6,
+              "y": 27,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/tool-latency"
+              }
+            },
+            {
+              "x": 0,
+              "y": 33,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/agent-turns-time"
+              }
+            },
+            {
+              "x": 6,
+              "y": 33,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/tool-genai-names"
+              }
+            },
+            {
+              "x": 0,
+              "y": 39,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/agent-tools-per-turn"
+              }
+            },
+            {
+              "x": 6,
+              "y": 39,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/tool-outcomes"
+              }
+            },
+            {
+              "x": 0,
+              "y": 45,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/agent-final-status"
+              }
+            },
+            {
+              "x": 6,
+              "y": 45,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/tool-calls-by-type"
+              }
+            },
+            {
+              "x": 0,
+              "y": 51,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/tool-table"
+              }
+            },
+            {
+              "x": 0,
+              "y": 57,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/errors-time"
+              }
+            },
+            {
+              "x": 6,
+              "y": 57,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/errors-by-op"
+              }
+            },
+            {
+              "x": 0,
+              "y": 63,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/recent-errors"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "",
+    "refreshInterval": "",
+    "links": []
+  },
+  "tags": [
+    {
+      "key": "tag",
+      "value": "hermes"
+    },
+    {
+      "key": "tag",
+      "value": "agent"
+    },
+    {
+      "key": "tag",
+      "value": "llm"
+    },
+    {
+      "key": "tag",
+      "value": "observability"
+    },
+    {
+      "key": "tag",
+      "value": "traces"
+    }
+  ],
+  "image": ""
+}

--- a/inkeep/inkeep-dashboard.json
+++ b/inkeep/inkeep-dashboard.json
@@ -1,1 +1,1252 @@
-{"description":"","image":"data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE0Ljk0OTQgMTMuOTQyQzE2LjIzMTggMTIuNDI1OCAxNy4zMjY4IDkuNzAyMiAxNi4xOTU2IDYuNTc0ODdDMTUuNjQ0MyA1LjA1MjQ1IDE1LjAyMTkgNC4yMDI0OSAxNC4yOTY5IDMuNjYyNTJDMTMuODU1NyAzLjMzMzc5IDEyLjA5MzMgMi41MDYzMyA5Ljc1OTY1IDIuODY3NTZDOC4wNTM0OSAzLjEzMjU1IDUuNzc0ODcgNC4yMDg3NCA0LjI5MzY5IDUuOTU5OUMyLjg1NzUyIDcuNjYxMDYgMS43NDg4MyA5LjAwNDc0IDEuNjk3NTggMTAuMzA5N0MxLjYzMTMzIDExLjk4ODMgMi44OTYyNyAxMy40MzA4IDMuMDUwMDEgMTMuNjY0NUMzLjMyMzc0IDE0LjA3OTUgNS4xOTExNSAxNi40NTE4IDguNjk5NzEgMTYuNTczMUMxMS43OTcgMTYuNjc5MyAxMy44MTQ0IDE1LjI4NDQgMTQuOTQ5NCAxMy45NDJaIiBmaWxsPSIjNDAzRDNFIi8+CjxwYXRoIGQ9Ik00LjU1MzYzIDIuNzM3NDdDMi45Mzc0NiAzLjg5MTE2IDEuMTIxMzEgNi4yNTEwMyAxLjQ0NzU0IDkuNTYwODZDMS42MDYyOCAxMS4xNzIgMi4wMDI1MSAxMi4xNDk1IDIuNTcxMjMgMTIuODUwN0MyLjkxNzQ2IDEzLjI3ODIgNC40MTk4OCAxNC41NDkzIDYuNzczNTEgMTQuNzM2OEM5LjE0NTg4IDE0LjkyNTYgMTAuOTQ5NSAxNC4zOTQ0IDEyLjgzMzIgMTMuMDg0NEMxNi42NjE3IDEwLjQyMDggMTYuMDk4IDYuMzkzNTMgMTUuOTM0MyA1LjkyNDhDMTUuNzcwNSA1LjQ1NjA3IDE0LjU0NDQgMi42OTYyMiAxMS4xNzMzIDEuNzE1MDJDOC4xOTg0NCAwLjg1MDA2OCA1Ljk4MzU1IDEuNzE1MDIgNC41NTM2MyAyLjczNzQ3WiIgZmlsbD0iIzVFNjM2NyIvPgo8cGF0aCBkPSJNNy4zOTM1MyAyLjk2MTA5QzUuNjE3MzcgMi44OTczNCAzLjkxOTk2IDQuMjg4NTIgMy43NTYyMiA2LjAwNTkzQzMuNTkyNDggNy43MjIwOSA0LjY1NDkyIDkuMDI5NTIgNi4zMDk4MyA5LjI5NTc2QzcuOTY0NzUgOS41NjA3NCA5Ljg3ODM5IDguNTU1OCAxMC4yNjM0IDYuNDUwOTFDMTAuNjYwOSA0LjI4MjI3IDkuMDg5NjkgMy4wMjIzNCA3LjM5MzUzIDIuOTYxMDlaIiBmaWxsPSJ3aGl0ZSIvPgo8cGF0aCBkPSJNNy45NDIxNyA1LjkwMTE1QzcuOTQyMTcgNS45MDExNSA4LjM2OTY1IDUuODEyNCA4LjQ1NDY1IDUuMTgyNDRDOC41MzgzOSA0LjU2MjQ3IDguMjMwOTEgNC4wMzM3NSA3LjUxMzQ1IDMuODQzNzZDNi43MzM0OSAzLjYzNzUyIDYuMjA0NzcgNC4wNjYyNSA2LjA2NzI3IDQuNTE3NDdDNS44NzYwMyA1LjE0NDk0IDYuMTU4NTIgNS40NDM2NyA2LjE1ODUyIDUuNDQzNjdDNi4xNTg1MiA1LjQ0MzY3IDUuMzkzNTYgNS42Mjc0MSA1LjMzMjMxIDYuNTI5ODdDNS4yNzQ4MSA3LjM4MTA3IDUuODU2MDMgNy44Mzg1NSA2LjQzOTc1IDcuOTc4NTRDNy4xNjA5NiA4LjE1MjI4IDcuOTc4NDIgNy45NTQ3OSA4LjE3ODQxIDcuMDM0ODRDOC4zNDQ2NSA2LjI3NzM4IDcuOTQyMTcgNS45MDExNSA3Ljk0MjE3IDUuOTAxMTVaIiBmaWxsPSIjMzAzMDMwIi8+CjxwYXRoIGQ9Ik02LjczOTgzIDQuNzUzNjJDNi42NzEwOSA1LjAxMjM1IDYuODA4NTggNS4yNjIzNCA3LjA3ODU3IDUuMzMxMDlDNy4zNjk4IDUuNDA0ODMgNy42MzQ3OSA1LjMwODU5IDcuNzA2MDMgNS4wMTExQzcuNzY4NTMgNC43NDczNyA3LjY0MzU0IDQuNTE0ODggNy4zMzYwNSA0LjQzOTg4QzcuMDgzNTcgNC4zNzczOSA2LjgxNDgzIDQuNDcxMTMgNi43Mzk4MyA0Ljc1MzYyWiIgZmlsbD0id2hpdGUiLz4KPHBhdGggZD0iTTYuOTU5NzggNi4wMzk3NEM2LjYzMjMgNS45Mzg0OSA2LjE5OTgyIDYuMDY0NzMgNi4xMzEwNyA2LjUwNDcxQzYuMDYyMzMgNi45NDQ2OSA2LjMyNjA2IDcuMTY5NjggNi42NzEwNCA3LjIzMjE3QzcuMDE2MDMgNy4yOTQ2NyA3LjM0MjI2IDcuMTEzNDMgNy40MDYwMSA2Ljc2MDk1QzcuNDY4NSA2LjQwOTcyIDcuMjg2MDEgNi4xMzk3MyA2Ljk1OTc4IDYuMDM5NzRaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K","layout":[{"h":3,"i":"04247ee1-b408-457d-ac00-47ce45e64291","moved":false,"static":false,"w":3,"x":0,"y":0},{"h":3,"i":"d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570","moved":false,"static":false,"w":3,"x":3,"y":0},{"h":3,"i":"799913e6-fb95-497e-858a-6490b5f9d10d","moved":false,"static":false,"w":3,"x":6,"y":0},{"h":7,"i":"3633c7ad-203a-4e25-99f4-8cc81bf15d65","moved":false,"static":false,"w":3,"x":9,"y":0},{"h":1,"i":"__dropping-elem__","isDraggable":true,"moved":false,"static":false,"w":1,"x":0,"y":3},{"h":5,"i":"af79b14b-5e76-47fb-a24e-a4629c642c28","moved":false,"static":false,"w":5,"x":4,"y":3},{"h":5,"i":"28bb5d45-046d-4980-ad5e-26b1aeecda2b","moved":false,"static":false,"w":4,"x":0,"y":4},{"h":7,"i":"fa87c0ad-c744-4573-85b7-0c44ad738f90","moved":false,"static":false,"w":3,"x":9,"y":7},{"h":6,"i":"389d43de-99b1-4c35-9589-f7d969abaa9d","moved":false,"static":false,"w":5,"x":4,"y":8},{"h":6,"i":"74a94376-eeaf-43c1-a273-5d8b98197138","moved":false,"static":false,"w":4,"x":0,"y":9},{"h":5,"i":"05e6759b-c460-4618-86c0-5d2bf0b311c1","moved":false,"static":false,"w":6,"x":6,"y":14},{"h":5,"i":"5e66cb8c-2219-47e6-ba71-8f82f9873bc8","moved":false,"static":false,"w":6,"x":0,"y":15}],"panelMap":{},"tags":[],"title":"Inkeep","uploadedGrafana":false,"uuid":"019b2dde-4338-76f9-9b49-be30bff3a497","variables":{"10d0eca9-9253-4583-821c-d3c812d78151":{"allSelected":false,"customValue":"","defaultValue":"","description":"The service name using Inkeep","dynamicVariablesAttribute":"service.name","dynamicVariablesSource":"All telemetry","id":"10d0eca9-9253-4583-821c-d3c812d78151","key":"10d0eca9-9253-4583-821c-d3c812d78151","modificationUUID":"fcf90c7c-e1ce-448a-a7c4-2ea3bf75e2a0","multiSelect":true,"name":"service_name","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"6af0f1f2-deb5-4456-ba1f-a9426bda5269":{"allSelected":true,"customValue":"","defaultValue":"","description":"The name of the Agent being used in Inkeep","dynamicVariablesAttribute":"agent.id","dynamicVariablesSource":"All telemetry","id":"6af0f1f2-deb5-4456-ba1f-a9426bda5269","modificationUUID":"ea801a4f-716d-4a9e-8726-53f232091166","multiSelect":true,"name":"agent_name","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"be7a68c4-fb97-43ea-bb94-0ded120bd3d7":{"allSelected":true,"customValue":"","defaultValue":"","description":"Model name being used in Agno call","dynamicVariablesAttribute":"ai.model.id","dynamicVariablesSource":"All telemetry","id":"be7a68c4-fb97-43ea-bb94-0ded120bd3d7","key":"be7a68c4-fb97-43ea-bb94-0ded120bd3d7","modificationUUID":"7521033f-d14c-490a-85ba-e62d28ea5914","multiSelect":true,"name":"llm_model","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"}},"version":"v5","widgets":[{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"04247ee1-b408-457d-ac00-47ce45e64291","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(ai.usage.inputTokens) ) ) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND ai.model.id in $llm_model AND ai.operationId = 'ai.streamText' AND agent.id IN $agent_name "},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"29abb456-7780-409f-9dcb-73d2ca9bfbbf","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Input Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(ai.usage.outputTokens) ) ) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name ai.operationId = 'ai.streamText' AND agent.id IN $agent_name AND ai.model.id IN $llm_model  "},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"82e778aa-ad64-4d51-b402-443b14fed1ee","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Output Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"799913e6-fb95-497e-858a-6490b5f9d10d","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"A","filter":{"expression":"has_error = 'true' AND service.name in $service_name AND agent.id IN $agent_name "},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null},{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"B","filter":{"expression":"has_error = 'false' service.name in $service_name AND agent.id IN $agent_name "},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"B","source":"","stepInterval":null}],"queryFormulas":[{"disabled":false,"expression":"A / (A+B)","legend":"","queryName":"F1"}],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"d048675e-48d1-4a7b-8227-e8323e635e5a","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[{"index":"e5e05d41-7479-4d60-a1cf-c433b8b61285","isEditEnabled":false,"keyIndex":1,"selectedGraph":"value","thresholdColor":"Red","thresholdFormat":"Text","thresholdLabel":"","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"percentunit","thresholdValue":10},{"index":"d74bf17b-552a-4636-8fad-c976b090d590","isEditEnabled":false,"keyIndex":0,"selectedGraph":"value","thresholdColor":"Orange","thresholdFormat":"Text","thresholdLabel":"","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"percentunit","thresholdValue":5}],"timePreferance":"GLOBAL_TIME","title":"Error Rate","yAxisUnit":"percentunit"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"3633c7ad-203a-4e25-99f4-8cc81bf15d65","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND ai.operationId = 'ai.streamText'"},"filters":{"items":[],"op":"AND"},"functions":[],"groupBy":[{"dataType":"string","id":"ai.model.id--string--tag","isColumn":false,"isJSON":false,"key":"ai.model.id","type":"tag"}],"having":{"expression":""},"legend":"{{ai.model.id}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"25b8e6bd-3c24-4e39-b1dc-2c5cdd0d0544","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Model Distribution","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"F1":"#eccd03"},"decimalPrecision":2,"description":"","fillSpans":false,"id":"28bb5d45-046d-4980-ad5e-26b1aeecda2b","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(ai.usage.totalTokens)"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND ai.model.id in $llm_model AND ai.operationId = 'ai.streamText'"},"filters":{"items":[],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[{"disabled":false,"expression":"A + B","legend":"","queryName":"F1"}],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"f8b213a2-3754-40e5-a9c7-7d2d856a7ccb","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Token Usage","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"af79b14b-5e76-47fb-a24e-a4629c642c28","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"p95(duration_nano) "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND agent.id in $agent_name AND name = 'POST /api/chat'"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"9c9391ab-9316-4784-9741-f5c903695304","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Latency (P95)","yAxisUnit":"ns"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"A":"#edce64","count()":"#a403ff"},"decimalPrecision":2,"description":"","fillSpans":false,"id":"74a94376-eeaf-43c1-a273-5d8b98197138","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND agent.id in $agent_name AND name = 'POST /api/chat'"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"d80dc0df-c718-4344-bc38-bbb546c00919","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Number of Requests","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"date":145,"duration_nano":145,"http_method":145,"name":145,"response_status_code":145,"service.name":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"5e66cb8c-2219-47e6-ba71-8f82f9873bc8","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"has_error = 'true' service.name IN $service_name agent.id IN $agent_name "},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"}],"pageSize":10,"queryName":"A","selectColumns":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"2b3ecaa8-c0a0-4a48-a772-f9e097cad9c9","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Errors","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"body":350,"timestamp":100},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"05e6759b-c460-4618-86c0-5d2bf0b311c1","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"logs","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name telemetry.sdk.language in $language"},"filters":{"items":[{"id":"14ee9f15-cd4f-453a-bc1f-90aa6c67ed49","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"ad1c34b3-c49a-43e3-8ff0-d54a4fd6b6db","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"},{"columnName":"id","order":"desc"}],"pageSize":10,"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"cf4892fd-86f1-4e83-a876-db114e6e125f","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Logs","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A.avg(duration_nano)":"ns","A.count()":"none"},"columnWidths":{"A.avg(duration_nano)":145,"A.count()":145,"agent.id":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"389d43de-99b1-4c35-9589-f7d969abaa9d","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() as 'Requests' avg(duration_nano) as 'Latency'"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name agent.id EXISTS AND name = 'POST /api/chat'"},"functions":[],"groupBy":[{"dataType":"string","id":"agent.id--string--tag","isColumn":false,"isJSON":false,"key":"agent.id","type":"tag"}],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"228d1de4-3cfa-4283-903e-6e89d9ac53d1","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Agents","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"News Agent":"#fccccc"},"decimalPrecision":2,"description":"","fillSpans":false,"id":"fa87c0ad-c744-4573-85b7-0c44ad738f90","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND name = 'POST /api/chat' AND agent.id EXISTS "},"functions":[],"groupBy":[{"dataType":"string","id":"agent.id--string--tag","isColumn":false,"isJSON":false,"key":"agent.id","type":"tag"}],"having":{"expression":""},"legend":"{{agent.id}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"b9404174-d8a7-4379-8501-c6ed9da7f05f","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Agent Distribution","yAxisUnit":"none"}]}
+{
+  "spec": {
+    "display": {
+      "name": "Inkeep",
+      "description": ""
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "service_name",
+            "description": "The service name using Inkeep"
+          },
+          "defaultValue": [
+            "inkeep-agents-run-api",
+            "inkeep-agents-manage-api"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "service.name",
+              "signal": "all"
+            }
+          },
+          "name": "service_name"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "agent_name",
+            "description": "The name of the Agent being used in Inkeep"
+          },
+          "defaultValue": [
+            "mcp-demo",
+            "meeting-prep",
+            "demo-agent",
+            "docs-qa"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "agent.id",
+              "signal": "all"
+            }
+          },
+          "name": "agent_name"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "llm_model",
+            "description": "Model name being used in Agno call"
+          },
+          "defaultValue": [
+            "gpt-4.1-mini",
+            "gpt-4.1",
+            "claude-sonnet-5",
+            "gemini-2.5-flash"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "ai.model.id",
+              "signal": "all"
+            }
+          },
+          "name": "llm_model"
+        }
+      }
+    ],
+    "panels": {
+      "04247ee1-b408-457d-ac00-47ce45e64291": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Input Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(ai.usage.inputTokens)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND ai.model.id in $llm_model AND ai.operationId = 'ai.streamText' AND agent.id IN $agent_name "
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "28bb5d45-046d-4980-ad5e-26b1aeecda2b": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Token Usage",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "inkeep-agents-manage-api": "#E48BCA",
+                  "inkeep-agents-run-api": "#5DE5E5"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "sum(ai.usage.totalTokens)"
+                            }
+                          ],
+                          "disabled": false,
+                          "filter": {
+                            "expression": "service.name in $service_name AND ai.model.id in $llm_model AND ai.operationId = 'ai.streamText'"
+                          },
+                          "groupBy": [
+                            {
+                              "name": "service.name",
+                              "signal": "",
+                              "fieldContext": "resource",
+                              "fieldDataType": "string"
+                            }
+                          ],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "A",
+                          "disabled": false,
+                          "order": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "functions": null,
+                          "legend": "{{service.name}}"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "3633c7ad-203a-4e25-99f4-8cc81bf15d65": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Model Distribution",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "claude-sonnet-5": "#E49A8B",
+                  "gemini-2.5-flash": "#30E885",
+                  "gpt-4.1": "#5D6EE5",
+                  "gpt-4.1-mini": "#7DE830"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND ai.operationId = 'ai.streamText'"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "ai.model.id",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{ai.model.id}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "389d43de-99b1-4c35-9589-f7d969abaa9d": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Agents",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A.p95(duration_nano)": "ns"
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()",
+                        "alias": "Requests"
+                      },
+                      {
+                        "expression": "p95(duration_nano)",
+                        "alias": "Duration"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name agent.id EXISTS AND name = 'POST 127.0.0.1/agents/a2a'"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "agent.id",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "59ba2185-34ee-46ac-b6fd-99a3ede58e29": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Ms To First Chunk",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ms",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "F1": "#eccd03"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "p95(ai.response.msToFirstChunk)"
+                            }
+                          ],
+                          "disabled": false,
+                          "filter": {
+                            "expression": "service.name in $service_name AND ai.model.id in $llm_model AND ai.operationId = 'ai.streamText.doStream'"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": "ms to first chunk"
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "A + B",
+                          "disabled": true,
+                          "order": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "functions": null,
+                          "legend": ""
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "5e66cb8c-2219-47e6-ba71-8f82f9873bc8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Errors",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "service.name",
+                  "signal": "traces",
+                  "fieldContext": "resource",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "name",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "duration_nano",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "http_method",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "response_status_code",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "has_error = 'true' service.name IN $service_name agent.id IN $agent_name "
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "name",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "duration_nano",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "http_method",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "response_status_code",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      }
+                    ],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "74a94376-eeaf-43c1-a273-5d8b98197138": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Number of Requests",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "inkeep-agents-manage-api": "#E48BCA",
+                  "inkeep-agents-run-api": "#5DE5E5"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND agent.id in $agent_name AND name = 'POST /api/chat'"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "799913e6-fb95-497e-858a-6490b5f9d10d": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Error Rate",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "percentunit",
+                "decimalPrecision": "2"
+              },
+              "thresholds": [
+                {
+                  "value": 0.1,
+                  "operator": "above",
+                  "unit": "percentunit",
+                  "color": "Red",
+                  "format": "text"
+                },
+                {
+                  "value": 0.05,
+                  "operator": "above",
+                  "unit": "percentunit",
+                  "color": "Orange",
+                  "format": "text"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "has_error = 'true' AND service.name in $service_name AND agent.id IN $agent_name "
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "has_error = 'false' service.name in $service_name AND agent.id IN $agent_name "
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "A / (A+B)",
+                          "disabled": false,
+                          "order": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "functions": null,
+                          "legend": ""
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "9b2632b2-3a69-42e7-b149-a3413e5a51b9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Ms To Finish",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ms",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "F1": "#eccd03"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "p95(ai.response.msToFinish)"
+                            }
+                          ],
+                          "disabled": false,
+                          "filter": {
+                            "expression": "service.name in $service_name AND ai.model.id in $llm_model AND ai.operationId = 'ai.streamText.doStream'"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": "ms to Finish"
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "A + B",
+                          "disabled": true,
+                          "order": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "functions": null,
+                          "legend": ""
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "af79b14b-5e76-47fb-a24e-a4629c642c28": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Duration (P95)",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ns",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "inkeep-agents-manage-api": "#E48BCA",
+                  "inkeep-agents-run-api": "#5DE5E5"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "p95(duration_nano)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND agent.id in $agent_name AND name = 'POST 127.0.0.1/agents/a2a'"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Output Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(ai.usage.outputTokens)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name ai.operationId = 'ai.streamText' AND agent.id IN $agent_name AND ai.model.id IN $llm_model  "
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "fa87c0ad-c744-4573-85b7-0c44ad738f90": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Agent Distribution",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "demo-agent": "#30ABE8",
+                  "docs-qa": "#E55D90",
+                  "mcp-demo": "#C35DE5",
+                  "meeting-prep": "#E0E48B"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND name = 'POST /api/chat' AND agent.id EXISTS "
+                    },
+                    "groupBy": [
+                      {
+                        "name": "agent.id",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{agent.id}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/04247ee1-b408-457d-ac00-47ce45e64291"
+              }
+            },
+            {
+              "x": 4,
+              "y": 0,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570"
+              }
+            },
+            {
+              "x": 8,
+              "y": 0,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/799913e6-fb95-497e-858a-6490b5f9d10d"
+              }
+            },
+            {
+              "x": 0,
+              "y": 3,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/74a94376-eeaf-43c1-a273-5d8b98197138"
+              }
+            },
+            {
+              "x": 6,
+              "y": 3,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/af79b14b-5e76-47fb-a24e-a4629c642c28"
+              }
+            },
+            {
+              "x": 0,
+              "y": 9,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/59ba2185-34ee-46ac-b6fd-99a3ede58e29"
+              }
+            },
+            {
+              "x": 6,
+              "y": 9,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/9b2632b2-3a69-42e7-b149-a3413e5a51b9"
+              }
+            },
+            {
+              "x": 0,
+              "y": 15,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/28bb5d45-046d-4980-ad5e-26b1aeecda2b"
+              }
+            },
+            {
+              "x": 8,
+              "y": 15,
+              "width": 4,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/389d43de-99b1-4c35-9589-f7d969abaa9d"
+              }
+            },
+            {
+              "x": 0,
+              "y": 21,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/3633c7ad-203a-4e25-99f4-8cc81bf15d65"
+              }
+            },
+            {
+              "x": 6,
+              "y": 21,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/fa87c0ad-c744-4573-85b7-0c44ad738f90"
+              }
+            },
+            {
+              "x": 0,
+              "y": 27,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/5e66cb8c-2219-47e6-ba71-8f82f9873bc8"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "",
+    "refreshInterval": "",
+    "links": []
+  },
+  "tags": [],
+  "image": "/assets/Icons/eight-ball"
+}

--- a/litellm/litellm-proxy-dashboard.json
+++ b/litellm/litellm-proxy-dashboard.json
@@ -1,1 +1,1016 @@
-{"description":"","image":"data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE0Ljk0OTQgMTMuOTQyQzE2LjIzMTggMTIuNDI1OCAxNy4zMjY4IDkuNzAyMiAxNi4xOTU2IDYuNTc0ODdDMTUuNjQ0MyA1LjA1MjQ1IDE1LjAyMTkgNC4yMDI0OSAxNC4yOTY5IDMuNjYyNTJDMTMuODU1NyAzLjMzMzc5IDEyLjA5MzMgMi41MDYzMyA5Ljc1OTY1IDIuODY3NTZDOC4wNTM0OSAzLjEzMjU1IDUuNzc0ODcgNC4yMDg3NCA0LjI5MzY5IDUuOTU5OUMyLjg1NzUyIDcuNjYxMDYgMS43NDg4MyA5LjAwNDc0IDEuNjk3NTggMTAuMzA5N0MxLjYzMTMzIDExLjk4ODMgMi44OTYyNyAxMy40MzA4IDMuMDUwMDEgMTMuNjY0NUMzLjMyMzc0IDE0LjA3OTUgNS4xOTExNSAxNi40NTE4IDguNjk5NzEgMTYuNTczMUMxMS43OTcgMTYuNjc5MyAxMy44MTQ0IDE1LjI4NDQgMTQuOTQ5NCAxMy45NDJaIiBmaWxsPSIjNDAzRDNFIi8+CjxwYXRoIGQ9Ik00LjU1MzYzIDIuNzM3NDdDMi45Mzc0NiAzLjg5MTE2IDEuMTIxMzEgNi4yNTEwMyAxLjQ0NzU0IDkuNTYwODZDMS42MDYyOCAxMS4xNzIgMi4wMDI1MSAxMi4xNDk1IDIuNTcxMjMgMTIuODUwN0MyLjkxNzQ2IDEzLjI3ODIgNC40MTk4OCAxNC41NDkzIDYuNzczNTEgMTQuNzM2OEM5LjE0NTg4IDE0LjkyNTYgMTAuOTQ5NSAxNC4zOTQ0IDEyLjgzMzIgMTMuMDg0NEMxNi42NjE3IDEwLjQyMDggMTYuMDk4IDYuMzkzNTMgMTUuOTM0MyA1LjkyNDhDMTUuNzcwNSA1LjQ1NjA3IDE0LjU0NDQgMi42OTYyMiAxMS4xNzMzIDEuNzE1MDJDOC4xOTg0NCAwLjg1MDA2OCA1Ljk4MzU1IDEuNzE1MDIgNC41NTM2MyAyLjczNzQ3WiIgZmlsbD0iIzVFNjM2NyIvPgo8cGF0aCBkPSJNNy4zOTM1MyAyLjk2MTA5QzUuNjE3MzcgMi44OTczNCAzLjkxOTk2IDQuMjg4NTIgMy43NTYyMiA2LjAwNTkzQzMuNTkyNDggNy43MjIwOSA0LjY1NDkyIDkuMDI5NTIgNi4zMDk4MyA5LjI5NTc2QzcuOTY0NzUgOS41NjA3NCA5Ljg3ODM5IDguNTU1OCAxMC4yNjM0IDYuNDUwOTFDMTAuNjYwOSA0LjI4MjI3IDkuMDg5NjkgMy4wMjIzNCA3LjM5MzUzIDIuOTYxMDlaIiBmaWxsPSJ3aGl0ZSIvPgo8cGF0aCBkPSJNNy45NDIxNyA1LjkwMTE1QzcuOTQyMTcgNS45MDExNSA4LjM2OTY1IDUuODEyNCA4LjQ1NDY1IDUuMTgyNDRDOC41MzgzOSA0LjU2MjQ3IDguMjMwOTEgNC4wMzM3NSA3LjUxMzQ1IDMuODQzNzZDNi43MzM0OSAzLjYzNzUyIDYuMjA0NzcgNC4wNjYyNSA2LjA2NzI3IDQuNTE3NDdDNS44NzYwMyA1LjE0NDk0IDYuMTU4NTIgNS40NDM2NyA2LjE1ODUyIDUuNDQzNjdDNi4xNTg1MiA1LjQ0MzY3IDUuMzkzNTYgNS42Mjc0MSA1LjMzMjMxIDYuNTI5ODdDNS4yNzQ4MSA3LjM4MTA3IDUuODU2MDMgNy44Mzg1NSA2LjQzOTc1IDcuOTc4NTRDNy4xNjA5NiA4LjE1MjI4IDcuOTc4NDIgNy45NTQ3OSA4LjE3ODQxIDcuMDM0ODRDOC4zNDQ2NSA2LjI3NzM4IDcuOTQyMTcgNS45MDExNSA3Ljk0MjE3IDUuOTAxMTVaIiBmaWxsPSIjMzAzMDMwIi8+CjxwYXRoIGQ9Ik02LjczOTgzIDQuNzUzNjJDNi42NzEwOSA1LjAxMjM1IDYuODA4NTggNS4yNjIzNCA3LjA3ODU3IDUuMzMxMDlDNy4zNjk4IDUuNDA0ODMgNy42MzQ3OSA1LjMwODU5IDcuNzA2MDMgNS4wMTExQzcuNzY4NTMgNC43NDczNyA3LjY0MzU0IDQuNTE0ODggNy4zMzYwNSA0LjQzOTg4QzcuMDgzNTcgNC4zNzczOSA2LjgxNDgzIDQuNDcxMTMgNi43Mzk4MyA0Ljc1MzYyWiIgZmlsbD0id2hpdGUiLz4KPHBhdGggZD0iTTYuOTU5NzggNi4wMzk3NEM2LjYzMjMgNS45Mzg0OSA2LjE5OTgyIDYuMDY0NzMgNi4xMzEwNyA2LjUwNDcxQzYuMDYyMzMgNi45NDQ2OSA2LjMyNjA2IDcuMTY5NjggNi42NzEwNCA3LjIzMjE3QzcuMDE2MDMgNy4yOTQ2NyA3LjM0MjI2IDcuMTEzNDMgNy40MDYwMSA2Ljc2MDk1QzcuNDY4NSA2LjQwOTcyIDcuMjg2MDEgNi4xMzk3MyA2Ljk1OTc4IDYuMDM5NzRaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K","layout":[{"h":3,"i":"04247ee1-b408-457d-ac00-47ce45e64291","moved":false,"static":false,"w":3,"x":0,"y":0},{"h":3,"i":"d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570","moved":false,"static":false,"w":3,"x":3,"y":0},{"h":3,"i":"799913e6-fb95-497e-858a-6490b5f9d10d","moved":false,"static":false,"w":3,"x":6,"y":0},{"h":5,"i":"3633c7ad-203a-4e25-99f4-8cc81bf15d65","moved":false,"static":false,"w":3,"x":9,"y":0},{"h":5,"i":"28bb5d45-046d-4980-ad5e-26b1aeecda2b","moved":false,"static":false,"w":4,"x":0,"y":3},{"h":5,"i":"af79b14b-5e76-47fb-a24e-a4629c642c28","moved":false,"static":false,"w":4,"x":4,"y":3},{"h":5,"i":"74a94376-eeaf-43c1-a273-5d8b98197138","moved":false,"static":false,"w":5,"x":0,"y":8},{"h":4,"i":"67a074ee-c46e-4a36-8f5c-10d981cae404","moved":false,"static":false,"w":6,"x":5,"y":8},{"h":6,"i":"5e66cb8c-2219-47e6-ba71-8f82f9873bc8","moved":false,"static":false,"w":6,"x":6,"y":12},{"h":5,"i":"52f3517a-3c2e-4379-afa9-7b93f7bf8b07","moved":false,"static":false,"w":6,"x":0,"y":13},{"h":1,"i":"__dropping-elem__","isDraggable":true,"moved":false,"static":false,"w":1,"x":10,"y":18}],"panelMap":{},"tags":[],"title":"LiteLLM Proxy","uploadedGrafana":false,"uuid":"019a30f6-94d9-7487-9a28-a16e5a2fb604","variables":{"10d0eca9-9253-4583-821c-d3c812d78151":{"allSelected":false,"customValue":"","defaultValue":"","description":"The service name using LiteLLM Proxy","dynamicVariablesAttribute":"service.name","dynamicVariablesSource":"All telemetry","haveCustomValuesSelected":false,"id":"10d0eca9-9253-4583-821c-d3c812d78151","key":"10d0eca9-9253-4583-821c-d3c812d78151","modificationUUID":"5918817e-f2ef-4de3-87ce-2f01030916a0","multiSelect":true,"name":"service_name","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"93c33118-5f46-404b-b45e-8a81160c44c4":{"allSelected":false,"customValue":"","defaultValue":"","description":"Language being used for running LiteLLM proxy","dynamicVariablesAttribute":"telemetry.sdk.language","dynamicVariablesSource":"All telemetry","haveCustomValuesSelected":false,"id":"93c33118-5f46-404b-b45e-8a81160c44c4","key":"93c33118-5f46-404b-b45e-8a81160c44c4","modificationUUID":"078d08e1-347d-40dc-92bf-290cf53235fb","multiSelect":true,"name":"language","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"be7a68c4-fb97-43ea-bb94-0ded120bd3d7":{"allSelected":false,"customValue":"","defaultValue":"","description":"Model name being used in LiteLLM proxy calls","dynamicVariablesAttribute":"gen_ai.request.model","dynamicVariablesSource":"All telemetry","haveCustomValuesSelected":false,"id":"be7a68c4-fb97-43ea-bb94-0ded120bd3d7","modificationUUID":"4ccde4e1-9b64-43dc-aef9-1db3d0e7fc6a","multiSelect":true,"name":"llm_model","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"}},"version":"v5","widgets":[{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"04247ee1-b408-457d-ac00-47ce45e64291","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.prompt_tokens) ) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"},"filters":{"items":[{"id":"bf7097ca-55b4-4336-8dc2-a7c58773d776","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"43a52b60-06c6-4575-8c20-9643fbc42f0d","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]},{"id":"fda4f92c-3c78-419f-9716-374b49066a1e","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"in","value":["$llm_model"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"ed422bed-bbee-400f-bcb5-d90bef6d4f87","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Input Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.completion_tokens) ) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"},"filters":{"items":[{"id":"bf7097ca-55b4-4336-8dc2-a7c58773d776","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"39573744-2bb6-4f34-a522-6ffb03679d0a","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]},{"id":"67f753b1-b6fb-474c-972a-2af5636ad033","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"in","value":["$llm_model"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"461e0704-f622-4069-acb0-c171fa379f5e","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Output Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"799913e6-fb95-497e-858a-6490b5f9d10d","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"A","filter":{"expression":"has_error = 'true' service.name in $service_name"},"filters":{"items":[{"id":"bf7097ca-55b4-4336-8dc2-a7c58773d776","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"28844ce9-4002-4cc8-aab4-f1e24d2875a1","key":{"id":"has_error","key":"has_error","type":""},"op":"=","value":"true"}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null},{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"B","filter":{"expression":"has_error = 'false' service.name in $service_name"},"filters":{"items":[{"id":"bf7097ca-55b4-4336-8dc2-a7c58773d776","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"bb603a97-bc7b-4236-a26c-a280c9be8195","key":{"id":"has_error","key":"has_error","type":""},"op":"=","value":"false"}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"B","source":"","stepInterval":null}],"queryFormulas":[{"disabled":false,"expression":"A / (A+B)","legend":"","queryName":"F1"}],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"06db8fa1-2559-4a1e-ae05-19f94089cb58","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[{"index":"e5e05d41-7479-4d60-a1cf-c433b8b61285","isEditEnabled":false,"keyIndex":1,"selectedGraph":"value","thresholdColor":"Red","thresholdFormat":"Text","thresholdLabel":"","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"percentunit","thresholdValue":10},{"index":"d74bf17b-552a-4636-8fad-c976b090d590","isEditEnabled":false,"keyIndex":0,"selectedGraph":"value","thresholdColor":"Orange","thresholdFormat":"Text","thresholdLabel":"","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"percentunit","thresholdValue":5}],"timePreferance":"GLOBAL_TIME","title":"Error Rate","yAxisUnit":"percentunit"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"3633c7ad-203a-4e25-99f4-8cc81bf15d65","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND gen_ai.request.model EXISTS"},"filters":{"items":[{"id":"bf7097ca-55b4-4336-8dc2-a7c58773d776","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"5bae7f50-a643-428a-97af-baa4ac1ff6bf","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"exists","value":"undefined"}],"op":"AND"},"functions":[],"groupBy":[{"dataType":"string","id":"gen_ai.request.model--string--tag","isColumn":false,"isJSON":false,"key":"gen_ai.request.model","type":"tag"}],"having":{"expression":""},"legend":"{{gen_ai.request.model}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"d1ad853e-2d10-4b75-be1c-ef355ddf3222","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Model Distribution","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"F1":"#eccd03"},"description":"","fillSpans":false,"id":"28bb5d45-046d-4980-ad5e-26b1aeecda2b","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(llm.usage.total_tokens) ) ) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"},"filters":{"items":[{"id":"bf7097ca-55b4-4336-8dc2-a7c58773d776","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"aa4f31c9-208c-4b81-8e0a-02c0ea39c634","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]},{"id":"92d543ee-c853-4b9a-af69-a896940f8f55","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"in","value":["$llm_model"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"39e5fa6c-eb68-4f3d-94a0-dee6291a9815","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Token Usage","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"af79b14b-5e76-47fb-a24e-a4629c642c28","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"p95(duration_nano) "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"},"filters":{"items":[{"id":"bf7097ca-55b4-4336-8dc2-a7c58773d776","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"21308e7d-80ad-4cfe-bfaa-062f49baf261","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]},{"id":"a143a7a0-017e-479c-8957-0db2f33b8d3a","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"in","value":["$llm_model"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"fa7d3c90-3c95-448b-901b-ba9206c172a0","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Latency (P95)","yAxisUnit":"ns"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"A":"#edce64","count()":"#a403ff"},"description":"","fillSpans":false,"id":"74a94376-eeaf-43c1-a273-5d8b98197138","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"476bec16-cee5-4d4a-b99d-4ebd6e73e34b","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Number of Requests","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"date":145,"duration_nano":145,"http_method":145,"name":145,"response_status_code":145,"service.name":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"5e66cb8c-2219-47e6-ba71-8f82f9873bc8","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"has_error = true service.name IN $service_name"},"filters":{"items":[{"id":"bf7097ca-55b4-4336-8dc2-a7c58773d776","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"7e306dd4-0004-40a5-a25f-af5f335d74ef","key":{"id":"has_error","key":"has_error","type":""},"op":"=","value":"true"}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"}],"pageSize":10,"queryName":"A","selectColumns":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"b85f93b2-09b5-4fcd-8aa8-f6a2875a41b5","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Errors","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A":""},"columnWidths":{"A":145,"service.name":145,"telemetry.sdk.language":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"67a074ee-c46e-4a36-8f5c-10d981cae404","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() as 'Count of Calls' "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name  AND gen_ai.request.model EXISTS"},"filters":{"items":[{"id":"bf7097ca-55b4-4336-8dc2-a7c58773d776","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"b8acb8bd-5763-4840-81f8-24897cc22cae","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"exists","value":"undefined"}],"op":"AND"},"functions":[],"groupBy":[{"dataType":"string","id":"service.name--string--resource","isColumn":true,"isJSON":false,"key":"service.name","type":"resource"},{"dataType":"string","id":"telemetry.sdk.language--string--resource","isColumn":false,"isJSON":false,"key":"telemetry.sdk.language","type":"resource"}],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"c64fddf9-2e1c-4fcf-a820-2c572d73395c","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Services and Languages","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A.avg(duration_nano)":"ns","A.count()":"","A.sum(llm.usage.total_tokens)":""},"columnWidths":{"A.avg(duration_nano)":145,"A.count()":145,"A.sum(llm.usage.total_tokens)":145,"gen_ai.request.model":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"52f3517a-3c2e-4379-afa9-7b93f7bf8b07","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() as 'Number of Calls' avg(duration_nano) as 'Latency' sum(llm.usage.total_tokens) as 'Tokens'"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name name = 'litellm_request'"},"functions":[],"groupBy":[{"dataType":"","id":"gen_ai.request.model----","key":"gen_ai.request.model","type":""}],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"d4d3ca03-e160-45f3-8210-21b2e75ae32c","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Models Info","yAxisUnit":"none"}]}
+{
+  "spec": {
+    "display": {
+      "name": "LiteLLM Proxy",
+      "description": ""
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "service_name",
+            "description": "The service name using LiteLLM Proxy"
+          },
+          "defaultValue": [
+            "litellm",
+            "litellm-staging"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "service.name",
+              "signal": "all"
+            }
+          },
+          "name": "service_name"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "language",
+            "description": "Language being used for running LiteLLM proxy"
+          },
+          "defaultValue": [
+            "python"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "telemetry.sdk.language",
+              "signal": "all"
+            }
+          },
+          "name": "language"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "llm_model",
+            "description": "Model name being used in LiteLLM proxy calls"
+          },
+          "defaultValue": [
+            "openai/gpt-4.1",
+            "openai/gpt-4.1-mini",
+            "anthropic/claude-sonnet-5",
+            "anthropic/claude-haiku-4-5",
+            "gemini/gemini-2.5-flash",
+            "gemini/gemini-2.5-pro"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "gen_ai.request.model",
+              "signal": "all"
+            }
+          },
+          "name": "llm_model"
+        }
+      }
+    ],
+    "panels": {
+      "04247ee1-b408-457d-ac00-47ce45e64291": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Input Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(gen_ai.usage.prompt_tokens)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "28bb5d45-046d-4980-ad5e-26b1aeecda2b": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Token Usage",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "litellm": "#5D85E5",
+                  "litellm-staging": "#E48B8C"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(llm.usage.total_tokens)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "3633c7ad-203a-4e25-99f4-8cc81bf15d65": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Model Distribution",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "anthropic/claude-haiku-4-5": "#30CBE8",
+                  "anthropic/claude-sonnet-5": "#E4D88B",
+                  "gemini/gemini-2.5-flash": "#E55DA7",
+                  "gemini/gemini-2.5-pro": "#A2E48B",
+                  "openai/gpt-4.1": "#30E865",
+                  "openai/gpt-4.1-mini": "#AB5DE5"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND gen_ai.request.model EXISTS"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "gen_ai.request.model",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{gen_ai.request.model}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "52f3517a-3c2e-4379-afa9-7b93f7bf8b07": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Models Info",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A.avg(duration_nano)": "ns",
+                  "A.count()": "",
+                  "A.sum(llm.usage.total_tokens)": ""
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()",
+                        "alias": "Number of Calls"
+                      },
+                      {
+                        "expression": "avg(duration_nano)",
+                        "alias": "Latency"
+                      },
+                      {
+                        "expression": "sum(llm.usage.total_tokens)",
+                        "alias": "Tokens"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name name = 'litellm_request'"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "gen_ai.request.model",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "5e66cb8c-2219-47e6-ba71-8f82f9873bc8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Errors",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "service.name",
+                  "signal": "traces",
+                  "fieldContext": "resource",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "name",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "duration_nano",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "http_method",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "response_status_code",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "has_error = true service.name IN $service_name"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "name",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "duration_nano",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "http_method",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "response_status_code",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      }
+                    ],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "67a074ee-c46e-4a36-8f5c-10d981cae404": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Services and Languages",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A": ""
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()",
+                        "alias": "Count of Calls"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name  AND gen_ai.request.model EXISTS"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "telemetry.sdk.language",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "74a94376-eeaf-43c1-a273-5d8b98197138": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Number of Requests",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "litellm": "#5D85E5",
+                  "litellm-staging": "#E48B8C"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "799913e6-fb95-497e-858a-6490b5f9d10d": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Error Rate",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "percentunit",
+                "decimalPrecision": "2"
+              },
+              "thresholds": [
+                {
+                  "value": 0.1,
+                  "operator": "above",
+                  "unit": "percentunit",
+                  "color": "Red",
+                  "format": "text"
+                },
+                {
+                  "value": 0.05,
+                  "operator": "above",
+                  "unit": "percentunit",
+                  "color": "Orange",
+                  "format": "text"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "has_error = 'true' service.name in $service_name"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "has_error = 'false' service.name in $service_name"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "A / (A+B)",
+                          "disabled": false,
+                          "order": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "functions": null,
+                          "legend": ""
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "af79b14b-5e76-47fb-a24e-a4629c642c28": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Latency (P95)",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ns",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "litellm": "#5D85E5",
+                  "litellm-staging": "#E48B8C"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "p95(duration_nano)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Output Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(gen_ai.usage.completion_tokens)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/04247ee1-b408-457d-ac00-47ce45e64291"
+              }
+            },
+            {
+              "x": 4,
+              "y": 0,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570"
+              }
+            },
+            {
+              "x": 8,
+              "y": 0,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/799913e6-fb95-497e-858a-6490b5f9d10d"
+              }
+            },
+            {
+              "x": 0,
+              "y": 3,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/74a94376-eeaf-43c1-a273-5d8b98197138"
+              }
+            },
+            {
+              "x": 6,
+              "y": 3,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/af79b14b-5e76-47fb-a24e-a4629c642c28"
+              }
+            },
+            {
+              "x": 0,
+              "y": 9,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/28bb5d45-046d-4980-ad5e-26b1aeecda2b"
+              }
+            },
+            {
+              "x": 8,
+              "y": 9,
+              "width": 4,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/3633c7ad-203a-4e25-99f4-8cc81bf15d65"
+              }
+            },
+            {
+              "x": 0,
+              "y": 15,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/52f3517a-3c2e-4379-afa9-7b93f7bf8b07"
+              }
+            },
+            {
+              "x": 8,
+              "y": 15,
+              "width": 4,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/67a074ee-c46e-4a36-8f5c-10d981cae404"
+              }
+            },
+            {
+              "x": 0,
+              "y": 21,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/5e66cb8c-2219-47e6-ba71-8f82f9873bc8"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "",
+    "refreshInterval": "",
+    "links": []
+  },
+  "tags": [],
+  "image": "/assets/Icons/eight-ball"
+}

--- a/litellm/litellm-sdk-dashboard.json
+++ b/litellm/litellm-sdk-dashboard.json
@@ -1,1 +1,1104 @@
-{"description":"","image":"data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE0Ljk0OTQgMTMuOTQyQzE2LjIzMTggMTIuNDI1OCAxNy4zMjY4IDkuNzAyMiAxNi4xOTU2IDYuNTc0ODdDMTUuNjQ0MyA1LjA1MjQ1IDE1LjAyMTkgNC4yMDI0OSAxNC4yOTY5IDMuNjYyNTJDMTMuODU1NyAzLjMzMzc5IDEyLjA5MzMgMi41MDYzMyA5Ljc1OTY1IDIuODY3NTZDOC4wNTM0OSAzLjEzMjU1IDUuNzc0ODcgNC4yMDg3NCA0LjI5MzY5IDUuOTU5OUMyLjg1NzUyIDcuNjYxMDYgMS43NDg4MyA5LjAwNDc0IDEuNjk3NTggMTAuMzA5N0MxLjYzMTMzIDExLjk4ODMgMi44OTYyNyAxMy40MzA4IDMuMDUwMDEgMTMuNjY0NUMzLjMyMzc0IDE0LjA3OTUgNS4xOTExNSAxNi40NTE4IDguNjk5NzEgMTYuNTczMUMxMS43OTcgMTYuNjc5MyAxMy44MTQ0IDE1LjI4NDQgMTQuOTQ5NCAxMy45NDJaIiBmaWxsPSIjNDAzRDNFIi8+CjxwYXRoIGQ9Ik00LjU1MzYzIDIuNzM3NDdDMi45Mzc0NiAzLjg5MTE2IDEuMTIxMzEgNi4yNTEwMyAxLjQ0NzU0IDkuNTYwODZDMS42MDYyOCAxMS4xNzIgMi4wMDI1MSAxMi4xNDk1IDIuNTcxMjMgMTIuODUwN0MyLjkxNzQ2IDEzLjI3ODIgNC40MTk4OCAxNC41NDkzIDYuNzczNTEgMTQuNzM2OEM5LjE0NTg4IDE0LjkyNTYgMTAuOTQ5NSAxNC4zOTQ0IDEyLjgzMzIgMTMuMDg0NEMxNi42NjE3IDEwLjQyMDggMTYuMDk4IDYuMzkzNTMgMTUuOTM0MyA1LjkyNDhDMTUuNzcwNSA1LjQ1NjA3IDE0LjU0NDQgMi42OTYyMiAxMS4xNzMzIDEuNzE1MDJDOC4xOTg0NCAwLjg1MDA2OCA1Ljk4MzU1IDEuNzE1MDIgNC41NTM2MyAyLjczNzQ3WiIgZmlsbD0iIzVFNjM2NyIvPgo8cGF0aCBkPSJNNy4zOTM1MyAyLjk2MTA5QzUuNjE3MzcgMi44OTczNCAzLjkxOTk2IDQuMjg4NTIgMy43NTYyMiA2LjAwNTkzQzMuNTkyNDggNy43MjIwOSA0LjY1NDkyIDkuMDI5NTIgNi4zMDk4MyA5LjI5NTc2QzcuOTY0NzUgOS41NjA3NCA5Ljg3ODM5IDguNTU1OCAxMC4yNjM0IDYuNDUwOTFDMTAuNjYwOSA0LjI4MjI3IDkuMDg5NjkgMy4wMjIzNCA3LjM5MzUzIDIuOTYxMDlaIiBmaWxsPSJ3aGl0ZSIvPgo8cGF0aCBkPSJNNy45NDIxNyA1LjkwMTE1QzcuOTQyMTcgNS45MDExNSA4LjM2OTY1IDUuODEyNCA4LjQ1NDY1IDUuMTgyNDRDOC41MzgzOSA0LjU2MjQ3IDguMjMwOTEgNC4wMzM3NSA3LjUxMzQ1IDMuODQzNzZDNi43MzM0OSAzLjYzNzUyIDYuMjA0NzcgNC4wNjYyNSA2LjA2NzI3IDQuNTE3NDdDNS44NzYwMyA1LjE0NDk0IDYuMTU4NTIgNS40NDM2NyA2LjE1ODUyIDUuNDQzNjdDNi4xNTg1MiA1LjQ0MzY3IDUuMzkzNTYgNS42Mjc0MSA1LjMzMjMxIDYuNTI5ODdDNS4yNzQ4MSA3LjM4MTA3IDUuODU2MDMgNy44Mzg1NSA2LjQzOTc1IDcuOTc4NTRDNy4xNjA5NiA4LjE1MjI4IDcuOTc4NDIgNy45NTQ3OSA4LjE3ODQxIDcuMDM0ODRDOC4zNDQ2NSA2LjI3NzM4IDcuOTQyMTcgNS45MDExNSA3Ljk0MjE3IDUuOTAxMTVaIiBmaWxsPSIjMzAzMDMwIi8+CjxwYXRoIGQ9Ik02LjczOTgzIDQuNzUzNjJDNi42NzEwOSA1LjAxMjM1IDYuODA4NTggNS4yNjIzNCA3LjA3ODU3IDUuMzMxMDlDNy4zNjk4IDUuNDA0ODMgNy42MzQ3OSA1LjMwODU5IDcuNzA2MDMgNS4wMTExQzcuNzY4NTMgNC43NDczNyA3LjY0MzU0IDQuNTE0ODggNy4zMzYwNSA0LjQzOTg4QzcuMDgzNTcgNC4zNzczOSA2LjgxNDgzIDQuNDcxMTMgNi43Mzk4MyA0Ljc1MzYyWiIgZmlsbD0id2hpdGUiLz4KPHBhdGggZD0iTTYuOTU5NzggNi4wMzk3NEM2LjYzMjMgNS45Mzg0OSA2LjE5OTgyIDYuMDY0NzMgNi4xMzEwNyA2LjUwNDcxQzYuMDYyMzMgNi45NDQ2OSA2LjMyNjA2IDcuMTY5NjggNi42NzEwNCA3LjIzMjE3QzcuMDE2MDMgNy4yOTQ2NyA3LjM0MjI2IDcuMTEzNDMgNy40MDYwMSA2Ljc2MDk1QzcuNDY4NSA2LjQwOTcyIDcuMjg2MDEgNi4xMzk3MyA2Ljk1OTc4IDYuMDM5NzRaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K","layout":[{"h":3,"i":"04247ee1-b408-457d-ac00-47ce45e64291","moved":false,"static":false,"w":3,"x":0,"y":0},{"h":3,"i":"d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570","moved":false,"static":false,"w":3,"x":3,"y":0},{"h":3,"i":"799913e6-fb95-497e-858a-6490b5f9d10d","moved":false,"static":false,"w":3,"x":6,"y":0},{"h":5,"i":"3633c7ad-203a-4e25-99f4-8cc81bf15d65","moved":false,"static":false,"w":3,"x":9,"y":0},{"h":5,"i":"28bb5d45-046d-4980-ad5e-26b1aeecda2b","moved":false,"static":false,"w":4,"x":0,"y":3},{"h":5,"i":"af79b14b-5e76-47fb-a24e-a4629c642c28","moved":false,"static":false,"w":4,"x":4,"y":3},{"h":5,"i":"74a94376-eeaf-43c1-a273-5d8b98197138","moved":false,"static":false,"w":5,"x":0,"y":8},{"h":3,"i":"67a074ee-c46e-4a36-8f5c-10d981cae404","moved":false,"static":false,"w":6,"x":5,"y":8},{"h":6,"i":"5e66cb8c-2219-47e6-ba71-8f82f9873bc8","moved":false,"static":false,"w":7,"x":5,"y":11},{"h":4,"i":"bc6e3017-2b44-4152-a0d7-fe11e6b7a290","moved":false,"static":false,"w":5,"x":0,"y":13},{"h":5,"i":"05e6759b-c460-4618-86c0-5d2bf0b311c1","moved":false,"static":false,"w":6,"x":0,"y":17},{"h":1,"i":"__dropping-elem__","isDraggable":true,"moved":false,"static":false,"w":1,"x":10,"y":17}],"panelMap":{},"tags":[],"title":"LiteLLM SDK","uploadedGrafana":false,"uuid":"0199f31c-7838-75c6-9896-4a087c09b9d8","variables":{"10d0eca9-9253-4583-821c-d3c812d78151":{"allSelected":false,"customValue":"","defaultValue":"","description":"The service name using LiteLLM SDK","dynamicVariablesAttribute":"service.name","dynamicVariablesSource":"All telemetry","id":"10d0eca9-9253-4583-821c-d3c812d78151","key":"10d0eca9-9253-4583-821c-d3c812d78151","modificationUUID":"96a84e50-568d-4eca-8fb7-c164eaa0ab53","multiSelect":true,"name":"service_name","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"93c33118-5f46-404b-b45e-8a81160c44c4":{"allSelected":false,"customValue":"","defaultValue":"","description":"Language being used for making LiteLLM SDK calls","dynamicVariablesAttribute":"telemetry.sdk.language","dynamicVariablesSource":"All telemetry","id":"93c33118-5f46-404b-b45e-8a81160c44c4","key":"93c33118-5f46-404b-b45e-8a81160c44c4","modificationUUID":"01859077-0017-4c33-8bcf-1fa1fca1a897","multiSelect":true,"name":"language","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"be7a68c4-fb97-43ea-bb94-0ded120bd3d7":{"allSelected":false,"customValue":"","defaultValue":"","description":"Model name being used in LiteLLM SDK call","dynamicVariablesAttribute":"gen_ai.request.model","dynamicVariablesSource":"All telemetry","id":"be7a68c4-fb97-43ea-bb94-0ded120bd3d7","modificationUUID":"5c402f80-71ea-417d-af85-1f0e7b1e7b22","multiSelect":true,"name":"llm_model","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"}},"version":"v5","widgets":[{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"04247ee1-b408-457d-ac00-47ce45e64291","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.prompt_tokens) ) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"},"filters":{"items":[{"id":"14ee9f15-cd4f-453a-bc1f-90aa6c67ed49","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"43dc892d-7290-4af7-870f-3359d5b61c85","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]},{"id":"0c7cac39-9213-4561-af93-2999dd27f86a","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"in","value":["$llm_model"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"ed422bed-bbee-400f-bcb5-d90bef6d4f87","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Input Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.completion_tokens) ) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"},"filters":{"items":[{"id":"14ee9f15-cd4f-453a-bc1f-90aa6c67ed49","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"ca7737dd-69d1-43d3-be60-7f770f382dba","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]},{"id":"86e07972-b41f-4cb8-b270-86badbb99522","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"in","value":["$llm_model"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"461e0704-f622-4069-acb0-c171fa379f5e","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Output Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"799913e6-fb95-497e-858a-6490b5f9d10d","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"A","filter":{"expression":"has_error = 'true' service.name in $service_name"},"filters":{"items":[{"id":"14ee9f15-cd4f-453a-bc1f-90aa6c67ed49","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"692ead8c-128f-4c43-bc10-5ed81004fe3a","key":{"id":"has_error","key":"has_error","type":""},"op":"=","value":"true"}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null},{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"B","filter":{"expression":"has_error = 'false' service.name in $service_name"},"filters":{"items":[{"id":"14ee9f15-cd4f-453a-bc1f-90aa6c67ed49","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"650e917a-d16c-4a78-8ae2-9e4adee0bd5a","key":{"id":"has_error","key":"has_error","type":""},"op":"=","value":"false"}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"B","source":"","stepInterval":null}],"queryFormulas":[{"disabled":false,"expression":"A / (A+B)","legend":"","queryName":"F1"}],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"06db8fa1-2559-4a1e-ae05-19f94089cb58","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[{"index":"e5e05d41-7479-4d60-a1cf-c433b8b61285","isEditEnabled":false,"keyIndex":1,"selectedGraph":"value","thresholdColor":"Red","thresholdFormat":"Text","thresholdLabel":"","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"percentunit","thresholdValue":10},{"index":"d74bf17b-552a-4636-8fad-c976b090d590","isEditEnabled":false,"keyIndex":0,"selectedGraph":"value","thresholdColor":"Orange","thresholdFormat":"Text","thresholdLabel":"","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"percentunit","thresholdValue":5}],"timePreferance":"GLOBAL_TIME","title":"Error Rate","yAxisUnit":"percentunit"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"3633c7ad-203a-4e25-99f4-8cc81bf15d65","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND gen_ai.request.model EXISTS"},"filters":{"items":[{"id":"14ee9f15-cd4f-453a-bc1f-90aa6c67ed49","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"dfad00b3-bdbc-4aa2-8de3-6fd704a859c7","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"exists","value":"undefined"}],"op":"AND"},"functions":[],"groupBy":[{"dataType":"string","id":"gen_ai.request.model--string--tag","isColumn":false,"isJSON":false,"key":"gen_ai.request.model","type":"tag"}],"having":{"expression":""},"legend":"{{gen_ai.request.model}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"d1ad853e-2d10-4b75-be1c-ef355ddf3222","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Model Distribution","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"F1":"#eccd03"},"description":"","fillSpans":false,"id":"28bb5d45-046d-4980-ad5e-26b1aeecda2b","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(llm.usage.total_tokens) ) ) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"},"filters":{"items":[{"id":"14ee9f15-cd4f-453a-bc1f-90aa6c67ed49","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"20e17fa1-4e3d-4d69-bee6-32b4c28e0d3e","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]},{"id":"9971f126-8ae0-4913-8f3b-48509556af48","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"in","value":["$llm_model"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"39e5fa6c-eb68-4f3d-94a0-dee6291a9815","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Token Usage","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"af79b14b-5e76-47fb-a24e-a4629c642c28","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"p95(duration_nano) "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"},"filters":{"items":[{"id":"14ee9f15-cd4f-453a-bc1f-90aa6c67ed49","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"5e99c2d8-7144-4893-97dc-c38a3500648a","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]},{"id":"3bf2e71f-1ec8-4bf2-86d5-c690e6198591","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"in","value":["$llm_model"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"fa7d3c90-3c95-448b-901b-ba9206c172a0","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Latency (P95)","yAxisUnit":"ns"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"A":"#edce64","count()":"#a403ff"},"description":"","fillSpans":false,"id":"74a94376-eeaf-43c1-a273-5d8b98197138","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"},"filters":{"items":[{"id":"14ee9f15-cd4f-453a-bc1f-90aa6c67ed49","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"6c857a5f-7ca9-43ed-9b1b-cec4d7e1b13b","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]},{"id":"8a6e8e99-54a6-4c5a-94d3-576d02baa64e","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"in","value":["$llm_model"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"8dbb7a0e-d188-4b27-993c-da996cfa9aa6","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Number of Requests","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"date":145,"duration_nano":145,"http_method":145,"name":145,"response_status_code":145,"service.name":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"5e66cb8c-2219-47e6-ba71-8f82f9873bc8","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"has_error = true service.name IN $service_name"},"filters":{"items":[{"id":"14ee9f15-cd4f-453a-bc1f-90aa6c67ed49","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"aa5c231a-a80c-44b4-a5e6-e6a05b7c353b","key":{"id":"has_error","key":"has_error","type":""},"op":"=","value":"true"}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"}],"pageSize":10,"queryName":"A","selectColumns":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"b85f93b2-09b5-4fcd-8aa8-f6a2875a41b5","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Errors","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A":""},"columnWidths":{"A":145,"service.name":145,"telemetry.sdk.language":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"67a074ee-c46e-4a36-8f5c-10d981cae404","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() as 'Count of Calls' "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name  AND gen_ai.request.model EXISTS"},"filters":{"items":[{"id":"14ee9f15-cd4f-453a-bc1f-90aa6c67ed49","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"5f60b47c-5e56-4be8-a495-aee36f49e799","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"exists","value":"undefined"}],"op":"AND"},"functions":[],"groupBy":[{"dataType":"string","id":"service.name--string--resource","isColumn":true,"isJSON":false,"key":"service.name","type":"resource"},{"dataType":"string","id":"telemetry.sdk.language--string--resource","isColumn":false,"isJSON":false,"key":"telemetry.sdk.language","type":"resource"}],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"c64fddf9-2e1c-4fcf-a820-2c572d73395c","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Services and Languages","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"A":"#5eddce"},"description":"","fillSpans":false,"id":"bc6e3017-2b44-4152-a0d7-fe11e6b7a290","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"metricName":"http.client.duration.max","reduceTo":"avg","spaceAggregation":"avg","temporality":"","timeAggregation":"avg"}],"dataSource":"metrics","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name"},"filters":{"items":[{"id":"14ee9f15-cd4f-453a-bc1f-90aa6c67ed49","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"3e688253-85e8-4cfc-814d-5ab821a950db","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"HTTP Request Duration","yAxisUnit":"ms"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"body":350,"timestamp":100},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"05e6759b-c460-4618-86c0-5d2bf0b311c1","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"logs","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name telemetry.sdk.language in $language"},"filters":{"items":[{"id":"14ee9f15-cd4f-453a-bc1f-90aa6c67ed49","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"ad1c34b3-c49a-43e3-8ff0-d54a4fd6b6db","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"},{"columnName":"id","order":"desc"}],"pageSize":10,"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"cf4892fd-86f1-4e83-a876-db114e6e125f","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Logs","yAxisUnit":"none"}]}
+{
+  "spec": {
+    "display": {
+      "name": "LiteLLM SDK",
+      "description": ""
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "service_name",
+            "description": "The service name using LiteLLM SDK"
+          },
+          "defaultValue": [
+            "litellm-otel",
+            "litellm-batch-worker"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "service.name",
+              "signal": "all"
+            }
+          },
+          "name": "service_name"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "language",
+            "description": "Language being used for making LiteLLM SDK calls"
+          },
+          "defaultValue": [
+            "python"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "telemetry.sdk.language",
+              "signal": "all"
+            }
+          },
+          "name": "language"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "llm_model",
+            "description": "Model name being used in LiteLLM SDK call"
+          },
+          "defaultValue": [
+            "openai/gpt-4.1",
+            "openai/gpt-4.1-mini",
+            "openai/gpt-5-mini",
+            "anthropic/claude-sonnet-5",
+            "anthropic/claude-haiku-4-5",
+            "gemini/gemini-2.5-flash",
+            "gemini/gemini-2.5-pro"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "gen_ai.request.model",
+              "signal": "all"
+            }
+          },
+          "name": "llm_model"
+        }
+      }
+    ],
+    "panels": {
+      "04247ee1-b408-457d-ac00-47ce45e64291": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Input Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(gen_ai.usage.prompt_tokens)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "05e6759b-c460-4618-86c0-5d2bf0b311c1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Logs",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "timestamp",
+                  "signal": "logs",
+                  "fieldContext": "log",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "body",
+                  "signal": "logs",
+                  "fieldContext": "log",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "logs",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name telemetry.sdk.language in $language"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "28bb5d45-046d-4980-ad5e-26b1aeecda2b": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Token Usage",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "litellm-batch-worker": "#E48BAA",
+                  "litellm-otel": "#5DB3E5"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(llm.usage.total_tokens)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "3633c7ad-203a-4e25-99f4-8cc81bf15d65": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Model Distribution",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "anthropic/claude-haiku-4-5": "#E55DD5",
+                  "anthropic/claude-sonnet-5": "#30E8C8",
+                  "gemini/gemini-2.5-flash": "#C0E48B",
+                  "gemini/gemini-2.5-pro": "#3067E8",
+                  "openai/gpt-4.1": "#3AE830",
+                  "openai/gpt-4.1-mini": "#7E5DE5",
+                  "openai/gpt-5-mini": "#E4BB8B"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND gen_ai.request.model EXISTS"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "gen_ai.request.model",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{gen_ai.request.model}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "5e66cb8c-2219-47e6-ba71-8f82f9873bc8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Errors",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "service.name",
+                  "signal": "traces",
+                  "fieldContext": "resource",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "name",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "duration_nano",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "http_method",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "response_status_code",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "has_error = true service.name IN $service_name"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "name",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "duration_nano",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "http_method",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "response_status_code",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      }
+                    ],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "67a074ee-c46e-4a36-8f5c-10d981cae404": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Services and Languages",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A": ""
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()",
+                        "alias": "Count of Calls"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name  AND gen_ai.request.model EXISTS"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "telemetry.sdk.language",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "74a94376-eeaf-43c1-a273-5d8b98197138": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Number of Requests",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "litellm-batch-worker": "#E48BAA",
+                  "litellm-otel": "#5DB3E5"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "799913e6-fb95-497e-858a-6490b5f9d10d": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Error Rate",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "percentunit",
+                "decimalPrecision": "2"
+              },
+              "thresholds": [
+                {
+                  "value": 0.1,
+                  "operator": "above",
+                  "unit": "percentunit",
+                  "color": "Red",
+                  "format": "text"
+                },
+                {
+                  "value": 0.05,
+                  "operator": "above",
+                  "unit": "percentunit",
+                  "color": "Orange",
+                  "format": "text"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "has_error = 'true' service.name in $service_name"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "has_error = 'false' service.name in $service_name"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "A / (A+B)",
+                          "disabled": false,
+                          "order": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "functions": null,
+                          "legend": ""
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "af79b14b-5e76-47fb-a24e-a4629c642c28": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Latency (P95)",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ns",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "litellm-batch-worker": "#E48BAA",
+                  "litellm-otel": "#5DB3E5"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "p95(duration_nano)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "bc6e3017-2b44-4152-a0d7-fe11e6b7a290": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "HTTP Request Duration",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ms",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "litellm-batch-worker": "#E48BAA",
+                  "litellm-otel": "#5DB3E5"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "metrics",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "metricName": "http.client.duration.max",
+                        "temporality": "",
+                        "timeAggregation": "avg",
+                        "spaceAggregation": "avg",
+                        "reduceTo": "avg"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Output Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(gen_ai.usage.completion_tokens)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/04247ee1-b408-457d-ac00-47ce45e64291"
+              }
+            },
+            {
+              "x": 4,
+              "y": 0,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570"
+              }
+            },
+            {
+              "x": 8,
+              "y": 0,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/799913e6-fb95-497e-858a-6490b5f9d10d"
+              }
+            },
+            {
+              "x": 0,
+              "y": 3,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/74a94376-eeaf-43c1-a273-5d8b98197138"
+              }
+            },
+            {
+              "x": 6,
+              "y": 3,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/af79b14b-5e76-47fb-a24e-a4629c642c28"
+              }
+            },
+            {
+              "x": 0,
+              "y": 9,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/28bb5d45-046d-4980-ad5e-26b1aeecda2b"
+              }
+            },
+            {
+              "x": 6,
+              "y": 9,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/bc6e3017-2b44-4152-a0d7-fe11e6b7a290"
+              }
+            },
+            {
+              "x": 0,
+              "y": 15,
+              "width": 4,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/3633c7ad-203a-4e25-99f4-8cc81bf15d65"
+              }
+            },
+            {
+              "x": 4,
+              "y": 15,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/67a074ee-c46e-4a36-8f5c-10d981cae404"
+              }
+            },
+            {
+              "x": 0,
+              "y": 21,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/5e66cb8c-2219-47e6-ba71-8f82f9873bc8"
+              }
+            },
+            {
+              "x": 6,
+              "y": 21,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/05e6759b-c460-4618-86c0-5d2bf0b311c1"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "",
+    "refreshInterval": "",
+    "links": []
+  },
+  "tags": [],
+  "image": "/assets/Icons/eight-ball"
+}

--- a/livekit/livekit-dashboard.json
+++ b/livekit/livekit-dashboard.json
@@ -1,1 +1,1390 @@
-{"description":"","image":"data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE0Ljk0OTQgMTMuOTQyQzE2LjIzMTggMTIuNDI1OCAxNy4zMjY4IDkuNzAyMiAxNi4xOTU2IDYuNTc0ODdDMTUuNjQ0MyA1LjA1MjQ1IDE1LjAyMTkgNC4yMDI0OSAxNC4yOTY5IDMuNjYyNTJDMTMuODU1NyAzLjMzMzc5IDEyLjA5MzMgMi41MDYzMyA5Ljc1OTY1IDIuODY3NTZDOC4wNTM0OSAzLjEzMjU1IDUuNzc0ODcgNC4yMDg3NCA0LjI5MzY5IDUuOTU5OUMyLjg1NzUyIDcuNjYxMDYgMS43NDg4MyA5LjAwNDc0IDEuNjk3NTggMTAuMzA5N0MxLjYzMTMzIDExLjk4ODMgMi44OTYyNyAxMy40MzA4IDMuMDUwMDEgMTMuNjY0NUMzLjMyMzc0IDE0LjA3OTUgNS4xOTExNSAxNi40NTE4IDguNjk5NzEgMTYuNTczMUMxMS43OTcgMTYuNjc5MyAxMy44MTQ0IDE1LjI4NDQgMTQuOTQ5NCAxMy45NDJaIiBmaWxsPSIjNDAzRDNFIi8+CjxwYXRoIGQ9Ik00LjU1MzYzIDIuNzM3NDdDMi45Mzc0NiAzLjg5MTE2IDEuMTIxMzEgNi4yNTEwMyAxLjQ0NzU0IDkuNTYwODZDMS42MDYyOCAxMS4xNzIgMi4wMDI1MSAxMi4xNDk1IDIuNTcxMjMgMTIuODUwN0MyLjkxNzQ2IDEzLjI3ODIgNC40MTk4OCAxNC41NDkzIDYuNzczNTEgMTQuNzM2OEM5LjE0NTg4IDE0LjkyNTYgMTAuOTQ5NSAxNC4zOTQ0IDEyLjgzMzIgMTMuMDg0NEMxNi42NjE3IDEwLjQyMDggMTYuMDk4IDYuMzkzNTMgMTUuOTM0MyA1LjkyNDhDMTUuNzcwNSA1LjQ1NjA3IDE0LjU0NDQgMi42OTYyMiAxMS4xNzMzIDEuNzE1MDJDOC4xOTg0NCAwLjg1MDA2OCA1Ljk4MzU1IDEuNzE1MDIgNC41NTM2MyAyLjczNzQ3WiIgZmlsbD0iIzVFNjM2NyIvPgo8cGF0aCBkPSJNNy4zOTM1MyAyLjk2MTA5QzUuNjE3MzcgMi44OTczNCAzLjkxOTk2IDQuMjg4NTIgMy43NTYyMiA2LjAwNTkzQzMuNTkyNDggNy43MjIwOSA0LjY1NDkyIDkuMDI5NTIgNi4zMDk4MyA5LjI5NTc2QzcuOTY0NzUgOS41NjA3NCA5Ljg3ODM5IDguNTU1OCAxMC4yNjM0IDYuNDUwOTFDMTAuNjYwOSA0LjI4MjI3IDkuMDg5NjkgMy4wMjIzNCA3LjM5MzUzIDIuOTYxMDlaIiBmaWxsPSJ3aGl0ZSIvPgo8cGF0aCBkPSJNNy45NDIxNyA1LjkwMTE1QzcuOTQyMTcgNS45MDExNSA4LjM2OTY1IDUuODEyNCA4LjQ1NDY1IDUuMTgyNDRDOC41MzgzOSA0LjU2MjQ3IDguMjMwOTEgNC4wMzM3NSA3LjUxMzQ1IDMuODQzNzZDNi43MzM0OSAzLjYzNzUyIDYuMjA0NzcgNC4wNjYyNSA2LjA2NzI3IDQuNTE3NDdDNS44NzYwMyA1LjE0NDk0IDYuMTU4NTIgNS40NDM2NyA2LjE1ODUyIDUuNDQzNjdDNi4xNTg1MiA1LjQ0MzY3IDUuMzkzNTYgNS42Mjc0MSA1LjMzMjMxIDYuNTI5ODdDNS4yNzQ4MSA3LjM4MTA3IDUuODU2MDMgNy44Mzg1NSA2LjQzOTc1IDcuOTc4NTRDNy4xNjA5NiA4LjE1MjI4IDcuOTc4NDIgNy45NTQ3OSA4LjE3ODQxIDcuMDM0ODRDOC4zNDQ2NSA2LjI3NzM4IDcuOTQyMTcgNS45MDExNSA3Ljk0MjE3IDUuOTAxMTVaIiBmaWxsPSIjMzAzMDMwIi8+CjxwYXRoIGQ9Ik02LjczOTgzIDQuNzUzNjJDNi42NzEwOSA1LjAxMjM1IDYuODA4NTggNS4yNjIzNCA3LjA3ODU3IDUuMzMxMDlDNy4zNjk4IDUuNDA0ODMgNy42MzQ3OSA1LjMwODU5IDcuNzA2MDMgNS4wMTExQzcuNzY4NTMgNC43NDczNyA3LjY0MzU0IDQuNTE0ODggNy4zMzYwNSA0LjQzOTg4QzcuMDgzNTcgNC4zNzczOSA2LjgxNDgzIDQuNDcxMTMgNi43Mzk4MyA0Ljc1MzYyWiIgZmlsbD0id2hpdGUiLz4KPHBhdGggZD0iTTYuOTU5NzggNi4wMzk3NEM2LjYzMjMgNS45Mzg0OSA2LjE5OTgyIDYuMDY0NzMgNi4xMzEwNyA2LjUwNDcxQzYuMDYyMzMgNi45NDQ2OSA2LjMyNjA2IDcuMTY5NjggNi42NzEwNCA3LjIzMjE3QzcuMDE2MDMgNy4yOTQ2NyA3LjM0MjI2IDcuMTEzNDMgNy40MDYwMSA2Ljc2MDk1QzcuNDY4NSA2LjQwOTcyIDcuMjg2MDEgNi4xMzk3MyA2Ljk1OTc4IDYuMDM5NzRaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K","layout":[{"h":3,"i":"04247ee1-b408-457d-ac00-47ce45e64291","moved":false,"static":false,"w":3,"x":0,"y":0},{"h":3,"i":"d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570","moved":false,"static":false,"w":3,"x":3,"y":0},{"h":3,"i":"799913e6-fb95-497e-858a-6490b5f9d10d","moved":false,"static":false,"w":3,"x":6,"y":0},{"h":6,"i":"3633c7ad-203a-4e25-99f4-8cc81bf15d65","moved":false,"static":false,"w":3,"x":9,"y":0},{"h":3,"i":"579f8e38-9b07-4c73-ae6c-db82b65ea4b2","moved":false,"static":false,"w":3,"x":0,"y":3},{"h":3,"i":"7acd2252-19fb-4734-9dd2-d1152ef6da3d","moved":false,"static":false,"w":3,"x":3,"y":3},{"h":3,"i":"fe46bf68-9c77-478f-958e-36d8478ebbcd","moved":false,"static":false,"w":3,"x":6,"y":3},{"h":5,"i":"28bb5d45-046d-4980-ad5e-26b1aeecda2b","moved":false,"static":false,"w":5,"x":0,"y":6},{"h":5,"i":"74a94376-eeaf-43c1-a273-5d8b98197138","moved":false,"static":false,"w":5,"x":5,"y":6},{"h":5,"i":"af79b14b-5e76-47fb-a24e-a4629c642c28","moved":false,"static":false,"w":5,"x":0,"y":11},{"h":4,"i":"bc6e3017-2b44-4152-a0d7-fe11e6b7a290","moved":false,"static":false,"w":5,"x":5,"y":11},{"h":3,"i":"67a074ee-c46e-4a36-8f5c-10d981cae404","moved":false,"static":false,"w":6,"x":5,"y":15},{"h":6,"i":"e9849813-832e-4661-9395-a11fd60f80d1","moved":false,"static":false,"w":5,"x":0,"y":16},{"h":7,"i":"05e6759b-c460-4618-86c0-5d2bf0b311c1","moved":false,"static":false,"w":6,"x":5,"y":18},{"h":3,"i":"5e66cb8c-2219-47e6-ba71-8f82f9873bc8","moved":false,"static":false,"w":5,"x":0,"y":22}],"panelMap":{},"tags":[],"title":"LiveKit","uploadedGrafana":false,"uuid":"019abc1a-863f-7db0-a7e3-6fb47b4558b9","variables":{"10d0eca9-9253-4583-821c-d3c812d78151":{"allSelected":false,"customValue":"","defaultValue":"","description":"The service name using LiveKit","dynamicVariablesAttribute":"service.name","dynamicVariablesSource":"All telemetry","id":"10d0eca9-9253-4583-821c-d3c812d78151","key":"10d0eca9-9253-4583-821c-d3c812d78151","modificationUUID":"d79a90b3-eb3b-4018-bfc5-d06ffd2d454c","multiSelect":true,"name":"service_name","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"2c6e624c-7059-4f1c-be3b-810267de5857":{"allSelected":false,"customValue":"","description":"Number of turns in the conversation","id":"2c6e624c-7059-4f1c-be3b-810267de5857","modificationUUID":"e26619ce-4cf5-4ea7-98f6-06c6ed628f0b","multiSelect":false,"name":"turns_threshold","order":0,"queryValue":"","showALLOption":false,"sort":"DISABLED","textboxValue":"1","type":"TEXTBOX"},"93c33118-5f46-404b-b45e-8a81160c44c4":{"allSelected":true,"customValue":"","defaultValue":"","description":"Language being used for making LiveKit calls","dynamicVariablesAttribute":"telemetry.sdk.language","dynamicVariablesSource":"All telemetry","id":"93c33118-5f46-404b-b45e-8a81160c44c4","key":"93c33118-5f46-404b-b45e-8a81160c44c4","modificationUUID":"e1a5e1a6-3213-4e76-89f3-01d65cc0471f","multiSelect":true,"name":"language","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"be7a68c4-fb97-43ea-bb94-0ded120bd3d7":{"allSelected":false,"customValue":"","defaultValue":"","description":"Model name being used in LiveKit convsersation","dynamicVariablesAttribute":"gen_ai.request.model","dynamicVariablesSource":"All telemetry","id":"be7a68c4-fb97-43ea-bb94-0ded120bd3d7","key":"be7a68c4-fb97-43ea-bb94-0ded120bd3d7","modificationUUID":"460f0828-704f-44f7-8309-65a1dd3b3eca","multiSelect":true,"name":"llm_model","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"}},"version":"v5","widgets":[{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"04247ee1-b408-457d-ac00-47ce45e64291","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.input_tokens) ) ) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name name = 'llm_request' telemetry.sdk.language in $language gen_ai.request.model in $llm_model"},"filters":{"items":[{"id":"d0fd8178-0307-45dd-9459-1b052b22121d","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"74afd5bd-e3cd-4124-812f-9b22af1e9b83","key":{"id":"name","key":"name","type":""},"op":"=","value":"llm_request"},{"id":"b3200e23-2e69-4280-9b23-f344c3a7475e","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]},{"id":"2e4f0b1e-e0d0-4add-b35d-8df31003053e","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"in","value":["$llm_model"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"2acb7a2a-806a-4e4e-a5ab-96d618665a8d","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Input Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.output_tokens) ) ) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name name = 'llm_request' telemetry.sdk.language in $language gen_ai.request.model in $llm_model"},"filters":{"items":[{"id":"d0fd8178-0307-45dd-9459-1b052b22121d","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"5b65db7c-54f0-4ead-a245-000f1a310367","key":{"id":"name","key":"name","type":""},"op":"=","value":"llm_request"},{"id":"05dd81e7-7490-4a84-a7f9-20fb87823462","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]},{"id":"8f51f6e6-1a0d-4004-88fc-c851c8c511a3","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"in","value":["$llm_model"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"364df34d-e61e-46aa-bd53-e83342b2b0ff","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Output Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"799913e6-fb95-497e-858a-6490b5f9d10d","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"A","filter":{"expression":"has_error = 'true' service.name in $service_name"},"filters":{"items":[{"id":"45f6077f-8492-46fe-b146-4a31f92cd1bd","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"1426bee0-f647-4d48-be3d-8d0862722f92","key":{"id":"has_error","key":"has_error","type":""},"op":"=","value":"true"}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null},{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"B","filter":{"expression":"has_error = 'false' service.name in $service_name"},"filters":{"items":[{"id":"45f6077f-8492-46fe-b146-4a31f92cd1bd","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"c3bd2eb4-ee27-4e25-81a3-218260a30494","key":{"id":"has_error","key":"has_error","type":""},"op":"=","value":"false"}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"B","source":"","stepInterval":null}],"queryFormulas":[{"disabled":false,"expression":"A / (A+B)","legend":"","queryName":"F1"}],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"06db8fa1-2559-4a1e-ae05-19f94089cb58","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[{"index":"e5e05d41-7479-4d60-a1cf-c433b8b61285","isEditEnabled":false,"keyIndex":1,"selectedGraph":"value","thresholdColor":"Red","thresholdFormat":"Text","thresholdLabel":"","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"percentunit","thresholdValue":10},{"index":"d74bf17b-552a-4636-8fad-c976b090d590","isEditEnabled":false,"keyIndex":0,"selectedGraph":"value","thresholdColor":"Orange","thresholdFormat":"Text","thresholdLabel":"","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"percentunit","thresholdValue":5}],"timePreferance":"GLOBAL_TIME","title":"Error Rate","yAxisUnit":"percentunit"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"3633c7ad-203a-4e25-99f4-8cc81bf15d65","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND gen_ai.request.model EXISTS"},"filters":{"items":[{"id":"14ee9f15-cd4f-453a-bc1f-90aa6c67ed49","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"dfad00b3-bdbc-4aa2-8de3-6fd704a859c7","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"exists","value":"undefined"}],"op":"AND"},"functions":[],"groupBy":[{"dataType":"string","id":"gen_ai.request.model--string--tag","isColumn":false,"isJSON":false,"key":"gen_ai.request.model","type":"tag"}],"having":{"expression":""},"legend":"{{gen_ai.request.model}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"d1ad853e-2d10-4b75-be1c-ef355ddf3222","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Model Distribution","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"F1":"#eccd03"},"decimalPrecision":2,"description":"","fillSpans":false,"id":"28bb5d45-046d-4980-ad5e-26b1aeecda2b","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.input_tokens)"}],"dataSource":"traces","disabled":true,"expression":"A","filter":{"expression":"service.name in $service_name name = 'llm_request' telemetry.sdk.language in $language gen_ai.request.model in $llm_model"},"filters":{"items":[{"id":"d0fd8178-0307-45dd-9459-1b052b22121d","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"afc94045-7cd4-450e-ac31-76cfd877a430","key":{"id":"name","key":"name","type":""},"op":"=","value":"llm_request"},{"id":"7618e9a5-0e5a-4c3d-bcd8-62653857c8dc","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]},{"id":"ebbb3064-6b3c-47b3-9f7d-bc8aac73cf26","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"in","value":["$llm_model"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null},{"aggregations":[{"expression":"sum(gen_ai.usage.output_tokens) ) "}],"dataSource":"traces","disabled":true,"expression":"B","filter":{"expression":"service.name in $service_name name = 'llm_request' telemetry.sdk.language in $language gen_ai.request.model in $llm_model"},"filters":{"items":[{"id":"d0fd8178-0307-45dd-9459-1b052b22121d","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"aaaf3b9d-4ba1-4112-bd99-b79bb85937f9","key":{"id":"name","key":"name","type":""},"op":"=","value":"llm_request"},{"id":"3ee19322-45f7-4049-95b2-a04410d283d1","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]},{"id":"63118eda-02fb-4315-9785-a0026b9966b2","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"in","value":["$llm_model"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"B","source":"","stepInterval":null}],"queryFormulas":[{"disabled":false,"expression":"A + B","legend":"","queryName":"F1"}],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"e77025a4-01b7-4df4-8ab7-4e7a552fa950","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Token Usage","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"af79b14b-5e76-47fb-a24e-a4629c642c28","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"p95(duration_nano) "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language name = 'agent_turn'"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"164e8a7e-d654-42c5-9f05-f71f97764e8b","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Agent Response Latency (P95)","yAxisUnit":"ns"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"A":"#edce64","count()":"#a403ff"},"decimalPrecision":2,"description":"","fillSpans":false,"id":"74a94376-eeaf-43c1-a273-5d8b98197138","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND name = 'job_entrypoint'"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"d06c6f78-55b6-4d4e-8029-8bc10cbf55b2","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Number of Conversations","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"date":145,"duration_nano":145,"http_method":145,"name":145,"response_status_code":145,"service.name":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"5e66cb8c-2219-47e6-ba71-8f82f9873bc8","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"has_error = 'true' service.name IN $service_name"},"filters":{"items":[{"id":"45f6077f-8492-46fe-b146-4a31f92cd1bd","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"cd7bce73-6b30-45bb-bd0a-0e93316a2ddd","key":{"id":"has_error","key":"has_error","type":""},"op":"=","value":"true"}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"}],"pageSize":10,"queryName":"A","selectColumns":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"b85f93b2-09b5-4fcd-8aa8-f6a2875a41b5","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Errors","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A":""},"columnWidths":{"A":145,"service.name":145,"telemetry.sdk.language":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"67a074ee-c46e-4a36-8f5c-10d981cae404","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() as 'Count of Conversations' "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name AND telemetry.sdk.language IN $language AND name = 'job_entrypoint'"},"filters":{"items":[{"id":"d0fd8178-0307-45dd-9459-1b052b22121d","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"5eedcf6b-65b0-4ce2-bb47-7a228ba91b18","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]},{"id":"1ac12c80-bdaf-48a4-b528-3b0d43fef423","key":{"id":"name","key":"name","type":""},"op":"=","value":"job_entrypoint"}],"op":"AND"},"functions":[],"groupBy":[{"dataType":"string","id":"service.name--string--resource","isColumn":true,"isJSON":false,"key":"service.name","type":"resource"},{"dataType":"string","id":"telemetry.sdk.language--string--resource","isColumn":false,"isJSON":false,"key":"telemetry.sdk.language","type":"resource"}],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"0acfe809-680f-4475-80a3-fa286feb54e1","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Services and Languages","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"A":"#5eddce"},"decimalPrecision":2,"description":"","fillSpans":false,"id":"bc6e3017-2b44-4152-a0d7-fe11e6b7a290","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"metricName":"http.client.duration.max","reduceTo":"avg","spaceAggregation":"avg","temporality":"","timeAggregation":"avg"}],"dataSource":"metrics","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name"},"filters":{"items":[{"id":"d0fd8178-0307-45dd-9459-1b052b22121d","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"3e688253-85e8-4cfc-814d-5ab821a950db","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"HTTP Request Duration","yAxisUnit":"ms"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"body":350,"timestamp":100},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"05e6759b-c460-4618-86c0-5d2bf0b311c1","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"logs","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name telemetry.sdk.language in $language"},"filters":{"items":[{"id":"14ee9f15-cd4f-453a-bc1f-90aa6c67ed49","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"ad1c34b3-c49a-43e3-8ff0-d54a4fd6b6db","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"},{"columnName":"id","order":"desc"}],"pageSize":10,"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"cf4892fd-86f1-4e83-a876-db114e6e125f","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Logs","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"e9849813-832e-4661-9395-a11fd60f80d1","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"avg(duration_nano)"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name AND name = 'tts_node'"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"7dd67ed5-b734-434e-a146-1cbf121e0c6c","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"TTS Duration","yAxisUnit":"ns"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"579f8e38-9b07-4c73-ae6c-db82b65ea4b2","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregateAttribute":{"dataType":"","id":"----","key":"","type":""},"aggregateOperator":"count","aggregations":[{"expression":"count_distinct(trace_id)"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name name = 'agent_turn' AND count < $turns_threshold"},"filters":{"items":[{"id":"fcaf87c9-4e50-4990-8d3c-5bfc6908d34f","key":{"id":"service.name","key":"service.name","type":""},"op":"in","value":["$service_name"]},{"id":"0a01543a-b91f-4642-a3b1-dbd14f975f7d","key":{"id":"name","key":"name","type":""},"op":"=","value":"agent_turn"},{"id":"a3deb5cb-c76b-45e5-9cda-97d0b8ec1741","key":{"id":"count","key":"count","type":""},"op":"<","value":"$turns_threshold"}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","reduceTo":"avg","source":"","spaceAggregation":"sum","stepInterval":null,"timeAggregation":"rate"}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":"SELECT\n    count() AS conversations_below_threshold\nFROM (\n    SELECT\n        traceID,\n        count(*) AS turn_count\n    FROM signoz_traces.distributed_signoz_index_v3\n    WHERE serviceName IN $service_name\n      AND name = 'agent_turn'\n    GROUP BY traceID\n    HAVING turn_count < toUInt64($turns_threshold)\n)\n"}],"id":"d7ca4560-7e08-4025-b563-f44be21b45b7","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"clickhouse_sql"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Number of Conversations Below Threshold","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A":""},"columnWidths":{"traceID":145,"turn_count":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"fe46bf68-9c77-478f-958e-36d8478ebbcd","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregateAttribute":{"dataType":"","id":"----","key":"","type":""},"aggregateOperator":"count","aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":""},"filters":{"items":[],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","reduceTo":"avg","source":"","spaceAggregation":"sum","stepInterval":null,"timeAggregation":"rate"}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":"SELECT\n    traceID,\n    turn_count\nFROM (\n    SELECT\n        traceID,\n        count(*) AS turn_count\n    FROM signoz_traces.distributed_signoz_index_v3\n    WHERE serviceName IN $service_name\n      AND name = 'agent_turn'\n    GROUP BY traceID\n)\nWHERE turn_count < toUInt64($turns_threshold)\nORDER BY turn_count ASC, traceID\n"}],"id":"6e0e1cbc-4073-4148-912e-70775add4b6b","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"clickhouse_sql"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Conversations Below Threshold","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"7acd2252-19fb-4734-9dd2-d1152ef6da3d","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregateAttribute":{"dataType":"","id":"----","key":"","type":""},"aggregateOperator":"count","aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":""},"filters":{"items":[],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","reduceTo":"avg","source":"","spaceAggregation":"sum","stepInterval":null,"timeAggregation":"rate"}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":"SELECT\n    avg(turn_count) AS avg_turns_per_conversation\nFROM (\n    SELECT\n        traceID,\n        count(*) AS turn_count\n    FROM signoz_traces.distributed_signoz_index_v3\n    WHERE serviceName IN $service_name\n      AND name = 'agent_turn'\n    GROUP BY traceID\n)\n"}],"id":"169c7ecc-7bc4-47de-bb86-a9560aa7bf26","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"clickhouse_sql"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Average Turns Per Conversation","yAxisUnit":"none"}]}
+{
+  "spec": {
+    "display": {
+      "name": "LiveKit",
+      "description": ""
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "service_name",
+            "description": "The service name using LiveKit"
+          },
+          "defaultValue": [
+            "livekit-otel",
+            "livekit-voice-agent",
+            "livekit-telephony"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "service.name",
+              "signal": "all"
+            }
+          },
+          "name": "service_name"
+        }
+      },
+      {
+        "kind": "TextVariable",
+        "spec": {
+          "display": {
+            "name": "turns_threshold",
+            "description": "Number of turns in the conversation"
+          },
+          "value": "3",
+          "constant": false,
+          "name": "turns_threshold"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "language",
+            "description": "Language being used for making LiveKit calls"
+          },
+          "defaultValue": [
+            "python"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "telemetry.sdk.language",
+              "signal": "all"
+            }
+          },
+          "name": "language"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "llm_model",
+            "description": "Model name being used in LiveKit convsersation"
+          },
+          "defaultValue": [
+            "openai/gpt-4.1-mini",
+            "openai/gpt-4.1",
+            "google/gemini-2.5-flash",
+            "anthropic/claude-haiku-4-5"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "gen_ai.request.model",
+              "signal": "all"
+            }
+          },
+          "name": "llm_model"
+        }
+      }
+    ],
+    "panels": {
+      "04247ee1-b408-457d-ac00-47ce45e64291": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Input Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(gen_ai.usage.input_tokens)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name name = 'llm_request' telemetry.sdk.language in $language gen_ai.request.model in $llm_model"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "05e6759b-c460-4618-86c0-5d2bf0b311c1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Logs",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "timestamp",
+                  "signal": "logs",
+                  "fieldContext": "log",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "body",
+                  "signal": "logs",
+                  "fieldContext": "log",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "logs",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name telemetry.sdk.language in $language"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "28bb5d45-046d-4980-ad5e-26b1aeecda2b": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Token Usage",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "F1": "#eccd03"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "sum(gen_ai.usage.input_tokens)"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "service.name in $service_name name = 'llm_request' telemetry.sdk.language in $language gen_ai.request.model in $llm_model"
+                          },
+                          "groupBy": [
+                            {
+                              "name": "service.name",
+                              "signal": "",
+                              "fieldContext": "resource",
+                              "fieldDataType": "string"
+                            }
+                          ],
+                          "order": null,
+                          "selectFields": null,
+                          "secondaryAggregations": null,
+                          "functions": null,
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "sum(gen_ai.usage.output_tokens)"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "service.name in $service_name name = 'llm_request' telemetry.sdk.language in $language gen_ai.request.model in $llm_model"
+                          },
+                          "groupBy": [
+                            {
+                              "name": "service.name",
+                              "signal": "",
+                              "fieldContext": "resource",
+                              "fieldDataType": "string"
+                            }
+                          ],
+                          "order": null,
+                          "selectFields": null,
+                          "secondaryAggregations": null,
+                          "functions": null,
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "A + B",
+                          "disabled": false,
+                          "order": null,
+                          "functions": null,
+                          "legend": "{{service.name}}"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "3633c7ad-203a-4e25-99f4-8cc81bf15d65": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Model Distribution",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": null
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND gen_ai.request.model EXISTS"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "gen_ai.request.model",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{gen_ai.request.model}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "579f8e38-9b07-4c73-ae6c-db82b65ea4b2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Number of Conversations Below Threshold",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/ClickHouseSQL",
+                  "spec": {
+                    "name": "A",
+                    "query": "SELECT\n    count() AS conversations_below_threshold\nFROM (\n    SELECT\n        traceID,\n        count(*) AS turn_count\n    FROM signoz_traces.distributed_signoz_index_v3\n    WHERE serviceName IN $service_name\n      AND name = 'agent_turn'\n    GROUP BY traceID\n    HAVING turn_count < toUInt64($turns_threshold)\n)\n",
+                    "disabled": false,
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "5e66cb8c-2219-47e6-ba71-8f82f9873bc8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Errors",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "service.name",
+                  "signal": "traces",
+                  "fieldContext": "resource",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "name",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "duration_nano",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "http_method",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "response_status_code",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "has_error = 'true' service.name IN $service_name"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "name",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "duration_nano",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "http_method",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "response_status_code",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      }
+                    ],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "67a074ee-c46e-4a36-8f5c-10d981cae404": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Services and Languages",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A": ""
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()",
+                        "alias": "Count of Conversations"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name AND telemetry.sdk.language IN $language AND name = 'job_entrypoint'"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "telemetry.sdk.language",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "74a94376-eeaf-43c1-a273-5d8b98197138": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Number of Conversations",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "A": "#edce64",
+                  "count()": "#a403ff"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND name = 'job_entrypoint'"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "799913e6-fb95-497e-858a-6490b5f9d10d": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Error Rate",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "percentunit",
+                "decimalPrecision": "2"
+              },
+              "thresholds": [
+                {
+                  "value": 0.1,
+                  "operator": "above",
+                  "unit": "percentunit",
+                  "color": "Red",
+                  "format": "text"
+                },
+                {
+                  "value": 0.05,
+                  "operator": "above",
+                  "unit": "percentunit",
+                  "color": "Orange",
+                  "format": "text"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "has_error = 'true' service.name in $service_name"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "has_error = 'false' service.name in $service_name"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "A / (A+B)",
+                          "disabled": false,
+                          "order": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "functions": null,
+                          "legend": ""
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "7acd2252-19fb-4734-9dd2-d1152ef6da3d": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Average Turns Per Conversation",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/ClickHouseSQL",
+                  "spec": {
+                    "name": "A",
+                    "query": "SELECT\n    avg(turn_count) AS avg_turns_per_conversation\nFROM (\n    SELECT\n        traceID,\n        count(*) AS turn_count\n    FROM signoz_traces.distributed_signoz_index_v3\n    WHERE serviceName IN $service_name\n      AND name = 'agent_turn'\n    GROUP BY traceID\n)\n",
+                    "disabled": false,
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "af79b14b-5e76-47fb-a24e-a4629c642c28": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Agent Response Latency (P95)",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ns",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": null
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "p95(duration_nano)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name telemetry.sdk.language in $language name = 'agent_turn'"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "bc6e3017-2b44-4152-a0d7-fe11e6b7a290": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "HTTP Request Duration",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ms",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "A": "#5eddce"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "metrics",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "metricName": "http.client.duration.max",
+                        "temporality": "",
+                        "timeAggregation": "avg",
+                        "spaceAggregation": "avg",
+                        "reduceTo": "avg"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Output Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(gen_ai.usage.output_tokens)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name name = 'llm_request' telemetry.sdk.language in $language gen_ai.request.model in $llm_model"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "e9849813-832e-4661-9395-a11fd60f80d1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "TTS Duration",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ns",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": null
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "avg(duration_nano)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name AND name = 'tts_node'"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "fe46bf68-9c77-478f-958e-36d8478ebbcd": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Conversations Below Threshold",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A": ""
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/ClickHouseSQL",
+                  "spec": {
+                    "name": "A",
+                    "query": "SELECT\n    traceID,\n    turn_count\nFROM (\n    SELECT\n        traceID,\n        count(*) AS turn_count\n    FROM signoz_traces.distributed_signoz_index_v3\n    WHERE serviceName IN $service_name\n      AND name = 'agent_turn'\n    GROUP BY traceID\n)\nWHERE turn_count < toUInt64($turns_threshold)\nORDER BY turn_count ASC, traceID\n",
+                    "disabled": false,
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 3,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/04247ee1-b408-457d-ac00-47ce45e64291"
+              }
+            },
+            {
+              "x": 3,
+              "y": 0,
+              "width": 3,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570"
+              }
+            },
+            {
+              "x": 6,
+              "y": 0,
+              "width": 3,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/799913e6-fb95-497e-858a-6490b5f9d10d"
+              }
+            },
+            {
+              "x": 9,
+              "y": 0,
+              "width": 3,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/7acd2252-19fb-4734-9dd2-d1152ef6da3d"
+              }
+            },
+            {
+              "x": 0,
+              "y": 3,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/74a94376-eeaf-43c1-a273-5d8b98197138"
+              }
+            },
+            {
+              "x": 6,
+              "y": 3,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/af79b14b-5e76-47fb-a24e-a4629c642c28"
+              }
+            },
+            {
+              "x": 0,
+              "y": 9,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/e9849813-832e-4661-9395-a11fd60f80d1"
+              }
+            },
+            {
+              "x": 6,
+              "y": 9,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/bc6e3017-2b44-4152-a0d7-fe11e6b7a290"
+              }
+            },
+            {
+              "x": 0,
+              "y": 15,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/28bb5d45-046d-4980-ad5e-26b1aeecda2b"
+              }
+            },
+            {
+              "x": 8,
+              "y": 15,
+              "width": 4,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/3633c7ad-203a-4e25-99f4-8cc81bf15d65"
+              }
+            },
+            {
+              "x": 0,
+              "y": 21,
+              "width": 5,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/fe46bf68-9c77-478f-958e-36d8478ebbcd"
+              }
+            },
+            {
+              "x": 5,
+              "y": 21,
+              "width": 3,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/579f8e38-9b07-4c73-ae6c-db82b65ea4b2"
+              }
+            },
+            {
+              "x": 8,
+              "y": 21,
+              "width": 4,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/67a074ee-c46e-4a36-8f5c-10d981cae404"
+              }
+            },
+            {
+              "x": 0,
+              "y": 27,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/5e66cb8c-2219-47e6-ba71-8f82f9873bc8"
+              }
+            },
+            {
+              "x": 6,
+              "y": 27,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/05e6759b-c460-4618-86c0-5d2bf0b311c1"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "",
+    "refreshInterval": "",
+    "links": []
+  },
+  "tags": [],
+  "image": "/assets/Icons/eight-ball"
+}

--- a/mastra/mastra-dashboard.json
+++ b/mastra/mastra-dashboard.json
@@ -1,1 +1,1007 @@
-{"description":"","image":"data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE0Ljk0OTQgMTMuOTQyQzE2LjIzMTggMTIuNDI1OCAxNy4zMjY4IDkuNzAyMiAxNi4xOTU2IDYuNTc0ODdDMTUuNjQ0MyA1LjA1MjQ1IDE1LjAyMTkgNC4yMDI0OSAxNC4yOTY5IDMuNjYyNTJDMTMuODU1NyAzLjMzMzc5IDEyLjA5MzMgMi41MDYzMyA5Ljc1OTY1IDIuODY3NTZDOC4wNTM0OSAzLjEzMjU1IDUuNzc0ODcgNC4yMDg3NCA0LjI5MzY5IDUuOTU5OUMyLjg1NzUyIDcuNjYxMDYgMS43NDg4MyA5LjAwNDc0IDEuNjk3NTggMTAuMzA5N0MxLjYzMTMzIDExLjk4ODMgMi44OTYyNyAxMy40MzA4IDMuMDUwMDEgMTMuNjY0NUMzLjMyMzc0IDE0LjA3OTUgNS4xOTExNSAxNi40NTE4IDguNjk5NzEgMTYuNTczMUMxMS43OTcgMTYuNjc5MyAxMy44MTQ0IDE1LjI4NDQgMTQuOTQ5NCAxMy45NDJaIiBmaWxsPSIjNDAzRDNFIi8+CjxwYXRoIGQ9Ik00LjU1MzYzIDIuNzM3NDdDMi45Mzc0NiAzLjg5MTE2IDEuMTIxMzEgNi4yNTEwMyAxLjQ0NzU0IDkuNTYwODZDMS42MDYyOCAxMS4xNzIgMi4wMDI1MSAxMi4xNDk1IDIuNTcxMjMgMTIuODUwN0MyLjkxNzQ2IDEzLjI3ODIgNC40MTk4OCAxNC41NDkzIDYuNzczNTEgMTQuNzM2OEM5LjE0NTg4IDE0LjkyNTYgMTAuOTQ5NSAxNC4zOTQ0IDEyLjgzMzIgMTMuMDg0NEMxNi42NjE3IDEwLjQyMDggMTYuMDk4IDYuMzkzNTMgMTUuOTM0MyA1LjkyNDhDMTUuNzcwNSA1LjQ1NjA3IDE0LjU0NDQgMi42OTYyMiAxMS4xNzMzIDEuNzE1MDJDOC4xOTg0NCAwLjg1MDA2OCA1Ljk4MzU1IDEuNzE1MDIgNC41NTM2MyAyLjczNzQ3WiIgZmlsbD0iIzVFNjM2NyIvPgo8cGF0aCBkPSJNNy4zOTM1MyAyLjk2MTA5QzUuNjE3MzcgMi44OTczNCAzLjkxOTk2IDQuMjg4NTIgMy43NTYyMiA2LjAwNTkzQzMuNTkyNDggNy43MjIwOSA0LjY1NDkyIDkuMDI5NTIgNi4zMDk4MyA5LjI5NTc2QzcuOTY0NzUgOS41NjA3NCA5Ljg3ODM5IDguNTU1OCAxMC4yNjM0IDYuNDUwOTFDMTAuNjYwOSA0LjI4MjI3IDkuMDg5NjkgMy4wMjIzNCA3LjM5MzUzIDIuOTYxMDlaIiBmaWxsPSJ3aGl0ZSIvPgo8cGF0aCBkPSJNNy45NDIxNyA1LjkwMTE1QzcuOTQyMTcgNS45MDExNSA4LjM2OTY1IDUuODEyNCA4LjQ1NDY1IDUuMTgyNDRDOC41MzgzOSA0LjU2MjQ3IDguMjMwOTEgNC4wMzM3NSA3LjUxMzQ1IDMuODQzNzZDNi43MzM0OSAzLjYzNzUyIDYuMjA0NzcgNC4wNjYyNSA2LjA2NzI3IDQuNTE3NDdDNS44NzYwMyA1LjE0NDk0IDYuMTU4NTIgNS40NDM2NyA2LjE1ODUyIDUuNDQzNjdDNi4xNTg1MiA1LjQ0MzY3IDUuMzkzNTYgNS42Mjc0MSA1LjMzMjMxIDYuNTI5ODdDNS4yNzQ4MSA3LjM4MTA3IDUuODU2MDMgNy44Mzg1NSA2LjQzOTc1IDcuOTc4NTRDNy4xNjA5NiA4LjE1MjI4IDcuOTc4NDIgNy45NTQ3OSA4LjE3ODQxIDcuMDM0ODRDOC4zNDQ2NSA2LjI3NzM4IDcuOTQyMTcgNS45MDExNSA3Ljk0MjE3IDUuOTAxMTVaIiBmaWxsPSIjMzAzMDMwIi8+CjxwYXRoIGQ9Ik02LjczOTgzIDQuNzUzNjJDNi42NzEwOSA1LjAxMjM1IDYuODA4NTggNS4yNjIzNCA3LjA3ODU3IDUuMzMxMDlDNy4zNjk4IDUuNDA0ODMgNy42MzQ3OSA1LjMwODU5IDcuNzA2MDMgNS4wMTExQzcuNzY4NTMgNC43NDczNyA3LjY0MzU0IDQuNTE0ODggNy4zMzYwNSA0LjQzOTg4QzcuMDgzNTcgNC4zNzczOSA2LjgxNDgzIDQuNDcxMTMgNi43Mzk4MyA0Ljc1MzYyWiIgZmlsbD0id2hpdGUiLz4KPHBhdGggZD0iTTYuOTU5NzggNi4wMzk3NEM2LjYzMjMgNS45Mzg0OSA2LjE5OTgyIDYuMDY0NzMgNi4xMzEwNyA2LjUwNDcxQzYuMDYyMzMgNi45NDQ2OSA2LjMyNjA2IDcuMTY5NjggNi42NzEwNCA3LjIzMjE3QzcuMDE2MDMgNy4yOTQ2NyA3LjM0MjI2IDcuMTEzNDMgNy40MDYwMSA2Ljc2MDk1QzcuNDY4NSA2LjQwOTcyIDcuMjg2MDEgNi4xMzk3MyA2Ljk1OTc4IDYuMDM5NzRaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K","layout":[{"h":3,"i":"04247ee1-b408-457d-ac00-47ce45e64291","moved":false,"static":false,"w":3,"x":0,"y":0},{"h":3,"i":"d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570","moved":false,"static":false,"w":3,"x":3,"y":0},{"h":3,"i":"799913e6-fb95-497e-858a-6490b5f9d10d","moved":false,"static":false,"w":3,"x":6,"y":0},{"h":5,"i":"3633c7ad-203a-4e25-99f4-8cc81bf15d65","moved":false,"static":false,"w":3,"x":9,"y":0},{"h":5,"i":"28bb5d45-046d-4980-ad5e-26b1aeecda2b","moved":false,"static":false,"w":4,"x":0,"y":3},{"h":5,"i":"af79b14b-5e76-47fb-a24e-a4629c642c28","moved":false,"static":false,"w":4,"x":4,"y":3},{"h":5,"i":"74a94376-eeaf-43c1-a273-5d8b98197138","moved":false,"static":false,"w":5,"x":0,"y":8},{"h":6,"i":"5e66cb8c-2219-47e6-ba71-8f82f9873bc8","moved":false,"static":false,"w":7,"x":5,"y":8},{"h":4,"i":"099d57b7-97a6-4090-9870-66da15d3d70a","moved":false,"static":false,"w":6,"x":0,"y":14},{"h":4,"i":"56bd66d3-3eed-40a3-89df-f08f6f653a9b","moved":false,"static":false,"w":6,"x":6,"y":14}],"panelMap":{},"tags":[],"title":"Mastra","uploadedGrafana":false,"uuid":"0199cef9-46f8-748c-833a-15de455e792c","variables":{"10d0eca9-9253-4583-821c-d3c812d78151":{"allSelected":false,"customValue":"","defaultValue":"","description":"The service name using Anthropic API","dynamicVariablesAttribute":"service.name","dynamicVariablesSource":"All telemetry","haveCustomValuesSelected":false,"id":"10d0eca9-9253-4583-821c-d3c812d78151","key":"10d0eca9-9253-4583-821c-d3c812d78151","modificationUUID":"735355f5-c4c7-4969-ad30-eee98eeb36b8","multiSelect":true,"name":"service_name","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"93c33118-5f46-404b-b45e-8a81160c44c4":{"allSelected":false,"customValue":"","defaultValue":"","description":"Language being used for making Anthropic API calls","dynamicVariablesAttribute":"runId","dynamicVariablesSource":"All telemetry","id":"93c33118-5f46-404b-b45e-8a81160c44c4","modificationUUID":"9d866bce-2d9e-4ac5-8465-5ef1b3792553","multiSelect":true,"name":"agent_name","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"be7a68c4-fb97-43ea-bb94-0ded120bd3d7":{"allSelected":true,"customValue":"","defaultValue":"","description":"Model name being used in Anthropic API call","dynamicVariablesAttribute":"gen_ai.request.model","dynamicVariablesSource":"All telemetry","id":"be7a68c4-fb97-43ea-bb94-0ded120bd3d7","key":"be7a68c4-fb97-43ea-bb94-0ded120bd3d7","modificationUUID":"b69292da-13ae-4141-93cb-91b9b6c62ead","multiSelect":true,"name":"llm_model","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"}},"version":"v5","widgets":[{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"04247ee1-b408-457d-ac00-47ce45e64291","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.input_tokens) ) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name gen_ai.request.model in $llm_model runId in $agent_name "},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"fd5d9440-bbc5-4940-b6d8-d0445a9d06af","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Input Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.output_tokens) ) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name gen_ai.request.model in $llm_model runId in $agent_name"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"180ab9c9-d171-4c0f-ac63-5753bfadfc1d","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Output Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"799913e6-fb95-497e-858a-6490b5f9d10d","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"A","filter":{"expression":"has_error = 'true' service.name in $service_name"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null},{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"B","filter":{"expression":"has_error = 'false' service.name in $service_name"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"B","source":"","stepInterval":null}],"queryFormulas":[{"disabled":false,"expression":"A / (A+B)","legend":"","queryName":"F1"}],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"33769919-249a-4e96-ab38-fc91ce444a70","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[{"index":"e5e05d41-7479-4d60-a1cf-c433b8b61285","isEditEnabled":false,"keyIndex":1,"selectedGraph":"value","thresholdColor":"Red","thresholdFormat":"Text","thresholdLabel":"","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"percentunit","thresholdValue":10},{"index":"d74bf17b-552a-4636-8fad-c976b090d590","isEditEnabled":false,"keyIndex":0,"selectedGraph":"value","thresholdColor":"Orange","thresholdFormat":"Text","thresholdLabel":"","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"percentunit","thresholdValue":5}],"timePreferance":"GLOBAL_TIME","title":"Error Rate","yAxisUnit":"percentunit"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"3633c7ad-203a-4e25-99f4-8cc81bf15d65","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"gen_ai.request.model EXISTS service.name in $service_name"},"functions":[],"groupBy":[{"dataType":"string","id":"gen_ai.request.model--string--tag","isColumn":false,"isJSON":false,"key":"gen_ai.request.model","type":"tag"}],"having":{"expression":""},"legend":"{{gen_ai.request.model}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"bb31c57b-ceac-420e-8502-5e5b628f2447","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Model Distribution","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"F1":"#eccd03"},"description":"","fillSpans":false,"id":"28bb5d45-046d-4980-ad5e-26b1aeecda2b","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.total_tokens) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name gen_ai.request.model in $llm_model runId in $agent_name"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"ec5ea44a-a626-428e-a251-f3e8991e23d5","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Token Usage","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"af79b14b-5e76-47fb-a24e-a4629c642c28","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"p95(duration_nano) "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name gen_ai.request.model in $llm_model runId in $agent_name"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"17a1cb48-90f6-4d27-99ca-69cd64dace9a","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Latency (P95)","yAxisUnit":"ns"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"A":"#edce64","count()":"#a403ff"},"description":"","fillSpans":false,"id":"74a94376-eeaf-43c1-a273-5d8b98197138","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name gen_ai.request.model in $llm_model runId in $agent_name"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"ecac09c6-2617-4049-a1f7-91f704c7da8c","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Number of Requests","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"date":145,"duration_nano":145,"http_method":145,"name":145,"response_status_code":145,"service.name":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"5e66cb8c-2219-47e6-ba71-8f82f9873bc8","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"has_error = true service.name IN $service_name"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"}],"pageSize":10,"queryName":"A","selectColumns":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"b85f93b2-09b5-4fcd-8aa8-f6a2875a41b5","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Errors","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A":""},"columnWidths":{"A":145,"agent.id":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"099d57b7-97a6-4090-9870-66da15d3d70a","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name gen_ai.operation.name = 'agent.run' "},"functions":[],"groupBy":[{"dataType":"string","id":"agent.id--string--tag","isColumn":false,"isJSON":false,"key":"agent.id","type":"tag"}],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"2027b275-c797-4b7e-b36e-ab192adfe528","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Agents","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A":""},"columnWidths":{"A":145,"gen_ai.tool.description":145,"gen_ai.tool.name":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"56bd66d3-3eed-40a3-89df-f08f6f653a9b","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name gen_ai.operation.name = 'tool.execute' "},"functions":[],"groupBy":[{"dataType":"","id":"gen_ai.tool.name----","key":"gen_ai.tool.name","type":""},{"dataType":"string","id":"gen_ai.tool.description--string--tag","isColumn":false,"isJSON":false,"key":"gen_ai.tool.description","type":"tag"}],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"31108cfa-9f0c-4831-919f-a3a13b9f3526","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Tools","yAxisUnit":"none"}]}
+{
+  "spec": {
+    "display": {
+      "name": "Mastra",
+      "description": ""
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "service_name",
+            "description": "The service name using Anthropic API"
+          },
+          "defaultValue": [
+            "mastra-otel",
+            "mastra-workflow-api",
+            "mastra-chat-service"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "service.name",
+              "signal": "all"
+            }
+          },
+          "name": "service_name"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "agent_name",
+            "description": "Language being used for making Anthropic API calls"
+          },
+          "defaultValue": [
+            "chefAgent",
+            "weatherAgent",
+            "researchAgent",
+            "supportAgent"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "runId",
+              "signal": "all"
+            }
+          },
+          "name": "agent_name"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "llm_model",
+            "description": "Model name being used in Anthropic API call"
+          },
+          "defaultValue": [
+            "gpt-4.1-mini",
+            "gpt-4.1",
+            "claude-sonnet-5",
+            "gemini-2.5-flash"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "gen_ai.request.model",
+              "signal": "all"
+            }
+          },
+          "name": "llm_model"
+        }
+      }
+    ],
+    "panels": {
+      "04247ee1-b408-457d-ac00-47ce45e64291": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Input Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(gen_ai.usage.input_tokens)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name gen_ai.request.model in $llm_model runId in $agent_name "
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "099d57b7-97a6-4090-9870-66da15d3d70a": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Agents",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A": ""
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name gen_ai.operation.name = 'agent.run' "
+                    },
+                    "groupBy": [
+                      {
+                        "name": "agent.id",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "28bb5d45-046d-4980-ad5e-26b1aeecda2b": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Token Usage",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "mastra-chat-service": "#E85230",
+                  "mastra-otel": "#93E55D",
+                  "mastra-workflow-api": "#8B95E4"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(gen_ai.usage.total_tokens)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name gen_ai.request.model in $llm_model runId in $agent_name"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "3633c7ad-203a-4e25-99f4-8cc81bf15d65": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Model Distribution",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "claude-sonnet-5": "#DDE830",
+                  "gemini-2.5-flash": "#5DB5E5",
+                  "gpt-4.1": "#CF8BE4",
+                  "gpt-4.1-mini": "#5DE59D"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "gen_ai.request.model EXISTS service.name in $service_name"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "gen_ai.request.model",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{gen_ai.request.model}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "56bd66d3-3eed-40a3-89df-f08f6f653a9b": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Tools",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A": ""
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name gen_ai.operation.name = 'tool.execute' "
+                    },
+                    "groupBy": [
+                      {
+                        "name": "gen_ai.tool.name",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "gen_ai.tool.description",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "5e66cb8c-2219-47e6-ba71-8f82f9873bc8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Errors",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "service.name",
+                  "signal": "traces",
+                  "fieldContext": "resource",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "name",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "duration_nano",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "http_method",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "response_status_code",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "has_error = true service.name IN $service_name"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "name",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "duration_nano",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "http_method",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "response_status_code",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      }
+                    ],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "74a94376-eeaf-43c1-a273-5d8b98197138": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Number of Requests",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "mastra-chat-service": "#E85230",
+                  "mastra-otel": "#93E55D",
+                  "mastra-workflow-api": "#8B95E4"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name gen_ai.request.model in $llm_model runId in $agent_name"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "799913e6-fb95-497e-858a-6490b5f9d10d": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Error Rate",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "percentunit",
+                "decimalPrecision": "2"
+              },
+              "thresholds": [
+                {
+                  "value": 0.1,
+                  "operator": "above",
+                  "unit": "percentunit",
+                  "color": "Red",
+                  "format": "text"
+                },
+                {
+                  "value": 0.05,
+                  "operator": "above",
+                  "unit": "percentunit",
+                  "color": "Orange",
+                  "format": "text"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "has_error = 'true' service.name in $service_name"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "has_error = 'false' service.name in $service_name"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "A / (A+B)",
+                          "disabled": false,
+                          "order": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "functions": null,
+                          "legend": ""
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "af79b14b-5e76-47fb-a24e-a4629c642c28": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Latency (P95)",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ns",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "mastra-chat-service": "#E85230",
+                  "mastra-otel": "#93E55D",
+                  "mastra-workflow-api": "#8B95E4"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "p95(duration_nano)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name gen_ai.request.model in $llm_model runId in $agent_name"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Output Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(gen_ai.usage.output_tokens)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name gen_ai.request.model in $llm_model runId in $agent_name"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/04247ee1-b408-457d-ac00-47ce45e64291"
+              }
+            },
+            {
+              "x": 4,
+              "y": 0,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570"
+              }
+            },
+            {
+              "x": 8,
+              "y": 0,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/799913e6-fb95-497e-858a-6490b5f9d10d"
+              }
+            },
+            {
+              "x": 0,
+              "y": 3,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/74a94376-eeaf-43c1-a273-5d8b98197138"
+              }
+            },
+            {
+              "x": 6,
+              "y": 3,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/af79b14b-5e76-47fb-a24e-a4629c642c28"
+              }
+            },
+            {
+              "x": 0,
+              "y": 9,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/28bb5d45-046d-4980-ad5e-26b1aeecda2b"
+              }
+            },
+            {
+              "x": 8,
+              "y": 9,
+              "width": 4,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/3633c7ad-203a-4e25-99f4-8cc81bf15d65"
+              }
+            },
+            {
+              "x": 0,
+              "y": 15,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/099d57b7-97a6-4090-9870-66da15d3d70a"
+              }
+            },
+            {
+              "x": 6,
+              "y": 15,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/56bd66d3-3eed-40a3-89df-f08f6f653a9b"
+              }
+            },
+            {
+              "x": 0,
+              "y": 21,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/5e66cb8c-2219-47e6-ba71-8f82f9873bc8"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "",
+    "refreshInterval": "",
+    "links": []
+  },
+  "tags": [],
+  "image": "/assets/Icons/eight-ball"
+}

--- a/ollama/ollama-dashboard.json
+++ b/ollama/ollama-dashboard.json
@@ -1,1 +1,1170 @@
-{"description":"","image":"data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE0Ljk0OTQgMTMuOTQyQzE2LjIzMTggMTIuNDI1OCAxNy4zMjY4IDkuNzAyMiAxNi4xOTU2IDYuNTc0ODdDMTUuNjQ0MyA1LjA1MjQ1IDE1LjAyMTkgNC4yMDI0OSAxNC4yOTY5IDMuNjYyNTJDMTMuODU1NyAzLjMzMzc5IDEyLjA5MzMgMi41MDYzMyA5Ljc1OTY1IDIuODY3NTZDOC4wNTM0OSAzLjEzMjU1IDUuNzc0ODcgNC4yMDg3NCA0LjI5MzY5IDUuOTU5OUMyLjg1NzUyIDcuNjYxMDYgMS43NDg4MyA5LjAwNDc0IDEuNjk3NTggMTAuMzA5N0MxLjYzMTMzIDExLjk4ODMgMi44OTYyNyAxMy40MzA4IDMuMDUwMDEgMTMuNjY0NUMzLjMyMzc0IDE0LjA3OTUgNS4xOTExNSAxNi40NTE4IDguNjk5NzEgMTYuNTczMUMxMS43OTcgMTYuNjc5MyAxMy44MTQ0IDE1LjI4NDQgMTQuOTQ5NCAxMy45NDJaIiBmaWxsPSIjNDAzRDNFIi8+CjxwYXRoIGQ9Ik00LjU1MzYzIDIuNzM3NDdDMi45Mzc0NiAzLjg5MTE2IDEuMTIxMzEgNi4yNTEwMyAxLjQ0NzU0IDkuNTYwODZDMS42MDYyOCAxMS4xNzIgMi4wMDI1MSAxMi4xNDk1IDIuNTcxMjMgMTIuODUwN0MyLjkxNzQ2IDEzLjI3ODIgNC40MTk4OCAxNC41NDkzIDYuNzczNTEgMTQuNzM2OEM5LjE0NTg4IDE0LjkyNTYgMTAuOTQ5NSAxNC4zOTQ0IDEyLjgzMzIgMTMuMDg0NEMxNi42NjE3IDEwLjQyMDggMTYuMDk4IDYuMzkzNTMgMTUuOTM0MyA1LjkyNDhDMTUuNzcwNSA1LjQ1NjA3IDE0LjU0NDQgMi42OTYyMiAxMS4xNzMzIDEuNzE1MDJDOC4xOTg0NCAwLjg1MDA2OCA1Ljk4MzU1IDEuNzE1MDIgNC41NTM2MyAyLjczNzQ3WiIgZmlsbD0iIzVFNjM2NyIvPgo8cGF0aCBkPSJNNy4zOTM1MyAyLjk2MTA5QzUuNjE3MzcgMi44OTczNCAzLjkxOTk2IDQuMjg4NTIgMy43NTYyMiA2LjAwNTkzQzMuNTkyNDggNy43MjIwOSA0LjY1NDkyIDkuMDI5NTIgNi4zMDk4MyA5LjI5NTc2QzcuOTY0NzUgOS41NjA3NCA5Ljg3ODM5IDguNTU1OCAxMC4yNjM0IDYuNDUwOTFDMTAuNjYwOSA0LjI4MjI3IDkuMDg5NjkgMy4wMjIzNCA3LjM5MzUzIDIuOTYxMDlaIiBmaWxsPSJ3aGl0ZSIvPgo8cGF0aCBkPSJNNy45NDIxNyA1LjkwMTE1QzcuOTQyMTcgNS45MDExNSA4LjM2OTY1IDUuODEyNCA4LjQ1NDY1IDUuMTgyNDRDOC41MzgzOSA0LjU2MjQ3IDguMjMwOTEgNC4wMzM3NSA3LjUxMzQ1IDMuODQzNzZDNi43MzM0OSAzLjYzNzUyIDYuMjA0NzcgNC4wNjYyNSA2LjA2NzI3IDQuNTE3NDdDNS44NzYwMyA1LjE0NDk0IDYuMTU4NTIgNS40NDM2NyA2LjE1ODUyIDUuNDQzNjdDNi4xNTg1MiA1LjQ0MzY3IDUuMzkzNTYgNS42Mjc0MSA1LjMzMjMxIDYuNTI5ODdDNS4yNzQ4MSA3LjM4MTA3IDUuODU2MDMgNy44Mzg1NSA2LjQzOTc1IDcuOTc4NTRDNy4xNjA5NiA4LjE1MjI4IDcuOTc4NDIgNy45NTQ3OSA4LjE3ODQxIDcuMDM0ODRDOC4zNDQ2NSA2LjI3NzM4IDcuOTQyMTcgNS45MDExNSA3Ljk0MjE3IDUuOTAxMTVaIiBmaWxsPSIjMzAzMDMwIi8+CjxwYXRoIGQ9Ik02LjczOTgzIDQuNzUzNjJDNi42NzEwOSA1LjAxMjM1IDYuODA4NTggNS4yNjIzNCA3LjA3ODU3IDUuMzMxMDlDNy4zNjk4IDUuNDA0ODMgNy42MzQ3OSA1LjMwODU5IDcuNzA2MDMgNS4wMTExQzcuNzY4NTMgNC43NDczNyA3LjY0MzU0IDQuNTE0ODggNy4zMzYwNSA0LjQzOTg4QzcuMDgzNTcgNC4zNzczOSA2LjgxNDgzIDQuNDcxMTMgNi43Mzk4MyA0Ljc1MzYyWiIgZmlsbD0id2hpdGUiLz4KPHBhdGggZD0iTTYuOTU5NzggNi4wMzk3NEM2LjYzMjMgNS45Mzg0OSA2LjE5OTgyIDYuMDY0NzMgNi4xMzEwNyA2LjUwNDcxQzYuMDYyMzMgNi45NDQ2OSA2LjMyNjA2IDcuMTY5NjggNi42NzEwNCA3LjIzMjE3QzcuMDE2MDMgNy4yOTQ2NyA3LjM0MjI2IDcuMTEzNDMgNy40MDYwMSA2Ljc2MDk1QzcuNDY4NSA2LjQwOTcyIDcuMjg2MDEgNi4xMzk3MyA2Ljk1OTc4IDYuMDM5NzRaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K","layout":[{"h":3,"i":"2cf45508-6372-4ff2-bd7f-5309d110a736","moved":false,"static":false,"w":3,"x":0,"y":0},{"h":3,"i":"9428f721-6923-45fb-8929-99fe40137f8c","moved":false,"static":false,"w":3,"x":3,"y":0},{"h":6,"i":"b054f739-6769-4b83-bb8a-6c52862c708a","moved":false,"static":false,"w":3,"x":6,"y":0},{"h":6,"i":"3d3c5032-185a-4008-a953-5cafa7e7749e","moved":false,"static":false,"w":3,"x":9,"y":0},{"h":3,"i":"622a1e69-6506-4fd0-a0c8-f508c5e09527","moved":false,"static":false,"w":6,"x":0,"y":3},{"h":6,"i":"9214ea5d-2f8e-4ceb-be2d-8378f1afdfe8","moved":false,"static":false,"w":6,"x":0,"y":6},{"h":6,"i":"32b260c8-4edf-4a63-b027-6e3d60f63056","moved":false,"static":false,"w":6,"x":6,"y":6},{"h":6,"i":"815246b4-6b1a-474a-85a8-711a396f2afd","moved":false,"static":false,"w":6,"x":0,"y":12},{"h":6,"i":"71d9bc7d-537a-4063-927e-dc9a652cd629","moved":false,"static":false,"w":6,"x":6,"y":12},{"h":6,"i":"676e7814-03cc-4850-8097-86da5418a5ab","moved":false,"static":false,"w":6,"x":0,"y":18},{"h":6,"i":"92db876a-7b29-44c6-8bd5-2615a3e7bf08","moved":false,"static":false,"w":6,"x":6,"y":18},{"h":6,"i":"fbbf3c99-85b9-466b-bb47-62988fb9a0e2","moved":false,"static":false,"w":6,"x":0,"y":24},{"h":1,"i":"__dropping-elem__","isDraggable":true,"moved":false,"static":false,"w":1,"x":10,"y":24}],"panelMap":{},"tags":[],"title":"Ollama","uploadedGrafana":false,"variables":{"68ba7387-d1c2-4d2b-a4be-a53ceeb0d405":{"allSelected":false,"customValue":"","defaultValue":"","description":"SDK langauge used for OTel","dynamicVariablesAttribute":"telemetry.sdk.language","dynamicVariablesSource":"All telemetry","id":"68ba7387-d1c2-4d2b-a4be-a53ceeb0d405","key":"68ba7387-d1c2-4d2b-a4be-a53ceeb0d405","modificationUUID":"e33bb376-b437-42d5-9099-ecb9d84a9810","multiSelect":true,"name":"language","order":1,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"a42bfdca-f986-4141-a531-6cb9f851da44":{"allSelected":true,"customValue":"","defaultValue":"","description":"The llm model being used for Ollama call","dynamicVariablesAttribute":"gen_ai.request.model","dynamicVariablesSource":"All telemetry","haveCustomValuesSelected":false,"id":"a42bfdca-f986-4141-a531-6cb9f851da44","modificationUUID":"380705b5-840b-4fd5-b40e-1801d1937ed6","multiSelect":true,"name":"llm_model","order":2,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"bf4e96d6-a273-4a9e-8330-8f77ac4b1c63":{"allSelected":false,"customValue":"","defaultValue":"","description":"Service name using Ollama","dynamicVariablesAttribute":"service.name","dynamicVariablesSource":"All telemetry","haveCustomValuesSelected":false,"id":"bf4e96d6-a273-4a9e-8330-8f77ac4b1c63","key":"bf4e96d6-a273-4a9e-8330-8f77ac4b1c63","modificationUUID":"9eb52407-1705-4343-8d95-9dab76f9ef23","multiSelect":true,"name":"service_name","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"}},"version":"v5","widgets":[{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"2cf45508-6372-4ff2-bd7f-5309d110a736","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.input_tokens)"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"},"filters":{"items":[{"id":"3e3485e0-922e-47b3-a21e-819946f4ccdc","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"b03f5813-25cf-4532-8fc1-160e00eefeb0","key":{"dataType":"string","id":"telemetry.sdk.language--string--","key":"telemetry.sdk.language","type":""},"op":"IN","value":"$language"},{"id":"79691125-5e51-4ee1-9e1e-16668a9140cb","key":{"dataType":"string","id":"gen_ai.request.model--string--","key":"gen_ai.request.model","type":""},"op":"IN","value":"$llm_model"}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"4cfbba5a-4b37-48ca-95bb-8facf1e30722","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Input Tokens","yAxisUnit":""},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"9428f721-6923-45fb-8929-99fe40137f8c","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.output_tokens) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"},"filters":{"items":[{"id":"3e3485e0-922e-47b3-a21e-819946f4ccdc","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"b03f5813-25cf-4532-8fc1-160e00eefeb0","key":{"dataType":"string","id":"telemetry.sdk.language--string--","key":"telemetry.sdk.language","type":""},"op":"IN","value":"$language"},{"id":"79691125-5e51-4ee1-9e1e-16668a9140cb","key":{"dataType":"string","id":"gen_ai.request.model--string--","key":"gen_ai.request.model","type":""},"op":"IN","value":"$llm_model"}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"db4d1b40-960f-414d-889b-56c953203200","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Output Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"b054f739-6769-4b83-bb8a-6c52862c708a","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"llm.request.type = 'chat' service.name in $service_name telemetry.sdk.language in $language"},"functions":[],"groupBy":[{"dataType":"","id":"gen_ai.response.model----","key":"gen_ai.response.model","type":""}],"having":{"expression":""},"legend":"{{gen_ai.response.model}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"2fffe5c4-49ec-4482-a423-23309cadf091","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Model Distribution","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"3d3c5032-185a-4008-a953-5cafa7e7749e","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(llm.usage.total_tokens) "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"llm.request.type = 'chat' service.name in $service_name telemetry.sdk.language in $language"},"functions":[],"groupBy":[{"dataType":"","id":"gen_ai.response.model----","key":"gen_ai.response.model","type":""}],"having":{"expression":""},"legend":"{{gen_ai.response.model}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"bff84d3f-343b-480f-8708-602b6158884d","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Token Distribution by Model","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"622a1e69-6506-4fd0-a0c8-f508c5e09527","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"A","filter":{"expression":"has_error = 'true'  service.name in $service_name "},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null},{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"B","filter":{"expression":"has_error = 'false'  llm.request.type = 'chat' service.name in $service_name "},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"B","source":"","stepInterval":null}],"queryFormulas":[{"disabled":false,"expression":"A / (A+B)","legend":"","queryName":"F1"}],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"576a1523-02d5-41aa-8498-97a02a4866c9","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Error Rate","yAxisUnit":"%"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"9214ea5d-2f8e-4ceb-be2d-8378f1afdfe8","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(llm.usage.total_tokens) ) "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"telemetry.sdk.language in $language gen_ai.request.model in $llm_model service.name IN $service_name "},"functions":[],"groupBy":[{"dataType":"","id":"service.name----","key":"service.name","type":""}],"having":{"expression":""},"legend":"{{service.name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"af052e95-fb2c-460c-8c3e-1cfd5595862f","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Token Usage","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"32b260c8-4edf-4a63-b027-6e3d60f63056","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count()"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"llm.request.type = 'chat' telemetry.sdk.language in $language gen_ai.request.model in $llm_model service.name IN $service_name "},"functions":[],"groupBy":[{"dataType":"","id":"service.name----","key":"service.name","type":""}],"having":{"expression":""},"legend":"{{service.name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"c6de66b9-2eec-4065-8021-934df96f27de","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Number of Requests","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"71d9bc7d-537a-4063-927e-dc9a652cd629","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"metricName":"http.client.duration.max","reduceTo":"avg","spaceAggregation":"avg","temporality":"","timeAggregation":"avg"}],"dataSource":"metrics","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name "},"functions":[],"groupBy":[{"dataType":"string","id":"service.name--string--tag","isColumn":false,"isJSON":false,"key":"service.name","type":"tag"}],"having":{"expression":""},"legend":"{{service.name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"b75a5a82-06a2-43c4-97c5-d85d7ea6ea82","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"HTTP Request Duration","yAxisUnit":"ms"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"815246b4-6b1a-474a-85a8-711a396f2afd","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"p95(duration_nano)"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"llm.request.type = 'chat'  service.name IN $service_name "},"functions":[],"groupBy":[{"dataType":"string","id":"service.name--string--resource","isColumn":true,"isJSON":false,"key":"service.name","type":"resource"}],"having":{"expression":""},"legend":"{{service.name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"3c175f45-3ca1-4633-9ae6-21181d2c921a","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Request Duration(P95)","yAxisUnit":"ns"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A.avg(duration_nano)":"ns"},"columnWidths":{"A.avg(duration_nano)":145,"A.count()":145,"service.name":145,"telemetry.sdk.language":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"676e7814-03cc-4850-8097-86da5418a5ab","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() as 'Requests' avg(duration_nano) as 'Avg Duration'"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"llm.request.type = 'chat' "},"functions":[],"groupBy":[{"dataType":"string","id":"service.name--string--resource","isColumn":true,"isJSON":false,"key":"service.name","type":"resource"},{"dataType":"string","id":"telemetry.sdk.language--string--resource","isColumn":false,"isJSON":false,"key":"telemetry.sdk.language","type":"resource"}],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"13d44d28-250b-4bc7-9863-d2a654f9b9c3","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"body":350,"timestamp":100},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"fbbf3c99-85b9-466b-bb47-62988fb9a0e2","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"logs","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name "},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"},{"columnName":"id","order":"desc"}],"pageSize":100,"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"ad2e3851-8e95-4247-bbe9-178061f18ff4","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Logs","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"date":145,"duration_nano":145,"http_method":145,"name":145,"response_status_code":145,"service.name":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"92db876a-7b29-44c6-8bd5-2615a3e7bf08","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name  has_error = 'true'"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"}],"pageSize":10,"queryName":"A","selectColumns":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"91dc47bb-6f9d-4c5a-a5ee-9a0b8c2da7c9","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Errors","yAxisUnit":"none"}],"uuid":"019c101e-e6a4-72df-9e3f-97d39089379c"}
+{
+  "spec": {
+    "display": {
+      "name": "Ollama",
+      "description": ""
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "service_name",
+            "description": "Service name using Ollama"
+          },
+          "defaultValue": [
+            "ollama-assistant-app",
+            "ollama-planner-app",
+            "ollama-research-app"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "service.name",
+              "signal": "all"
+            }
+          },
+          "name": "service_name"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "language",
+            "description": "SDK langauge used for OTel"
+          },
+          "defaultValue": [
+            "python"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "telemetry.sdk.language",
+              "signal": "all"
+            }
+          },
+          "name": "language"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "llm_model",
+            "description": "The llm model being used for Ollama call"
+          },
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "gen_ai.request.model",
+              "signal": "all"
+            }
+          },
+          "name": "llm_model"
+        }
+      }
+    ],
+    "panels": {
+      "2cf45508-6372-4ff2-bd7f-5309d110a736": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Input Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(gen_ai.usage.input_tokens)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "32b260c8-4edf-4a63-b027-6e3d60f63056": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Number of Requests",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "ollama-assistant-app": "#E5735D",
+                  "ollama-planner-app": "#8BE4B4",
+                  "ollama-research-app": "#BA30E8"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "llm.request.type = 'chat' telemetry.sdk.language in $language gen_ai.request.model in $llm_model service.name IN $service_name "
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "3d3c5032-185a-4008-a953-5cafa7e7749e": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Token Distribution by Model",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "deepseek-r1:14b": "#9E8BE4",
+                  "gemma3:12b": "#DFE55D",
+                  "gemma3:4b": "#8BC6E4",
+                  "llama3.3:70b": "#E88C30",
+                  "mistral-small3.2:24b": "#68E55D",
+                  "qwen3:8b": "#E83075"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(llm.usage.total_tokens)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "llm.request.type = 'chat' service.name in $service_name telemetry.sdk.language in $language"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "gen_ai.response.model",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{gen_ai.response.model}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "622a1e69-6506-4fd0-a0c8-f508c5e09527": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Error Rate",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "%",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "has_error = 'true' llm.request.type = 'chat' service.name in $service_name "
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "has_error = 'false'  llm.request.type = 'chat' service.name in $service_name "
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "A / (A+B) * 100",
+                          "disabled": false,
+                          "order": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "functions": null,
+                          "legend": ""
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "676e7814-03cc-4850-8097-86da5418a5ab": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A.avg(duration_nano)": "ns"
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()",
+                        "alias": "Requests"
+                      },
+                      {
+                        "expression": "avg(duration_nano)",
+                        "alias": "Avg Duration"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "llm.request.type = 'chat' "
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "telemetry.sdk.language",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "71d9bc7d-537a-4063-927e-dc9a652cd629": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "HTTP Request Duration",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ms",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "ollama-assistant-app": "#E5735D",
+                  "ollama-planner-app": "#8BE4B4",
+                  "ollama-research-app": "#BA30E8"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "metrics",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "metricName": "http.client.duration.max",
+                        "temporality": "",
+                        "timeAggregation": "avg",
+                        "spaceAggregation": "avg",
+                        "reduceTo": "avg"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name "
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "815246b4-6b1a-474a-85a8-711a396f2afd": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Request Duration(P95)",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ns",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "ollama-assistant-app": "#E5735D",
+                  "ollama-planner-app": "#8BE4B4",
+                  "ollama-research-app": "#BA30E8"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "p95(duration_nano)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "llm.request.type = 'chat'  service.name IN $service_name "
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "9214ea5d-2f8e-4ceb-be2d-8378f1afdfe8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Token Usage",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "ollama-assistant-app": "#E5735D",
+                  "ollama-planner-app": "#8BE4B4",
+                  "ollama-research-app": "#BA30E8"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(llm.usage.total_tokens)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "telemetry.sdk.language in $language gen_ai.request.model in $llm_model service.name IN $service_name "
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "92db876a-7b29-44c6-8bd5-2615a3e7bf08": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Errors",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "service.name",
+                  "signal": "traces",
+                  "fieldContext": "resource",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "name",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "duration_nano",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "http_method",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "response_status_code",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name  has_error = 'true'"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "name",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "duration_nano",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "http_method",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "response_status_code",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      }
+                    ],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "9428f721-6923-45fb-8929-99fe40137f8c": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Output Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(gen_ai.usage.output_tokens)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "b054f739-6769-4b83-bb8a-6c52862c708a": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Model Distribution",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "deepseek-r1:14b": "#9E8BE4",
+                  "gemma3:12b": "#DFE55D",
+                  "gemma3:4b": "#8BC6E4",
+                  "llama3.3:70b": "#E88C30",
+                  "mistral-small3.2:24b": "#68E55D",
+                  "qwen3:8b": "#E83075"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "llm.request.type = 'chat' service.name in $service_name telemetry.sdk.language in $language"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "gen_ai.response.model",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{gen_ai.response.model}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "fbbf3c99-85b9-466b-bb47-62988fb9a0e2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Logs",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "timestamp",
+                  "signal": "logs",
+                  "fieldContext": "log",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "body",
+                  "signal": "logs",
+                  "fieldContext": "log",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "logs",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name "
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "limit": 100,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 3,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/2cf45508-6372-4ff2-bd7f-5309d110a736"
+              }
+            },
+            {
+              "x": 3,
+              "y": 0,
+              "width": 3,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/9428f721-6923-45fb-8929-99fe40137f8c"
+              }
+            },
+            {
+              "x": 6,
+              "y": 0,
+              "width": 3,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/b054f739-6769-4b83-bb8a-6c52862c708a"
+              }
+            },
+            {
+              "x": 9,
+              "y": 0,
+              "width": 3,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/3d3c5032-185a-4008-a953-5cafa7e7749e"
+              }
+            },
+            {
+              "x": 0,
+              "y": 3,
+              "width": 6,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/622a1e69-6506-4fd0-a0c8-f508c5e09527"
+              }
+            },
+            {
+              "x": 0,
+              "y": 6,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/9214ea5d-2f8e-4ceb-be2d-8378f1afdfe8"
+              }
+            },
+            {
+              "x": 6,
+              "y": 6,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/32b260c8-4edf-4a63-b027-6e3d60f63056"
+              }
+            },
+            {
+              "x": 0,
+              "y": 12,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/815246b4-6b1a-474a-85a8-711a396f2afd"
+              }
+            },
+            {
+              "x": 6,
+              "y": 12,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/71d9bc7d-537a-4063-927e-dc9a652cd629"
+              }
+            },
+            {
+              "x": 0,
+              "y": 18,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/676e7814-03cc-4850-8097-86da5418a5ab"
+              }
+            },
+            {
+              "x": 6,
+              "y": 18,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/92db876a-7b29-44c6-8bd5-2615a3e7bf08"
+              }
+            },
+            {
+              "x": 0,
+              "y": 24,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/fbbf3c99-85b9-466b-bb47-62988fb9a0e2"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "",
+    "refreshInterval": "",
+    "links": []
+  },
+  "tags": [],
+  "image": "/assets/Icons/eight-ball"
+}

--- a/openai/openai-dashboard.json
+++ b/openai/openai-dashboard.json
@@ -1,1 +1,1170 @@
-{"description":"","image":"data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE0Ljk0OTQgMTMuOTQyQzE2LjIzMTggMTIuNDI1OCAxNy4zMjY4IDkuNzAyMiAxNi4xOTU2IDYuNTc0ODdDMTUuNjQ0MyA1LjA1MjQ1IDE1LjAyMTkgNC4yMDI0OSAxNC4yOTY5IDMuNjYyNTJDMTMuODU1NyAzLjMzMzc5IDEyLjA5MzMgMi41MDYzMyA5Ljc1OTY1IDIuODY3NTZDOC4wNTM0OSAzLjEzMjU1IDUuNzc0ODcgNC4yMDg3NCA0LjI5MzY5IDUuOTU5OUMyLjg1NzUyIDcuNjYxMDYgMS43NDg4MyA5LjAwNDc0IDEuNjk3NTggMTAuMzA5N0MxLjYzMTMzIDExLjk4ODMgMi44OTYyNyAxMy40MzA4IDMuMDUwMDEgMTMuNjY0NUMzLjMyMzc0IDE0LjA3OTUgNS4xOTExNSAxNi40NTE4IDguNjk5NzEgMTYuNTczMUMxMS43OTcgMTYuNjc5MyAxMy44MTQ0IDE1LjI4NDQgMTQuOTQ5NCAxMy45NDJaIiBmaWxsPSIjNDAzRDNFIi8+CjxwYXRoIGQ9Ik00LjU1MzYzIDIuNzM3NDdDMi45Mzc0NiAzLjg5MTE2IDEuMTIxMzEgNi4yNTEwMyAxLjQ0NzU0IDkuNTYwODZDMS42MDYyOCAxMS4xNzIgMi4wMDI1MSAxMi4xNDk1IDIuNTcxMjMgMTIuODUwN0MyLjkxNzQ2IDEzLjI3ODIgNC40MTk4OCAxNC41NDkzIDYuNzczNTEgMTQuNzM2OEM5LjE0NTg4IDE0LjkyNTYgMTAuOTQ5NSAxNC4zOTQ0IDEyLjgzMzIgMTMuMDg0NEMxNi42NjE3IDEwLjQyMDggMTYuMDk4IDYuMzkzNTMgMTUuOTM0MyA1LjkyNDhDMTUuNzcwNSA1LjQ1NjA3IDE0LjU0NDQgMi42OTYyMiAxMS4xNzMzIDEuNzE1MDJDOC4xOTg0NCAwLjg1MDA2OCA1Ljk4MzU1IDEuNzE1MDIgNC41NTM2MyAyLjczNzQ3WiIgZmlsbD0iIzVFNjM2NyIvPgo8cGF0aCBkPSJNNy4zOTM1MyAyLjk2MTA5QzUuNjE3MzcgMi44OTczNCAzLjkxOTk2IDQuMjg4NTIgMy43NTYyMiA2LjAwNTkzQzMuNTkyNDggNy43MjIwOSA0LjY1NDkyIDkuMDI5NTIgNi4zMDk4MyA5LjI5NTc2QzcuOTY0NzUgOS41NjA3NCA5Ljg3ODM5IDguNTU1OCAxMC4yNjM0IDYuNDUwOTFDMTAuNjYwOSA0LjI4MjI3IDkuMDg5NjkgMy4wMjIzNCA3LjM5MzUzIDIuOTYxMDlaIiBmaWxsPSJ3aGl0ZSIvPgo8cGF0aCBkPSJNNy45NDIxNyA1LjkwMTE1QzcuOTQyMTcgNS45MDExNSA4LjM2OTY1IDUuODEyNCA4LjQ1NDY1IDUuMTgyNDRDOC41MzgzOSA0LjU2MjQ3IDguMjMwOTEgNC4wMzM3NSA3LjUxMzQ1IDMuODQzNzZDNi43MzM0OSAzLjYzNzUyIDYuMjA0NzcgNC4wNjYyNSA2LjA2NzI3IDQuNTE3NDdDNS44NzYwMyA1LjE0NDk0IDYuMTU4NTIgNS40NDM2NyA2LjE1ODUyIDUuNDQzNjdDNi4xNTg1MiA1LjQ0MzY3IDUuMzkzNTYgNS42Mjc0MSA1LjMzMjMxIDYuNTI5ODdDNS4yNzQ4MSA3LjM4MTA3IDUuODU2MDMgNy44Mzg1NSA2LjQzOTc1IDcuOTc4NTRDNy4xNjA5NiA4LjE1MjI4IDcuOTc4NDIgNy45NTQ3OSA4LjE3ODQxIDcuMDM0ODRDOC4zNDQ2NSA2LjI3NzM4IDcuOTQyMTcgNS45MDExNSA3Ljk0MjE3IDUuOTAxMTVaIiBmaWxsPSIjMzAzMDMwIi8+CjxwYXRoIGQ9Ik02LjczOTgzIDQuNzUzNjJDNi42NzEwOSA1LjAxMjM1IDYuODA4NTggNS4yNjIzNCA3LjA3ODU3IDUuMzMxMDlDNy4zNjk4IDUuNDA0ODMgNy42MzQ3OSA1LjMwODU5IDcuNzA2MDMgNS4wMTExQzcuNzY4NTMgNC43NDczNyA3LjY0MzU0IDQuNTE0ODggNy4zMzYwNSA0LjQzOTg4QzcuMDgzNTcgNC4zNzczOSA2LjgxNDgzIDQuNDcxMTMgNi43Mzk4MyA0Ljc1MzYyWiIgZmlsbD0id2hpdGUiLz4KPHBhdGggZD0iTTYuOTU5NzggNi4wMzk3NEM2LjYzMjMgNS45Mzg0OSA2LjE5OTgyIDYuMDY0NzMgNi4xMzEwNyA2LjUwNDcxQzYuMDYyMzMgNi45NDQ2OSA2LjMyNjA2IDcuMTY5NjggNi42NzEwNCA3LjIzMjE3QzcuMDE2MDMgNy4yOTQ2NyA3LjM0MjI2IDcuMTEzNDMgNy40MDYwMSA2Ljc2MDk1QzcuNDY4NSA2LjQwOTcyIDcuMjg2MDEgNi4xMzk3MyA2Ljk1OTc4IDYuMDM5NzRaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K","layout":[{"h":4,"i":"04247ee1-b408-457d-ac00-47ce45e64291","moved":false,"static":false,"w":3,"x":0,"y":0},{"h":4,"i":"d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570","moved":false,"static":false,"w":3,"x":3,"y":0},{"h":7,"i":"28409661-48e9-454c-ba5a-890e5268ef4e","moved":false,"static":false,"w":3,"x":6,"y":0},{"h":7,"i":"3633c7ad-203a-4e25-99f4-8cc81bf15d65","moved":false,"static":false,"w":3,"x":9,"y":0},{"h":3,"i":"01c76dbd-5af0-4dcc-9693-006d589112d5","moved":false,"static":false,"w":3,"x":0,"y":4},{"h":3,"i":"799913e6-fb95-497e-858a-6490b5f9d10d","moved":false,"static":false,"w":3,"x":3,"y":4},{"h":5,"i":"c0b61678-57d0-439f-8b7b-d7708442a53c","moved":false,"static":false,"w":6,"x":0,"y":7},{"h":5,"i":"af79b14b-5e76-47fb-a24e-a4629c642c28","moved":false,"static":false,"w":6,"x":6,"y":7},{"h":5,"i":"28bb5d45-046d-4980-ad5e-26b1aeecda2b","moved":false,"static":false,"w":6,"x":0,"y":12},{"h":5,"i":"74a94376-eeaf-43c1-a273-5d8b98197138","moved":false,"static":false,"w":6,"x":6,"y":12},{"h":4,"i":"67a074ee-c46e-4a36-8f5c-10d981cae404","moved":false,"static":false,"w":6,"x":0,"y":17},{"h":8,"i":"05e6759b-c460-4618-86c0-5d2bf0b311c1","moved":false,"static":false,"w":6,"x":6,"y":17},{"h":5,"i":"5e66cb8c-2219-47e6-ba71-8f82f9873bc8","moved":false,"static":false,"w":6,"x":0,"y":21}],"panelMap":{},"tags":[],"title":"OpenAI","uploadedGrafana":false,"uuid":"019b8f42-4e1c-7297-b95e-774ef68d27d2","variables":{"10d0eca9-9253-4583-821c-d3c812d78151":{"allSelected":false,"customValue":"","defaultValue":"","description":"The service name using OpenAI","dynamicVariablesAttribute":"service.name","dynamicVariablesSource":"All telemetry","id":"10d0eca9-9253-4583-821c-d3c812d78151","key":"10d0eca9-9253-4583-821c-d3c812d78151","modificationUUID":"a4b50ffc-8cc4-4129-bdfe-0988f6dfa973","multiSelect":true,"name":"service_name","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"93c33118-5f46-404b-b45e-8a81160c44c4":{"allSelected":true,"customValue":"","defaultValue":"","description":"Language being used for making Openai calls","dynamicVariablesAttribute":"telemetry.sdk.language","dynamicVariablesSource":"All telemetry","id":"93c33118-5f46-404b-b45e-8a81160c44c4","key":"93c33118-5f46-404b-b45e-8a81160c44c4","modificationUUID":"4fe9a898-2e18-4588-8dfc-b36f5da246d5","multiSelect":true,"name":"language","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"be7a68c4-fb97-43ea-bb94-0ded120bd3d7":{"allSelected":true,"customValue":"","defaultValue":"","description":"LLM Model name being used for Openai","dynamicVariablesAttribute":"gen_ai.request.model","dynamicVariablesSource":"All telemetry","id":"be7a68c4-fb97-43ea-bb94-0ded120bd3d7","modificationUUID":"077724b4-2316-486a-ab9f-a1a2420abb90","multiSelect":true,"name":"llm_model","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"}},"version":"v5","widgets":[{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"04247ee1-b408-457d-ac00-47ce45e64291","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.input_tokens) ) ) ) ) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND telemetry.sdk.language in $language AND  gen_ai.request.model in $llm_model"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"dee4dae1-9ec7-49dd-8f7c-503c5a701fd0","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Input Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.output_tokens) ) ) ) ) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND telemetry.sdk.language in $language AND  gen_ai.request.model  in $llm_model"},"filters":{"items":[{"id":"7cb134f5-f5fb-4f87-918d-7a0b1fe2db34","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"85cb41e1-c844-498b-b0ab-0446ca7c1579","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]},{"id":"23f6f262-6bc0-4567-a2eb-c5c0318e2ec8","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"in","value":["$llm_model"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"be2f496b-8879-4cdc-a048-bdf351b9e9f8","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Output Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"799913e6-fb95-497e-858a-6490b5f9d10d","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"A","filter":{"expression":"has_error = 'true' service.name in $service_name AND gen_ai.system EXISTS"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null},{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"B","filter":{"expression":"has_error = 'false' service.name in $service_name AND gen_ai.system EXISTS "},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"B","source":"","stepInterval":null}],"queryFormulas":[{"disabled":false,"expression":"A / (A+B)","legend":"","queryName":"F1"}],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"2a9e812b-ba2f-4ebd-b57c-b555b2b82fb7","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[{"index":"e5e05d41-7479-4d60-a1cf-c433b8b61285","isEditEnabled":false,"keyIndex":1,"selectedGraph":"value","thresholdColor":"Red","thresholdFormat":"Text","thresholdLabel":"","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"percentunit","thresholdValue":10},{"index":"d74bf17b-552a-4636-8fad-c976b090d590","isEditEnabled":false,"keyIndex":0,"selectedGraph":"value","thresholdColor":"Orange","thresholdFormat":"Text","thresholdLabel":"","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"percentunit","thresholdValue":5}],"timePreferance":"GLOBAL_TIME","title":"Error Rate","yAxisUnit":"percentunit"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"3633c7ad-203a-4e25-99f4-8cc81bf15d65","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND gen_ai.request.model EXISTS AND has_error = false"},"filters":{"items":[{"id":"7cb134f5-f5fb-4f87-918d-7a0b1fe2db34","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"fc3c7f7c-b8c4-4034-93b9-9439ab3de471","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"exists","value":""},{"id":"5764e168-afc2-4207-9eaa-dae49d745101","key":{"id":"has_error","key":"has_error","type":""},"op":"=","value":false}],"op":"AND"},"functions":[],"groupBy":[{"dataType":"string","id":"gen_ai.request.model--string--tag","isColumn":false,"isJSON":false,"key":"gen_ai.request.model","type":"tag"}],"having":{"expression":""},"legend":"{{gen_ai.request.model}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"5bc601ab-4225-4317-9fdf-ddc863321600","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Model Calls","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"F1":"#eccd03"},"decimalPrecision":2,"description":"","fillSpans":false,"id":"28bb5d45-046d-4980-ad5e-26b1aeecda2b","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(llm.usage.total_tokens) ) ) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND telemetry.sdk.language in $language AND gen_ai.request.model in $llm_model"},"functions":[],"groupBy":[{"dataType":"string","id":"service.name--string--resource","isColumn":true,"isJSON":false,"key":"service.name","type":"resource"}],"having":{"expression":""},"legend":"{{service.name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"8f4dd7cd-cdbf-45a8-9df6-6e00086bd6e8","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Token Usage","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"af79b14b-5e76-47fb-a24e-a4629c642c28","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"p95(duration_nano) "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND telemetry.sdk.language in $language AND gen_ai.request.model IN $llm_model "},"filters":{"items":[{"id":"7cb134f5-f5fb-4f87-918d-7a0b1fe2db34","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"d0815317-bc19-4815-8a53-3c44414d304e","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]},{"id":"e279056f-8408-4dec-aa88-bb954bbcb691","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"in","value":["$llm_model"]}],"op":"AND"},"functions":[],"groupBy":[{"dataType":"string","id":"service.name--string--resource","isColumn":true,"isJSON":false,"key":"service.name","type":"resource"}],"having":{"expression":""},"legend":"{{service.name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"9c6a8373-7c37-4d76-a2fd-5287a122223e","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Request Duration (P95)","yAxisUnit":"ns"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"A":"#edce64","count()":"#a403ff"},"decimalPrecision":2,"description":"","fillSpans":false,"id":"74a94376-eeaf-43c1-a273-5d8b98197138","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND telemetry.sdk.language in $language AND gen_ai.request.model in $llm_model  "},"filters":{"items":[{"id":"7cb134f5-f5fb-4f87-918d-7a0b1fe2db34","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"a800a9a5-3076-46c9-84ff-a6274b23b75a","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]},{"id":"8866ad4b-2400-4b7b-838c-611fb962f908","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"in","value":["$llm_model"]}],"op":"AND"},"functions":[],"groupBy":[{"dataType":"string","id":"service.name--string--resource","isColumn":true,"isJSON":false,"key":"service.name","type":"resource"}],"having":{"expression":""},"legend":"{{service.name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"dd8853e1-d021-4ecf-80ac-1546a85c7590","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Number of Requests","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"date":145,"duration_nano":145,"http_method":145,"name":145,"response_status_code":145,"service.name":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"5e66cb8c-2219-47e6-ba71-8f82f9873bc8","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"has_error = 'true' service.name IN $service_name"},"filters":{"items":[{"id":"45f6077f-8492-46fe-b146-4a31f92cd1bd","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"cd7bce73-6b30-45bb-bd0a-0e93316a2ddd","key":{"id":"has_error","key":"has_error","type":""},"op":"=","value":"true"}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"}],"pageSize":10,"queryName":"A","selectColumns":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"b85f93b2-09b5-4fcd-8aa8-f6a2875a41b5","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Errors","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A":""},"columnWidths":{"A":145,"service.name":145,"telemetry.sdk.language":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"67a074ee-c46e-4a36-8f5c-10d981cae404","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() as 'Count' "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name AND gen_ai.request.model EXISTS"},"filters":{"items":[{"id":"7cb134f5-f5fb-4f87-918d-7a0b1fe2db34","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"ba389db8-4417-45d5-8d23-62d9bfd9ae1e","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"exists","value":""}],"op":"AND"},"functions":[],"groupBy":[{"dataType":"string","id":"service.name--string--resource","isColumn":true,"isJSON":false,"key":"service.name","type":"resource"},{"dataType":"string","id":"telemetry.sdk.language--string--resource","isColumn":false,"isJSON":false,"key":"telemetry.sdk.language","type":"resource"}],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"b232e0fb-f5b6-4e7a-ad57-efa8f862086b","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Services and Languages","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"body":350,"timestamp":100},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"05e6759b-c460-4618-86c0-5d2bf0b311c1","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"logs","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name telemetry.sdk.language in $language"},"filters":{"items":[{"id":"14ee9f15-cd4f-453a-bc1f-90aa6c67ed49","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"ad1c34b3-c49a-43e3-8ff0-d54a4fd6b6db","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"},{"columnName":"id","order":"desc"}],"pageSize":10,"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"cf4892fd-86f1-4e83-a876-db114e6e125f","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Logs","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"01c76dbd-5af0-4dcc-9693-006d589112d5","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.input_tokens) )"}],"dataSource":"traces","disabled":true,"expression":"A","filter":{"expression":"service.name in $service_name AND telemetry.sdk.language in $language AND gen_ai.request.model in $llm_model"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null},{"aggregations":[{"expression":"sum(gen_ai.usage.cache_read_input_tokens) )"}],"dataSource":"traces","disabled":true,"expression":"B","filter":{"expression":"service.name in $service_name AND telemetry.sdk.language in $language AND gen_ai.request.model in $llm_model"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"B","source":"","stepInterval":null}],"queryFormulas":[{"disabled":false,"expression":"(B/A) * 100","legend":"","queryName":"F1"}],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"df48ee85-4dff-49f7-b0be-c725b1f8bb56","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Cache Utilization Rate","yAxisUnit":"percent"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"{llm.model_name=\"gpt-4.1-2025-04-14\"}":"#ce93ce","{llm.model_name=\"gpt-5-2025-08-07\"}":"#69aedd"},"decimalPrecision":2,"description":"","fillSpans":false,"id":"28409661-48e9-454c-ba5a-890e5268ef4e","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(llm.usage.total_tokens) ) ) ) "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name"},"functions":[],"groupBy":[{"dataType":"string","id":"gen_ai.request.model--string--tag","isColumn":false,"isJSON":false,"key":"gen_ai.request.model","type":"tag"}],"having":{"expression":""},"legend":"{{gen_ai.request.model}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"47944de4-3d65-4b6f-8e82-a2d0c9113b79","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Token Distribution by Models","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"c0b61678-57d0-439f-8b7b-d7708442a53c","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.input_tokens) )"}],"dataSource":"traces","disabled":true,"expression":"A","filter":{"expression":"service.name in $service_name AND telemetry.sdk.language in $language AND gen_ai.request.model in $llm_model"},"filters":{"items":[{"id":"7cb134f5-f5fb-4f87-918d-7a0b1fe2db34","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"da89ea33-38ae-41b7-81f2-1e9b1147aa18","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]},{"id":"b021aac5-0366-41db-827a-231c59f656c5","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"in","value":["$llm_model"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null},{"aggregations":[{"expression":"sum(gen_ai.usage.cached_prompt_text_tokens) )"}],"dataSource":"traces","disabled":true,"expression":"B","filter":{"expression":"service.name in $service_name AND telemetry.sdk.language in $language AND gen_ai.request.model in $llm_model"},"filters":{"items":[{"id":"7cb134f5-f5fb-4f87-918d-7a0b1fe2db34","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"b893c06d-625e-4558-8864-e4b50db96e54","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]},{"id":"a3280840-8661-45c5-a8b3-37e2b18985bb","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"in","value":["$llm_model"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"B","source":"","stepInterval":null}],"queryFormulas":[{"disabled":false,"expression":"(B/A) * 100","legend":"Cache Util Rate(%)","queryName":"F1"}],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"925b2c5f-2d79-4da7-aa8d-c84b4ff49656","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Cache Utilization Rate","yAxisUnit":"percent"}]}
+{
+  "spec": {
+    "display": {
+      "name": "OpenAI",
+      "description": ""
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "service_name",
+            "description": "The service name using OpenAI"
+          },
+          "defaultValue": [
+            "openai-otel"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "service.name",
+              "signal": "all"
+            }
+          },
+          "name": "service_name"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "language",
+            "description": "Language being used for making Openai calls"
+          },
+          "defaultValue": [
+            "python"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "telemetry.sdk.language",
+              "signal": "all"
+            }
+          },
+          "name": "language"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "llm_model",
+            "description": "LLM Model name being used for Openai"
+          },
+          "defaultValue": [
+            "gpt-5",
+            "gpt-4.1"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "gen_ai.request.model",
+              "signal": "all"
+            }
+          },
+          "name": "llm_model"
+        }
+      }
+    ],
+    "panels": {
+      "04247ee1-b408-457d-ac00-47ce45e64291": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Input Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(gen_ai.usage.input_tokens)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND telemetry.sdk.language in $language AND  gen_ai.request.model in $llm_model"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "05e6759b-c460-4618-86c0-5d2bf0b311c1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Logs",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "timestamp",
+                  "signal": "logs",
+                  "fieldContext": "log",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "body",
+                  "signal": "logs",
+                  "fieldContext": "log",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "logs",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name telemetry.sdk.language in $language"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "28409661-48e9-454c-ba5a-890e5268ef4e": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Token Distribution by Models",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "{llm.model_name=\"gpt-4.1-2025-04-14\"}": "#ce93ce",
+                  "{llm.model_name=\"gpt-5-2025-08-07\"}": "#69aedd"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "sum(gen_ai.usage.input_tokens)"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "service.name IN $service_name gen_ai.request.model EXISTS"
+                          },
+                          "groupBy": [
+                            {
+                              "name": "gen_ai.request.model",
+                              "signal": "",
+                              "fieldContext": "attribute",
+                              "fieldDataType": "string"
+                            }
+                          ],
+                          "order": null,
+                          "selectFields": null,
+                          "secondaryAggregations": null,
+                          "functions": null,
+                          "legend": "{{gen_ai.request.model}}"
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "sum(gen_ai.usage.output_tokens)"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "service.name IN $service_name gen_ai.request.model EXISTS"
+                          },
+                          "groupBy": [
+                            {
+                              "name": "gen_ai.request.model",
+                              "signal": "",
+                              "fieldContext": "attribute",
+                              "fieldDataType": "string"
+                            }
+                          ],
+                          "order": null,
+                          "selectFields": null,
+                          "secondaryAggregations": null,
+                          "functions": null,
+                          "legend": "{{gen_ai.request.model}}"
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "A + B",
+                          "disabled": false,
+                          "order": null,
+                          "functions": null,
+                          "legend": "{{gen_ai.request.model}}"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "28bb5d45-046d-4980-ad5e-26b1aeecda2b": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Token Usage",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "F1": "#eccd03"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "sum(gen_ai.usage.input_tokens)"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "service.name IN $service_name gen_ai.request.model IN $llm_model "
+                          },
+                          "groupBy": [
+                            {
+                              "name": "service.name",
+                              "signal": "",
+                              "fieldContext": "resource",
+                              "fieldDataType": "string"
+                            }
+                          ],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": "{{service.name}}"
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "sum(gen_ai.usage.input_tokens)"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "service.name IN $service_name gen_ai.request.model IN $llm_model "
+                          },
+                          "groupBy": [
+                            {
+                              "name": "service.name",
+                              "signal": "",
+                              "fieldContext": "",
+                              "fieldDataType": ""
+                            }
+                          ],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "A + B",
+                          "disabled": false,
+                          "order": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "functions": null,
+                          "legend": "{{service.name}}"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "3633c7ad-203a-4e25-99f4-8cc81bf15d65": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Model Calls",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": null
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND gen_ai.request.model EXISTS AND has_error = false"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "gen_ai.request.model",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{gen_ai.request.model}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "5e66cb8c-2219-47e6-ba71-8f82f9873bc8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Errors",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "service.name",
+                  "signal": "traces",
+                  "fieldContext": "resource",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "name",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "duration_nano",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "http_method",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "response_status_code",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "has_error = 'true' service.name IN $service_name"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "name",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "duration_nano",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "http_method",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "response_status_code",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      }
+                    ],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "67a074ee-c46e-4a36-8f5c-10d981cae404": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Services and Languages",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A": ""
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()",
+                        "alias": "Count"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name AND gen_ai.request.model EXISTS"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "telemetry.sdk.language",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "74a94376-eeaf-43c1-a273-5d8b98197138": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Number of Requests",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "A": "#edce64",
+                  "count()": "#a403ff"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND telemetry.sdk.language in $language AND gen_ai.request.model in $llm_model  "
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "799913e6-fb95-497e-858a-6490b5f9d10d": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Error Rate",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "percentunit",
+                "decimalPrecision": "2"
+              },
+              "thresholds": [
+                {
+                  "value": 10,
+                  "operator": "above",
+                  "unit": "percentunit",
+                  "color": "Red",
+                  "format": "text"
+                },
+                {
+                  "value": 5,
+                  "operator": "above",
+                  "unit": "percentunit",
+                  "color": "Orange",
+                  "format": "text"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "has_error = 'true' service.name in $service_name AND gen_ai.system EXISTS"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "has_error = 'false' service.name in $service_name AND gen_ai.system EXISTS "
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "A / (A+B)",
+                          "disabled": false,
+                          "order": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "functions": null,
+                          "legend": ""
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "af79b14b-5e76-47fb-a24e-a4629c642c28": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Request Duration (P95)",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ns",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": null
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "p95(duration_nano)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND telemetry.sdk.language in $language AND gen_ai.request.model IN $llm_model "
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Output Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(gen_ai.usage.output_tokens)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND telemetry.sdk.language in $language AND  gen_ai.request.model  in $llm_model"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 3,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/04247ee1-b408-457d-ac00-47ce45e64291"
+              }
+            },
+            {
+              "x": 3,
+              "y": 0,
+              "width": 3,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570"
+              }
+            },
+            {
+              "x": 6,
+              "y": 0,
+              "width": 3,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/28409661-48e9-454c-ba5a-890e5268ef4e"
+              }
+            },
+            {
+              "x": 9,
+              "y": 0,
+              "width": 3,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/3633c7ad-203a-4e25-99f4-8cc81bf15d65"
+              }
+            },
+            {
+              "x": 0,
+              "y": 4,
+              "width": 6,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/799913e6-fb95-497e-858a-6490b5f9d10d"
+              }
+            },
+            {
+              "x": 0,
+              "y": 7,
+              "width": 6,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/28bb5d45-046d-4980-ad5e-26b1aeecda2b"
+              }
+            },
+            {
+              "x": 6,
+              "y": 7,
+              "width": 6,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/af79b14b-5e76-47fb-a24e-a4629c642c28"
+              }
+            },
+            {
+              "x": 0,
+              "y": 12,
+              "width": 6,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/67a074ee-c46e-4a36-8f5c-10d981cae404"
+              }
+            },
+            {
+              "x": 6,
+              "y": 12,
+              "width": 6,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/74a94376-eeaf-43c1-a273-5d8b98197138"
+              }
+            },
+            {
+              "x": 0,
+              "y": 16,
+              "width": 6,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/5e66cb8c-2219-47e6-ba71-8f82f9873bc8"
+              }
+            },
+            {
+              "x": 6,
+              "y": 17,
+              "width": 6,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/05e6759b-c460-4618-86c0-5d2bf0b311c1"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "",
+    "refreshInterval": "",
+    "links": []
+  },
+  "tags": [],
+  "image": "/assets/Icons/eight-ball"
+}

--- a/opencode/opencode-dashboard.json
+++ b/opencode/opencode-dashboard.json
@@ -1,1 +1,1246 @@
-{"description":"Monitor OpenCode usage, costs, tokens, and productivity metrics","image":"data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE0Ljk0OTQgMTMuOTQyQzE2LjIzMTggMTIuNDI1OCAxNy4zMjY4IDkuNzAyMiAxNi4xOTU2IDYuNTc0ODdDMTUuNjQ0MyA1LjA1MjQ1IDE1LjAyMTkgNC4yMDI0OSAxNC4yOTY5IDMuNjYyNTJDMTMuODU1NyAzLjMzMzc5IDEyLjA5MzMgMi41MDYzMyA5Ljc1OTY1IDIuODY3NTZDOC4wNTM0OSAzLjEzMjU1IDUuNzc0ODcgNC4yMDg3NCA0LjI5MzY5IDUuOTU5OUMyLjg1NzUyIDcuNjYxMDYgMS43NDg4MyA5LjAwNDc0IDEuNjk3NTggMTAuMzA5N0MxLjYzMTMzIDExLjk4ODMgMi44OTYyNyAxMy40MzA4IDMuMDUwMDEgMTMuNjY0NUMzLjMyMzc0IDE0LjA3OTUgNS4xOTExNSAxNi40NTE4IDguNjk5NzEgMTYuNTczMUMxMS43OTcgMTYuNjc5MyAxMy44MTQ0IDE1LjI4NDQgMTQuOTQ5NCAxMy45NDJaIiBmaWxsPSIjNDAzRDNFIi8+CjxwYXRoIGQ9Ik00LjU1MzYzIDIuNzM3NDdDMi45Mzc0NiAzLjg5MTE2IDEuMTIxMzEgNi4yNTEwMyAxLjQ0NzU0IDkuNTYwODZDMS42MDYyOCAxMS4xNzIgMi4wMDI1MSAxMi4xNDk1IDIuNTcxMjMgMTIuODUwN0MyLjkxNzQ2IDEzLjI3ODIgNC40MTk4OCAxNC41NDkzIDYuNzczNTEgMTQuNzM2OEM5LjE0NTg4IDE0LjkyNTYgMTAuOTQ5NSAxNC4zOTQ0IDEyLjgzMzIgMTMuMDg0NEMxNi42NjE3IDEwLjQyMDggMTYuMDk4IDYuMzkzNTMgMTUuOTM0MyA1LjkyNDhDMTUuNzcwNSA1LjQ1NjA3IDE0LjU0NDQgMi42OTYyMiAxMS4xNzMzIDEuNzE1MDJDOC4xOTg0NCAwLjg1MDA2OCA1Ljk4MzU1IDEuNzE1MDIgNC41NTM2MyAyLjczNzQ3WiIgZmlsbD0iIzVFNjM2NyIvPgo8cGF0aCBkPSJNNy4zOTM1MyAyLjk2MTA5QzUuNjE3MzcgMi44OTczNCAzLjkxOTk2IDQuMjg4NTIgMy43NTYyMiA2LjAwNTkzQzMuNTkyNDggNy43MjIwOSA0LjY1NDkyIDkuMDI5NTIgNi4zMDk4MyA5LjI5NTc2QzcuOTY0NzUgOS41NjA3NCA5Ljg3ODM5IDguNTU1OCAxMC4yNjM0IDYuNDUwOTFDMTAuNjYwOSA0LjI4MjI3IDkuMDg5NjkgMy4wMjIzNCA3LjM5MzUzIDIuOTYxMDlaIiBmaWxsPSJ3aGl0ZSIvPgo8cGF0aCBkPSJNNy45NDIxNyA1LjkwMTE1QzcuOTQyMTcgNS45MDExNSA4LjM2OTY1IDUuODEyNCA4LjQ1NDY1IDUuMTgyNDRDOC41MzgzOSA0LjU2MjQ3IDguMjMwOTEgNC4wMzM3NSA3LjUxMzQ1IDMuODQzNzZDNi43MzM0OSAzLjYzNzUyIDYuMjA0NzcgNC4wNjYyNSA2LjA2NzI3IDQuNTE3NDdDNS44NzYwMyA1LjE0NDk0IDYuMTU4NTIgNS40NDM2NyA2LjE1ODUyIDUuNDQzNjdDNi4xNTg1MiA1LjQ0MzY3IDUuMzkzNTYgNS42Mjc0MSA1LjMzMjMxIDYuNTI5ODdDNS4yNzQ4MSA3LjM4MTA3IDUuODU2MDMgNy44Mzg1NSA2LjQzOTc1IDcuOTc4NTRDNy4xNjA5NiA4LjE1MjI4IDcuOTc4NDIgNy45NTQ3OSA4LjE3ODQxIDcuMDM0ODRDOC4zNDQ2NSA2LjI3NzM4IDcuOTQyMTcgNS45MDExNSA3Ljk0MjE3IDUuOTAxMTVaIiBmaWxsPSIjMzAzMDMwIi8+CjxwYXRoIGQ9Ik02LjczOTgzIDQuNzUzNjJDNi42NzEwOSA1LjAxMjM1IDYuODA4NTggNS4yNjIzNCA3LjA3ODU3IDUuMzMxMDlDNy4zNjk4IDUuNDA0ODMgNy42MzQ3OSA1LjMwODU5IDcuNzA2MDMgNS4wMTExQzcuNzY4NTMgNC43NDczNyA3LjY0MzU0IDQuNTE0ODggNy4zMzYwNSA0LjQzOTg4QzcuMDgzNTcgNC4zNzczOSA2LjgxNDgzIDQuNDcxMTMgNi43Mzk4MyA0Ljc1MzYyWiIgZmlsbD0id2hpdGUiLz4KPHBhdGggZD0iTTYuOTU5NzggNi4wMzk3NEM2LjYzMjMgNS45Mzg0OSA2LjE5OTgyIDYuMDY0NzMgNi4xMzEwNyA2LjUwNDcxQzYuMDYyMzMgNi45NDQ2OSA2LjMyNjA2IDcuMTY5NjggNi42NzEwNCA3LjIzMjE3QzcuMDE2MDMgNy4yOTQ2NyA3LjM0MjI2IDcuMTEzNDMgNy40MDYwMSA2Ljc2MDk1QzcuNDY4NSA2LjQwOTcyIDcuMjg2MDEgNi4xMzk3MyA2Ljk1OTc4IDYuMDM5NzRaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K","layout":[{"h":5,"i":"aab3c0db-5331-4e8a-909f-55825885a2f0","moved":false,"static":false,"w":2,"x":0,"y":0},{"h":5,"i":"352a8f99-f92c-4b64-8713-b713fe4d1f52","moved":false,"static":false,"w":2,"x":2,"y":0},{"h":5,"i":"session-count","moved":false,"static":false,"w":4,"x":4,"y":0},{"h":5,"i":"tool-decisions","moved":false,"static":false,"w":4,"x":8,"y":0},{"h":5,"i":"tool-success-rate","moved":false,"static":false,"w":4,"x":0,"y":5},{"h":5,"i":"274b2391-0a9b-4677-9980-fa8c9ec69f2b","moved":false,"static":false,"w":4,"x":4,"y":5},{"h":5,"i":"0dc080dc-e717-41f0-9b58-beffa81ed89d","moved":false,"static":false,"w":4,"x":8,"y":5},{"h":5,"i":"token-usage","moved":false,"static":false,"w":6,"x":0,"y":10},{"h":5,"i":"cost-usage","moved":false,"static":false,"w":6,"x":6,"y":10},{"h":5,"i":"token-by-type","moved":false,"static":false,"w":6,"x":0,"y":15},{"h":5,"i":"token-by-model","moved":false,"static":false,"w":6,"x":6,"y":15},{"h":6,"i":"cost-by-model","moved":false,"static":false,"w":6,"x":0,"y":20},{"h":6,"i":"cache-efficiency","moved":false,"static":false,"w":6,"x":6,"y":20},{"h":6,"i":"tool-usage-frequency","moved":false,"static":false,"w":6,"x":0,"y":26}],"panelMap":{},"tags":["ai","opentelemetry","opeencode"],"title":"OpenCode","uploadedGrafana":false,"uuid":"019d8813-9510-745a-ab83-a853e9730f43","variables":{},"version":"v5","widgets":[{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"Number of Claude Code sessions","fillMode":"none","fillSpans":false,"id":"session-count","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"logs","disabled":false,"expression":"A","filter":{"expression":"body = 'session.created'"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"3643a8a0-a669-4e64-9260-4696fb806655","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Sessions","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"Accept/reject decisions for code edits","fillMode":"none","fillSpans":false,"id":"tool-decisions","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"logs","disabled":false,"expression":"A","filter":{"expression":"body = 'tool_result'"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"d2c5aa96-752b-4080-b902-83ae041d339f","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Tool Calls","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"Total tokens consumed over time","fillMode":"none","fillSpans":false,"id":"token-usage","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"metricName":"opencode.token.usage","reduceTo":"sum","spaceAggregation":"sum","temporality":"","timeAggregation":"rate"}],"dataSource":"metrics","disabled":false,"expression":"A","filter":{"expression":""},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"359cde8c-7679-4004-86d0-7ea71d8fbd2a","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Token Usage Over Time","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"Cost accumulation over time","fillMode":"none","fillSpans":false,"id":"cost-usage","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"metricName":"opencode.cost.usage","reduceTo":"sum","spaceAggregation":"sum","temporality":"","timeAggregation":"rate"}],"dataSource":"metrics","disabled":false,"expression":"A","filter":{"expression":""},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"Cost (USD)","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"0d2e5f40-c9bb-46d8-a8d6-903d0b057704","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Cost Over Time (USD)","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"Input, output, cache read, cache creation","fillMode":"none","fillSpans":false,"id":"token-by-type","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"bar","query":{"builder":{"queryData":[{"aggregations":[{"metricName":"opencode.token.usage","reduceTo":"sum","spaceAggregation":"sum","temporality":"","timeAggregation":"rate"}],"dataSource":"metrics","disabled":false,"expression":"A","filter":{"expression":""},"functions":[],"groupBy":[{"dataType":"string","id":"type--string--tag","isColumn":false,"key":"type","type":"tag"}],"having":{"expression":""},"legend":"{{type}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"5c96630b-f864-4803-a9df-88864fa5883e","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Tokens by Type","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"Token consumption by model","fillMode":"none","fillSpans":false,"id":"token-by-model","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"bar","query":{"builder":{"queryData":[{"aggregations":[{"metricName":"opencode.token.usage","reduceTo":"sum","spaceAggregation":"sum","temporality":"","timeAggregation":"rate"}],"dataSource":"metrics","disabled":false,"expression":"A","filter":{"expression":""},"functions":[],"groupBy":[{"dataType":"string","id":"model--string--tag","isColumn":false,"key":"model","type":"tag"}],"having":{"expression":""},"legend":"{{model}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"50dd1055-886b-4a6d-bcab-c05093348bf3","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Tokens by Model","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"Cost breakdown by model","fillMode":"none","fillSpans":false,"id":"cost-by-model","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"bar","query":{"builder":{"queryData":[{"aggregations":[{"metricName":"opencode.cost.usage","reduceTo":"sum","spaceAggregation":"sum","temporality":"","timeAggregation":"rate"}],"dataSource":"metrics","disabled":false,"expression":"A","filter":{"expression":""},"functions":[],"groupBy":[{"dataType":"string","id":"model--string--tag","isColumn":false,"key":"model","type":"tag"}],"having":{"expression":""},"legend":"{{model}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"0e9e851d-a28e-43f2-a6f3-462eca146995","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Cost by Model","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"Percentage of tokens served from cache","fillMode":"none","fillSpans":false,"id":"cache-efficiency","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"metricName":"opencode.token.usage","reduceTo":"sum","spaceAggregation":"sum","temporality":"","timeAggregation":"rate"}],"dataSource":"metrics","disabled":false,"expression":"A","filter":{"expression":"type = 'cacheRead'"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"Cache Read","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":60},{"aggregations":[{"metricName":"opencode.token.usage","reduceTo":"sum","spaceAggregation":"sum","temporality":"","timeAggregation":"rate"}],"dataSource":"metrics","disabled":false,"expression":"B","filter":{"expression":"type = 'input'"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"Input","limit":null,"orderBy":[],"queryName":"B","source":"","stepInterval":60}],"queryFormulas":[{"disabled":false,"expression":"(A / (A + B)) * 100","legend":"Cache Efficiency %","queryName":"F1"}]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"7f24f508-874e-4a91-a094-d156b29a7af5","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Cache Efficiency %","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"Which tools are used most often","fillMode":"none","fillSpans":false,"id":"tool-usage-frequency","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"bar","query":{"builder":{"queryData":[{"aggregations":[{"metricName":"","reduceTo":"avg","spaceAggregation":"sum","temporality":"","timeAggregation":"avg"}],"dataSource":"logs","disabled":false,"expression":"A","filter":{"expression":"body = 'tool_result' service.name = 'opencode'"},"functions":[],"groupBy":[{"dataType":"string","id":"tool_name--string--tag","isColumn":false,"key":"tool_name","type":"tag"}],"having":{"expression":""},"legend":"{{tool_name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"c365c8da-20a1-427f-9f0d-ec86acb7ff26","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Tool Usage Frequency","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"true":"#3efd76"},"decimalPrecision":2,"description":"Success vs failure rate","fillMode":"none","fillSpans":false,"id":"tool-success-rate","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"metricName":"","reduceTo":"avg","spaceAggregation":"sum","temporality":"","timeAggregation":"avg"}],"dataSource":"logs","disabled":false,"expression":"A","filter":{"expression":"body = 'tool_result' service.name = 'opencode'"},"functions":[],"groupBy":[{"dataType":"bool","id":"success--bool--tag","isColumn":false,"isJSON":false,"key":"success","type":"tag"}],"having":{"expression":""},"legend":"{{success}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"273acef0-5cd5-4694-b4ae-c0068dd2ae82","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Tool Success","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"Success vs failure rate","fillMode":"none","fillSpans":false,"id":"274b2391-0a9b-4677-9980-fa8c9ec69f2b","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count()"}],"dataSource":"logs","disabled":false,"expression":"A","filter":{"expression":"body = 'tool_result' service.name = 'opencode'"},"functions":[],"groupBy":[{"dataType":"","id":"tool_name----","key":"tool_name","type":""}],"having":{"expression":""},"legend":"{{tool_name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"a15ca531-bf86-41ec-a278-e48eb4077a23","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Tool Calls","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"openai/o4-mini":"#77dff2"},"decimalPrecision":2,"description":"Success vs failure rate","fillMode":"none","fillSpans":false,"id":"0dc080dc-e717-41f0-9b58-beffa81ed89d","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count()"}],"dataSource":"logs","disabled":false,"expression":"A","filter":{"expression":"body = 'user_prompt' service.name = 'opencode'"},"functions":[],"groupBy":[{"dataType":"string","id":"model--string--tag","isColumn":false,"isJSON":false,"key":"model","type":"tag"}],"having":{"expression":""},"legend":"{{model}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":60}],"queryFormulas":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"831fee7c-0108-485c-85e5-d6e7d2c573aa","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Model Distribution","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"Total hypothetical API cost for selected window","fillMode":"none","fillSpans":false,"id":"aab3c0db-5331-4e8a-909f-55825885a2f0","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"metricName":"opencode.cost.usage","reduceTo":"sum","spaceAggregation":"sum","temporality":"","timeAggregation":"increase"}],"dataSource":"metrics","disabled":false,"expression":"A","filter":{"expression":""},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"Cost ($)","name":"A","query":"SELECT sum(value) as value FROM signoz_metrics.distributed_samples_v4 WHERE metric_name = 'opencode.cost.usage' AND unix_milli >= {{.start_timestamp_ms}} AND unix_milli <= {{.end_timestamp_ms}}"}],"id":"e73010e1-f7ae-4ee0-add1-d89f51a4e093","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Cost (Total)","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillMode":"none","fillSpans":false,"id":"352a8f99-f92c-4b64-8713-b713fe4d1f52","isLogScale":false,"legendPosition":"bottom","lineInterpolation":"spline","lineStyle":"solid","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"metricName":"opencode.token.usage","reduceTo":"sum","spaceAggregation":"sum","temporality":"","timeAggregation":"increase"}],"dataSource":"metrics","disabled":false,"expression":"A","filter":{"expression":""},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"Cost ($)","name":"A","query":"SELECT sum(value) as value FROM signoz_metrics.distributed_samples_v4 WHERE metric_name = 'opencode.cost.usage' AND unix_milli >= {{.start_timestamp_ms}} AND unix_milli <= {{.end_timestamp_ms}}"}],"id":"c3818d43-6bd3-46e9-bcd7-055546f1b770","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder","unit":""},"selectedLogFields":[],"selectedTracesFields":[],"showPoints":false,"softMax":0,"softMin":0,"spanGaps":true,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Total Tokens","yAxisUnit":"none"}]}
+{
+  "spec": {
+    "display": {
+      "name": "OpenCode",
+      "description": "Monitor OpenCode usage, costs, tokens, and productivity metrics"
+    },
+    "variables": [],
+    "panels": {
+      "0dc080dc-e717-41f0-9b58-beffa81ed89d": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Model Distribution",
+            "description": "Success vs failure rate"
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "anthropic/claude-sonnet-5": "#CFE48B",
+                  "google/gemini-2.5-pro": "#8BE495",
+                  "openai/gpt-5": "#3088E8",
+                  "openai/gpt-5-mini": "#E55D76"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "logs",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "body = 'user_prompt' service.name = 'opencode'"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "model",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{model}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "274b2391-0a9b-4677-9980-fa8c9ec69f2b": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Tool Calls",
+            "description": "Success vs failure rate"
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "bash": "#5DE599",
+                  "edit": "#E84C30",
+                  "glob": "#5DB9E5",
+                  "grep": "#CC8BE4",
+                  "list": "#E48BAE",
+                  "read": "#8B98E4",
+                  "webfetch": "#42E830",
+                  "write": "#E3E830"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "logs",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "body = 'tool_result' service.name = 'opencode'"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "tool_name",
+                        "signal": "",
+                        "fieldContext": "",
+                        "fieldDataType": ""
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{tool_name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "352a8f99-f92c-4b64-8713-b713fe4d1f52": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "metrics",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "metricName": "opencode.token.usage",
+                        "temporality": "",
+                        "timeAggregation": "increase",
+                        "spaceAggregation": "sum",
+                        "reduceTo": "sum"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": ""
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "aab3c0db-5331-4e8a-909f-55825885a2f0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cost (Total)",
+            "description": "Total hypothetical API cost for selected window"
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "metrics",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "metricName": "opencode.cost.usage",
+                        "temporality": "",
+                        "timeAggregation": "increase",
+                        "spaceAggregation": "sum",
+                        "reduceTo": "sum"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": ""
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "cache-efficiency": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cache Efficiency %",
+            "description": "Percentage of tokens served from cache"
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "Cache Efficiency %": "#8BE4E3",
+                  "Cache Read": "#803AE9",
+                  "Input": "#E5BB5D"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 60,
+                          "signal": "metrics",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "metricName": "opencode.token.usage",
+                              "temporality": "",
+                              "timeAggregation": "rate",
+                              "spaceAggregation": "sum",
+                              "reduceTo": "sum"
+                            }
+                          ],
+                          "disabled": false,
+                          "filter": {
+                            "expression": "type = 'cacheRead'"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": "Cache Read"
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 60,
+                          "signal": "metrics",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "metricName": "opencode.token.usage",
+                              "temporality": "",
+                              "timeAggregation": "rate",
+                              "spaceAggregation": "sum",
+                              "reduceTo": "sum"
+                            }
+                          ],
+                          "disabled": false,
+                          "filter": {
+                            "expression": "type = 'input'"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": "Input"
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "(A / (A + B)) * 100",
+                          "disabled": false,
+                          "order": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "functions": null,
+                          "legend": "Cache Efficiency %"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "cost-by-model": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cost by Model",
+            "description": "Cost breakdown by model"
+          },
+          "plugin": {
+            "kind": "signoz/BarChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false,
+                "stackedBarChart": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "anthropic/claude-sonnet-5": "#CFE48B",
+                  "google/gemini-2.5-pro": "#8BE495",
+                  "openai/gpt-5": "#3088E8",
+                  "openai/gpt-5-mini": "#E55D76"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "metrics",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "metricName": "opencode.cost.usage",
+                        "temporality": "",
+                        "timeAggregation": "rate",
+                        "spaceAggregation": "sum",
+                        "reduceTo": "sum"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": ""
+                    },
+                    "groupBy": [
+                      {
+                        "name": "model",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{model}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "cost-usage": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cost Over Time (USD)",
+            "description": "Cost accumulation over time"
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": null
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "metrics",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "metricName": "opencode.cost.usage",
+                        "temporality": "",
+                        "timeAggregation": "rate",
+                        "spaceAggregation": "sum",
+                        "reduceTo": "sum"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": ""
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "Cost (USD)"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "session-count": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Sessions",
+            "description": "Number of Claude Code sessions"
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "logs",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "body = 'session.created'"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "token-by-model": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Tokens by Model",
+            "description": "Token consumption by model"
+          },
+          "plugin": {
+            "kind": "signoz/BarChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false,
+                "stackedBarChart": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "anthropic/claude-sonnet-5": "#CFE48B",
+                  "google/gemini-2.5-pro": "#8BE495",
+                  "openai/gpt-5": "#3088E8",
+                  "openai/gpt-5-mini": "#E55D76"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "metrics",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "metricName": "opencode.token.usage",
+                        "temporality": "",
+                        "timeAggregation": "rate",
+                        "spaceAggregation": "sum",
+                        "reduceTo": "sum"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": ""
+                    },
+                    "groupBy": [
+                      {
+                        "name": "model",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{model}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "token-by-type": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Tokens by Type",
+            "description": "Input, output, cache read, cache creation"
+          },
+          "plugin": {
+            "kind": "signoz/BarChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false,
+                "stackedBarChart": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "cacheRead": "#30E8A8",
+                  "cacheWrite": "#DD5DE5",
+                  "input": "#665DE5",
+                  "output": "#E4AB8B"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "metrics",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "metricName": "opencode.token.usage",
+                        "temporality": "",
+                        "timeAggregation": "rate",
+                        "spaceAggregation": "sum",
+                        "reduceTo": "sum"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": ""
+                    },
+                    "groupBy": [
+                      {
+                        "name": "type",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{type}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "token-usage": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Token Usage Over Time",
+            "description": "Total tokens consumed over time"
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": null
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "metrics",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "metricName": "opencode.token.usage",
+                        "temporality": "",
+                        "timeAggregation": "rate",
+                        "spaceAggregation": "sum",
+                        "reduceTo": "sum"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": ""
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "tool-decisions": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Tool Calls",
+            "description": "Accept/reject decisions for code edits"
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "logs",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "body = 'tool_result'"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "tool-success-rate": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Tool Success",
+            "description": "Success vs failure rate"
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "false": "#97E55D",
+                  "true": "#E830B5"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "logs",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "body = 'tool_result' service.name = 'opencode'"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "success",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "bool"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{success}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "tool-usage-frequency": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Tool Usage Frequency",
+            "description": "Which tools are used most often"
+          },
+          "plugin": {
+            "kind": "signoz/BarChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false,
+                "stackedBarChart": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "bash": "#5DE599",
+                  "edit": "#E84C30",
+                  "glob": "#5DB9E5",
+                  "grep": "#CC8BE4",
+                  "list": "#E48BAE",
+                  "read": "#8B98E4",
+                  "webfetch": "#42E830",
+                  "write": "#E3E830"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "logs",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "body = 'tool_result' service.name = 'opencode'"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "tool_name",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{tool_name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 3,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/aab3c0db-5331-4e8a-909f-55825885a2f0"
+              }
+            },
+            {
+              "x": 3,
+              "y": 0,
+              "width": 3,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/352a8f99-f92c-4b64-8713-b713fe4d1f52"
+              }
+            },
+            {
+              "x": 6,
+              "y": 0,
+              "width": 3,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/session-count"
+              }
+            },
+            {
+              "x": 9,
+              "y": 0,
+              "width": 3,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/tool-decisions"
+              }
+            },
+            {
+              "x": 0,
+              "y": 3,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/token-usage"
+              }
+            },
+            {
+              "x": 6,
+              "y": 3,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/cost-usage"
+              }
+            },
+            {
+              "x": 0,
+              "y": 9,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/token-by-type"
+              }
+            },
+            {
+              "x": 6,
+              "y": 9,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/token-by-model"
+              }
+            },
+            {
+              "x": 0,
+              "y": 15,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/cost-by-model"
+              }
+            },
+            {
+              "x": 6,
+              "y": 15,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/cache-efficiency"
+              }
+            },
+            {
+              "x": 0,
+              "y": 21,
+              "width": 4,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/tool-success-rate"
+              }
+            },
+            {
+              "x": 4,
+              "y": 21,
+              "width": 4,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/274b2391-0a9b-4677-9980-fa8c9ec69f2b"
+              }
+            },
+            {
+              "x": 8,
+              "y": 21,
+              "width": 4,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/0dc080dc-e717-41f0-9b58-beffa81ed89d"
+              }
+            },
+            {
+              "x": 0,
+              "y": 27,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/tool-usage-frequency"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "",
+    "refreshInterval": "",
+    "links": []
+  },
+  "tags": [
+    {
+      "key": "tag",
+      "value": "ai"
+    },
+    {
+      "key": "tag",
+      "value": "opentelemetry"
+    },
+    {
+      "key": "tag",
+      "value": "opeencode"
+    }
+  ],
+  "image": "/assets/Icons/eight-ball"
+}

--- a/pipecat/pipecat-dashboard.json
+++ b/pipecat/pipecat-dashboard.json
@@ -1,1 +1,1663 @@
-{"description":"","image":"data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE0Ljk0OTQgMTMuOTQyQzE2LjIzMTggMTIuNDI1OCAxNy4zMjY4IDkuNzAyMiAxNi4xOTU2IDYuNTc0ODdDMTUuNjQ0MyA1LjA1MjQ1IDE1LjAyMTkgNC4yMDI0OSAxNC4yOTY5IDMuNjYyNTJDMTMuODU1NyAzLjMzMzc5IDEyLjA5MzMgMi41MDYzMyA5Ljc1OTY1IDIuODY3NTZDOC4wNTM0OSAzLjEzMjU1IDUuNzc0ODcgNC4yMDg3NCA0LjI5MzY5IDUuOTU5OUMyLjg1NzUyIDcuNjYxMDYgMS43NDg4MyA5LjAwNDc0IDEuNjk3NTggMTAuMzA5N0MxLjYzMTMzIDExLjk4ODMgMi44OTYyNyAxMy40MzA4IDMuMDUwMDEgMTMuNjY0NUMzLjMyMzc0IDE0LjA3OTUgNS4xOTExNSAxNi40NTE4IDguNjk5NzEgMTYuNTczMUMxMS43OTcgMTYuNjc5MyAxMy44MTQ0IDE1LjI4NDQgMTQuOTQ5NCAxMy45NDJaIiBmaWxsPSIjNDAzRDNFIi8+CjxwYXRoIGQ9Ik00LjU1MzYzIDIuNzM3NDdDMi45Mzc0NiAzLjg5MTE2IDEuMTIxMzEgNi4yNTEwMyAxLjQ0NzU0IDkuNTYwODZDMS42MDYyOCAxMS4xNzIgMi4wMDI1MSAxMi4xNDk1IDIuNTcxMjMgMTIuODUwN0MyLjkxNzQ2IDEzLjI3ODIgNC40MTk4OCAxNC41NDkzIDYuNzczNTEgMTQuNzM2OEM5LjE0NTg4IDE0LjkyNTYgMTAuOTQ5NSAxNC4zOTQ0IDEyLjgzMzIgMTMuMDg0NEMxNi42NjE3IDEwLjQyMDggMTYuMDk4IDYuMzkzNTMgMTUuOTM0MyA1LjkyNDhDMTUuNzcwNSA1LjQ1NjA3IDE0LjU0NDQgMi42OTYyMiAxMS4xNzMzIDEuNzE1MDJDOC4xOTg0NCAwLjg1MDA2OCA1Ljk4MzU1IDEuNzE1MDIgNC41NTM2MyAyLjczNzQ3WiIgZmlsbD0iIzVFNjM2NyIvPgo8cGF0aCBkPSJNNy4zOTM1MyAyLjk2MTA5QzUuNjE3MzcgMi44OTczNCAzLjkxOTk2IDQuMjg4NTIgMy43NTYyMiA2LjAwNTkzQzMuNTkyNDggNy43MjIwOSA0LjY1NDkyIDkuMDI5NTIgNi4zMDk4MyA5LjI5NTc2QzcuOTY0NzUgOS41NjA3NCA5Ljg3ODM5IDguNTU1OCAxMC4yNjM0IDYuNDUwOTFDMTAuNjYwOSA0LjI4MjI3IDkuMDg5NjkgMy4wMjIzNCA3LjM5MzUzIDIuOTYxMDlaIiBmaWxsPSJ3aGl0ZSIvPgo8cGF0aCBkPSJNNy45NDIxNyA1LjkwMTE1QzcuOTQyMTcgNS45MDExNSA4LjM2OTY1IDUuODEyNCA4LjQ1NDY1IDUuMTgyNDRDOC41MzgzOSA0LjU2MjQ3IDguMjMwOTEgNC4wMzM3NSA3LjUxMzQ1IDMuODQzNzZDNi43MzM0OSAzLjYzNzUyIDYuMjA0NzcgNC4wNjYyNSA2LjA2NzI3IDQuNTE3NDdDNS44NzYwMyA1LjE0NDk0IDYuMTU4NTIgNS40NDM2NyA2LjE1ODUyIDUuNDQzNjdDNi4xNTg1MiA1LjQ0MzY3IDUuMzkzNTYgNS42Mjc0MSA1LjMzMjMxIDYuNTI5ODdDNS4yNzQ4MSA3LjM4MTA3IDUuODU2MDMgNy44Mzg1NSA2LjQzOTc1IDcuOTc4NTRDNy4xNjA5NiA4LjE1MjI4IDcuOTc4NDIgNy45NTQ3OSA4LjE3ODQxIDcuMDM0ODRDOC4zNDQ2NSA2LjI3NzM4IDcuOTQyMTcgNS45MDExNSA3Ljk0MjE3IDUuOTAxMTVaIiBmaWxsPSIjMzAzMDMwIi8+CjxwYXRoIGQ9Ik02LjczOTgzIDQuNzUzNjJDNi42NzEwOSA1LjAxMjM1IDYuODA4NTggNS4yNjIzNCA3LjA3ODU3IDUuMzMxMDlDNy4zNjk4IDUuNDA0ODMgNy42MzQ3OSA1LjMwODU5IDcuNzA2MDMgNS4wMTExQzcuNzY4NTMgNC43NDczNyA3LjY0MzU0IDQuNTE0ODggNy4zMzYwNSA0LjQzOTg4QzcuMDgzNTcgNC4zNzczOSA2LjgxNDgzIDQuNDcxMTMgNi43Mzk4MyA0Ljc1MzYyWiIgZmlsbD0id2hpdGUiLz4KPHBhdGggZD0iTTYuOTU5NzggNi4wMzk3NEM2LjYzMjMgNS45Mzg0OSA2LjE5OTgyIDYuMDY0NzMgNi4xMzEwNyA2LjUwNDcxQzYuMDYyMzMgNi45NDQ2OSA2LjMyNjA2IDcuMTY5NjggNi42NzEwNCA3LjIzMjE3QzcuMDE2MDMgNy4yOTQ2NyA3LjM0MjI2IDcuMTEzNDMgNy40MDYwMSA2Ljc2MDk1QzcuNDY4NSA2LjQwOTcyIDcuMjg2MDEgNi4xMzk3MyA2Ljk1OTc4IDYuMDM5NzRaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K","layout":[{"h":3,"i":"04247ee1-b408-457d-ac00-47ce45e64291","moved":false,"static":false,"w":3,"x":0,"y":0},{"h":3,"i":"d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570","moved":false,"static":false,"w":3,"x":3,"y":0},{"h":3,"i":"799913e6-fb95-497e-858a-6490b5f9d10d","moved":false,"static":false,"w":3,"x":6,"y":0},{"h":5,"i":"3633c7ad-203a-4e25-99f4-8cc81bf15d65","moved":false,"static":false,"w":3,"x":9,"y":0},{"h":3,"i":"579f8e38-9b07-4c73-ae6c-db82b65ea4b2","moved":false,"static":false,"w":3,"x":0,"y":3},{"h":3,"i":"7acd2252-19fb-4734-9dd2-d1152ef6da3d","moved":false,"static":false,"w":3,"x":3,"y":3},{"h":5,"i":"2a0d0b95-c3ee-4088-984b-9442b322713d","moved":false,"static":false,"w":3,"x":6,"y":3},{"h":5,"i":"56970f2d-77c5-4765-8889-f469b9c28f87","moved":false,"static":false,"w":3,"x":9,"y":5},{"h":5,"i":"28bb5d45-046d-4980-ad5e-26b1aeecda2b","moved":false,"static":false,"w":5,"x":0,"y":6},{"h":4,"i":"fe46bf68-9c77-478f-958e-36d8478ebbcd","moved":false,"static":false,"w":4,"x":5,"y":8},{"h":5,"i":"af79b14b-5e76-47fb-a24e-a4629c642c28","moved":false,"static":false,"w":5,"x":0,"y":11},{"h":5,"i":"74a94376-eeaf-43c1-a273-5d8b98197138","moved":false,"static":false,"w":5,"x":5,"y":12},{"h":6,"i":"e9849813-832e-4661-9395-a11fd60f80d1","moved":false,"static":false,"w":5,"x":0,"y":16},{"h":4,"i":"bc6e3017-2b44-4152-a0d7-fe11e6b7a290","moved":false,"static":false,"w":5,"x":5,"y":17},{"h":3,"i":"67a074ee-c46e-4a36-8f5c-10d981cae404","moved":false,"static":false,"w":6,"x":5,"y":21},{"h":6,"i":"066e6cd9-1f1d-4b2a-94dd-4bdafb34a31f","moved":false,"static":false,"w":5,"x":0,"y":22},{"h":7,"i":"05e6759b-c460-4618-86c0-5d2bf0b311c1","moved":false,"static":false,"w":6,"x":5,"y":24},{"h":3,"i":"5e66cb8c-2219-47e6-ba71-8f82f9873bc8","moved":false,"static":false,"w":5,"x":0,"y":28},{"h":1,"i":"__dropping-elem__","isDraggable":true,"moved":false,"static":false,"w":1,"x":10,"y":31}],"panelMap":{},"tags":[],"title":"Pipecat","uploadedGrafana":false,"uuid":"019adc8f-fed6-7358-9c2b-e73adc7e1071","variables":{"10d0eca9-9253-4583-821c-d3c812d78151":{"allSelected":false,"customValue":"","defaultValue":"","description":"The service name using PipeCat","dynamicVariablesAttribute":"service.name","dynamicVariablesSource":"All telemetry","id":"10d0eca9-9253-4583-821c-d3c812d78151","key":"10d0eca9-9253-4583-821c-d3c812d78151","modificationUUID":"f5b63ce8-61b2-428d-bc20-3a73ee85f931","multiSelect":true,"name":"service_name","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"2c6e624c-7059-4f1c-be3b-810267de5857":{"allSelected":false,"customValue":"","description":"Number of turns in the conversation","id":"2c6e624c-7059-4f1c-be3b-810267de5857","key":"2c6e624c-7059-4f1c-be3b-810267de5857","modificationUUID":"e26619ce-4cf5-4ea7-98f6-06c6ed628f0b","multiSelect":false,"name":"turns_threshold","order":0,"queryValue":"","showALLOption":false,"sort":"DISABLED","textboxValue":"1","type":"TEXTBOX"},"93c33118-5f46-404b-b45e-8a81160c44c4":{"allSelected":true,"customValue":"","defaultValue":"","description":"Language being used for making PipeCat calls","dynamicVariablesAttribute":"telemetry.sdk.language","dynamicVariablesSource":"All telemetry","id":"93c33118-5f46-404b-b45e-8a81160c44c4","key":"93c33118-5f46-404b-b45e-8a81160c44c4","modificationUUID":"1c6b9d07-5972-462c-890d-65dc860855ae","multiSelect":true,"name":"language","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"be7a68c4-fb97-43ea-bb94-0ded120bd3d7":{"allSelected":true,"customValue":"","defaultValue":"","description":"Model name being used in PipeCat convsersation","dynamicVariablesAttribute":"gen_ai.request.model","dynamicVariablesSource":"All telemetry","id":"be7a68c4-fb97-43ea-bb94-0ded120bd3d7","modificationUUID":"6d404f24-046d-466b-a17e-619264192794","multiSelect":true,"name":"llm_model","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"}},"version":"v5","widgets":[{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"04247ee1-b408-457d-ac00-47ce45e64291","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.input_tokens) ) ) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"bb241026-ce55-4286-aa8d-692b0057e39d","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Input Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.output_tokens) ) ) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"5eaa5664-2564-415d-bea4-1a9e83c74108","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Output Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"799913e6-fb95-497e-858a-6490b5f9d10d","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"A","filter":{"expression":"has_error = 'true' service.name in $service_name"},"filters":{"items":[{"id":"45f6077f-8492-46fe-b146-4a31f92cd1bd","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"1426bee0-f647-4d48-be3d-8d0862722f92","key":{"id":"has_error","key":"has_error","type":""},"op":"=","value":"true"}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null},{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"B","filter":{"expression":"has_error = 'false' service.name in $service_name"},"filters":{"items":[{"id":"45f6077f-8492-46fe-b146-4a31f92cd1bd","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"c3bd2eb4-ee27-4e25-81a3-218260a30494","key":{"id":"has_error","key":"has_error","type":""},"op":"=","value":"false"}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"B","source":"","stepInterval":null}],"queryFormulas":[{"disabled":false,"expression":"A / (A+B)","legend":"","queryName":"F1"}],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"06db8fa1-2559-4a1e-ae05-19f94089cb58","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[{"index":"e5e05d41-7479-4d60-a1cf-c433b8b61285","isEditEnabled":false,"keyIndex":1,"selectedGraph":"value","thresholdColor":"Red","thresholdFormat":"Text","thresholdLabel":"","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"percentunit","thresholdValue":10},{"index":"d74bf17b-552a-4636-8fad-c976b090d590","isEditEnabled":false,"keyIndex":0,"selectedGraph":"value","thresholdColor":"Orange","thresholdFormat":"Text","thresholdLabel":"","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"percentunit","thresholdValue":5}],"timePreferance":"GLOBAL_TIME","title":"Error Rate","yAxisUnit":"percentunit"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"3633c7ad-203a-4e25-99f4-8cc81bf15d65","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND gen_ai.request.model EXISTS AND gen_ai.operation.name = 'chat'"},"functions":[],"groupBy":[{"dataType":"string","id":"gen_ai.request.model--string--tag","isColumn":false,"isJSON":false,"key":"gen_ai.request.model","type":"tag"}],"having":{"expression":""},"legend":"{{gen_ai.request.model}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"c2ee8c7c-31b9-4fcd-8634-d310c025e531","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"LLM Model Distribution","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"F1":"#eccd03"},"decimalPrecision":2,"description":"","fillSpans":false,"id":"28bb5d45-046d-4980-ad5e-26b1aeecda2b","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.input_tokens)"}],"dataSource":"traces","disabled":true,"expression":"A","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null},{"aggregations":[{"expression":"sum(gen_ai.usage.output_tokens)"}],"dataSource":"traces","disabled":true,"expression":"B","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"B","source":"","stepInterval":null}],"queryFormulas":[{"disabled":false,"expression":"A + B","legend":"","queryName":"F1"}],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"4661da5d-31c7-43b6-a24e-2c3fda80ae57","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Token Usage","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"af79b14b-5e76-47fb-a24e-a4629c642c28","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"avg(turn.duration_seconds) "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"03fe6301-9b05-4982-80f5-40d8a7163d30","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Agent Turn Latency (avg)","yAxisUnit":"ns"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"A":"#edce64","count()":"#a403ff"},"decimalPrecision":2,"description":"","fillSpans":false,"id":"74a94376-eeaf-43c1-a273-5d8b98197138","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND name = 'conversation'"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"c9ec790c-7ef7-4590-9a15-4a530ca85b0e","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Number of Conversations","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"date":145,"duration_nano":145,"http_method":145,"name":145,"response_status_code":145,"service.name":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"5e66cb8c-2219-47e6-ba71-8f82f9873bc8","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"has_error = 'true' service.name IN $service_name"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"}],"pageSize":10,"queryName":"A","selectColumns":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"b85f93b2-09b5-4fcd-8aa8-f6a2875a41b5","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Errors","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A":""},"columnWidths":{"A":145,"service.name":145,"telemetry.sdk.language":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"67a074ee-c46e-4a36-8f5c-10d981cae404","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() as 'Count of Conversations' "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name AND telemetry.sdk.language IN $language AND name = 'conversation'"},"functions":[],"groupBy":[{"dataType":"string","id":"service.name--string--resource","isColumn":true,"isJSON":false,"key":"service.name","type":"resource"},{"dataType":"string","id":"telemetry.sdk.language--string--resource","isColumn":false,"isJSON":false,"key":"telemetry.sdk.language","type":"resource"}],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"4f765427-aaeb-42b2-bb49-3f4cec8de917","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Services and Languages","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"A":"#5eddce"},"decimalPrecision":2,"description":"","fillSpans":false,"id":"bc6e3017-2b44-4152-a0d7-fe11e6b7a290","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"metricName":"http.client.duration.max","reduceTo":"avg","spaceAggregation":"avg","temporality":"","timeAggregation":"avg"}],"dataSource":"metrics","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name"},"filters":{"items":[{"id":"d0fd8178-0307-45dd-9459-1b052b22121d","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"3e688253-85e8-4cfc-814d-5ab821a950db","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"HTTP Request Duration","yAxisUnit":"ms"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"body":350,"timestamp":100},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"05e6759b-c460-4618-86c0-5d2bf0b311c1","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"logs","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name telemetry.sdk.language in $language"},"filters":{"items":[{"id":"14ee9f15-cd4f-453a-bc1f-90aa6c67ed49","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"ad1c34b3-c49a-43e3-8ff0-d54a4fd6b6db","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"},{"columnName":"id","order":"desc"}],"pageSize":10,"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"cf4892fd-86f1-4e83-a876-db114e6e125f","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Logs","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"e9849813-832e-4661-9395-a11fd60f80d1","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"avg(duration_nano)"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name AND name = 'tts'"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"1016df65-e02f-40ec-a8e8-d39c549f93e9","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"TTS Duration","yAxisUnit":"ns"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"579f8e38-9b07-4c73-ae6c-db82b65ea4b2","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregateAttribute":{"dataType":"","id":"----","key":"","type":""},"aggregateOperator":"count","aggregations":[{"expression":"count_distinct(trace_id)"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"name = 'agent_turn' AND count < $turns_threshold service.name in []"},"filters":{"items":[{"id":"eeb019fe-ae08-44c3-afd9-c9011573e337","key":{"id":"name","key":"name","type":""},"op":"=","value":"agent_turn"},{"id":"5f5ba866-bce0-4004-8cf5-1ed064737ed5","key":{"id":"count","key":"count","type":""},"op":"<","value":"$turns_threshold"},{"id":"b12032eb-bf37-49d1-b75f-59b84dd5c1e1","key":{"id":"service.name","key":"service.name","type":""},"op":"in","value":[]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","reduceTo":"avg","source":"","spaceAggregation":"sum","stepInterval":null,"timeAggregation":"rate"}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":"SELECT\n    count() AS conversations_below_threshold\nFROM (\n    SELECT\n        traceID,\n        count(*) AS turn_count\n    FROM signoz_traces.distributed_signoz_index_v3\n    WHERE serviceName IN $service_name\n      AND name = 'turn'\n    GROUP BY traceID\n    HAVING turn_count < toUInt64($turns_threshold)\n)\n"}],"id":"e843bcfe-68db-4e43-8dd4-7b46c1ab2951","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"clickhouse_sql"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Number of Conversations Below Threshold","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A":""},"columnWidths":{"traceID":145,"turn_count":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"fe46bf68-9c77-478f-958e-36d8478ebbcd","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregateAttribute":{"dataType":"","id":"----","key":"","type":""},"aggregateOperator":"count","aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":""},"filters":{"items":[],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","reduceTo":"avg","source":"","spaceAggregation":"sum","stepInterval":null,"timeAggregation":"rate"}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":"SELECT\n    traceID,\n    turn_count\nFROM (\n    SELECT\n        traceID,\n        count(*) AS turn_count\n    FROM signoz_traces.distributed_signoz_index_v3\n    WHERE serviceName IN $service_name\n      AND name = 'turn'\n    GROUP BY traceID\n)\nWHERE turn_count < toUInt64($turns_threshold)\nORDER BY turn_count ASC, traceID\n"}],"id":"dc529d72-407c-41e1-acf3-d990bf77bd69","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"clickhouse_sql"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Conversations Below Threshold","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"7acd2252-19fb-4734-9dd2-d1152ef6da3d","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregateAttribute":{"dataType":"","id":"----","key":"","type":""},"aggregateOperator":"count","aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":""},"filters":{"items":[],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","reduceTo":"avg","source":"","spaceAggregation":"sum","stepInterval":null,"timeAggregation":"rate"}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":"SELECT\n    avg(turn_count) AS avg_turns_per_conversation\nFROM (\n    SELECT\n        traceID,\n        count(*) AS turn_count\n    FROM signoz_traces.distributed_signoz_index_v3\n    WHERE serviceName IN $service_name\n      AND name = 'turn'\n    GROUP BY traceID\n)\n"}],"id":"d9eccec4-ff87-4cbf-a0c5-3f740ad43332","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"clickhouse_sql"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Average Turns Per Conversation","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"avg(duration_nano)":"#ff00c4"},"decimalPrecision":2,"description":"","fillSpans":false,"id":"066e6cd9-1f1d-4b2a-94dd-4bdafb34a31f","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"avg(duration_nano)"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name AND name = 'stt'"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"be97b8cb-c13e-4271-b58e-65f6849c2c1f","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"SST Duration","yAxisUnit":"ns"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"56970f2d-77c5-4765-8889-f469b9c28f87","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND gen_ai.request.model EXISTS AND gen_ai.operation.name = 'tts' "},"functions":[],"groupBy":[{"dataType":"string","id":"gen_ai.request.model--string--tag","isColumn":false,"isJSON":false,"key":"gen_ai.request.model","type":"tag"}],"having":{"expression":""},"legend":"{{gen_ai.request.model}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"9495e4c3-2766-4382-82ac-3e93d9222ef3","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"TTS Model Distribution","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"2a0d0b95-c3ee-4088-984b-9442b322713d","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND gen_ai.request.model EXISTS AND gen_ai.operation.name = 'stt' "},"functions":[],"groupBy":[{"dataType":"string","id":"gen_ai.request.model--string--tag","isColumn":false,"isJSON":false,"key":"gen_ai.request.model","type":"tag"}],"having":{"expression":""},"legend":"{{gen_ai.request.model}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"314f5592-4509-4d44-8177-8dbd2f823cff","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"STT Model Distribution","yAxisUnit":"none"}]}
+{
+  "spec": {
+    "display": {
+      "name": "Pipecat",
+      "description": ""
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "service_name",
+            "description": "The service name using PipeCat"
+          },
+          "defaultValue": [
+            "pipecat-otel",
+            "pipecat-voice-agent",
+            "pipecat-support-line"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "service.name",
+              "signal": "all"
+            }
+          },
+          "name": "service_name"
+        }
+      },
+      {
+        "kind": "TextVariable",
+        "spec": {
+          "display": {
+            "name": "turns_threshold",
+            "description": "Number of turns in the conversation"
+          },
+          "value": "3",
+          "constant": false,
+          "name": "turns_threshold"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "language",
+            "description": "Language being used for making PipeCat calls"
+          },
+          "defaultValue": [
+            "python"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "telemetry.sdk.language",
+              "signal": "all"
+            }
+          },
+          "name": "language"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "llm_model",
+            "description": "Model name being used in PipeCat convsersation"
+          },
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "gen_ai.request.model",
+              "signal": "all"
+            }
+          },
+          "name": "llm_model"
+        }
+      }
+    ],
+    "panels": {
+      "04247ee1-b408-457d-ac00-47ce45e64291": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Input Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(gen_ai.usage.input_tokens)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "05e6759b-c460-4618-86c0-5d2bf0b311c1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Logs",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "timestamp",
+                  "signal": "logs",
+                  "fieldContext": "log",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "body",
+                  "signal": "logs",
+                  "fieldContext": "log",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "logs",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name telemetry.sdk.language in $language"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "066e6cd9-1f1d-4b2a-94dd-4bdafb34a31f": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "SST Duration",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ns",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "pipecat-otel": "#985DE5",
+                  "pipecat-support-line": "#30E5E8",
+                  "pipecat-voice-agent": "#E4CC8B"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "avg(duration_nano)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name AND name = 'stt'"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "28bb5d45-046d-4980-ad5e-26b1aeecda2b": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Token Usage",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "pipecat-otel": "#985DE5",
+                  "pipecat-support-line": "#30E5E8",
+                  "pipecat-voice-agent": "#E4CC8B"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "sum(gen_ai.usage.input_tokens)"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"
+                          },
+                          "groupBy": [
+                            {
+                              "name": "service.name",
+                              "signal": "",
+                              "fieldContext": "resource",
+                              "fieldDataType": "string"
+                            }
+                          ],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "sum(gen_ai.usage.output_tokens)"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"
+                          },
+                          "groupBy": [
+                            {
+                              "name": "service.name",
+                              "signal": "",
+                              "fieldContext": "resource",
+                              "fieldDataType": "string"
+                            }
+                          ],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "A + B",
+                          "disabled": false,
+                          "order": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "functions": null,
+                          "legend": "{{service.name}}"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "2a0d0b95-c3ee-4088-984b-9442b322713d": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "STT Model Distribution",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "nova-3": "#E55DBB",
+                  "whisper-large-v3": "#AFE48B"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND gen_ai.request.model EXISTS AND gen_ai.operation.name = 'stt' "
+                    },
+                    "groupBy": [
+                      {
+                        "name": "gen_ai.request.model",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{gen_ai.request.model}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "3633c7ad-203a-4e25-99f4-8cc81bf15d65": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "LLM Model Distribution",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "claude-haiku-4-5": "#8BE4B5",
+                  "gemini-2.5-flash": "#BD30E8",
+                  "gpt-4.1": "#E5765D",
+                  "gpt-4.1-mini": "#4355EA"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND gen_ai.request.model EXISTS AND gen_ai.operation.name = 'chat'"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "gen_ai.request.model",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{gen_ai.request.model}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "56970f2d-77c5-4765-8889-f469b9c28f87": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "TTS Model Distribution",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "eleven_turbo_v2_5": "#8BC5E4",
+                  "sonic-2": "#DCE55D"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND gen_ai.request.model EXISTS AND gen_ai.operation.name = 'tts' "
+                    },
+                    "groupBy": [
+                      {
+                        "name": "gen_ai.request.model",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{gen_ai.request.model}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "579f8e38-9b07-4c73-ae6c-db82b65ea4b2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Number of Conversations Below Threshold",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/ClickHouseSQL",
+                  "spec": {
+                    "name": "A",
+                    "query": "SELECT\n    count() AS conversations_below_threshold\nFROM (\n    SELECT\n        traceID,\n        count(*) AS turn_count\n    FROM signoz_traces.distributed_signoz_index_v3\n    WHERE serviceName IN $service_name\n      AND name = 'turn'\n    GROUP BY traceID\n    HAVING turn_count < toUInt64($turns_threshold)\n)\n",
+                    "disabled": false,
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "5e66cb8c-2219-47e6-ba71-8f82f9873bc8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Errors",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "service.name",
+                  "signal": "traces",
+                  "fieldContext": "resource",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "name",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "duration_nano",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "http_method",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "response_status_code",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "has_error = 'true' service.name IN $service_name"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "name",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "duration_nano",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "http_method",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "response_status_code",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      }
+                    ],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "67a074ee-c46e-4a36-8f5c-10d981cae404": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Services and Languages",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A": ""
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()",
+                        "alias": "Count of Conversations"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name AND telemetry.sdk.language IN $language AND name = 'conversation'"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "telemetry.sdk.language",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "74a94376-eeaf-43c1-a273-5d8b98197138": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Number of Conversations",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "pipecat-otel": "#985DE5",
+                  "pipecat-support-line": "#30E5E8",
+                  "pipecat-voice-agent": "#E4CC8B"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND name = 'conversation'"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "799913e6-fb95-497e-858a-6490b5f9d10d": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Error Rate",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "percentunit",
+                "decimalPrecision": "2"
+              },
+              "thresholds": [
+                {
+                  "value": 0.1,
+                  "operator": "above",
+                  "unit": "percentunit",
+                  "color": "Red",
+                  "format": "text"
+                },
+                {
+                  "value": 0.05,
+                  "operator": "above",
+                  "unit": "percentunit",
+                  "color": "Orange",
+                  "format": "text"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "has_error = 'true' service.name in $service_name"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "has_error = 'false' service.name in $service_name"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "A / (A+B)",
+                          "disabled": false,
+                          "order": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "functions": null,
+                          "legend": ""
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "7acd2252-19fb-4734-9dd2-d1152ef6da3d": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Average Turns Per Conversation",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/ClickHouseSQL",
+                  "spec": {
+                    "name": "A",
+                    "query": "SELECT\n    avg(turn_count) AS avg_turns_per_conversation\nFROM (\n    SELECT\n        traceID,\n        count(*) AS turn_count\n    FROM signoz_traces.distributed_signoz_index_v3\n    WHERE serviceName IN $service_name\n      AND name = 'turn'\n    GROUP BY traceID\n)\n",
+                    "disabled": false,
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "af79b14b-5e76-47fb-a24e-a4629c642c28": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Agent Turn Latency (avg)",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ns",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "pipecat-otel": "#985DE5",
+                  "pipecat-support-line": "#30E5E8",
+                  "pipecat-voice-agent": "#E4CC8B"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "avg(turn.duration_seconds)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name telemetry.sdk.language in $language"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "bc6e3017-2b44-4152-a0d7-fe11e6b7a290": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "HTTP Request Duration",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ms",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "pipecat-otel": "#985DE5",
+                  "pipecat-support-line": "#30E5E8",
+                  "pipecat-voice-agent": "#E4CC8B"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "metrics",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "metricName": "http.client.duration.max",
+                        "temporality": "",
+                        "timeAggregation": "avg",
+                        "spaceAggregation": "avg",
+                        "reduceTo": "avg"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Output Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(gen_ai.usage.output_tokens)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "e9849813-832e-4661-9395-a11fd60f80d1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "TTS Duration",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ns",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "pipecat-otel": "#985DE5",
+                  "pipecat-support-line": "#30E5E8",
+                  "pipecat-voice-agent": "#E4CC8B"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "avg(duration_nano)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name AND name = 'tts'"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "fe46bf68-9c77-478f-958e-36d8478ebbcd": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Conversations Below Threshold",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A": ""
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/ClickHouseSQL",
+                  "spec": {
+                    "name": "A",
+                    "query": "SELECT\n    traceID,\n    turn_count\nFROM (\n    SELECT\n        traceID,\n        count(*) AS turn_count\n    FROM signoz_traces.distributed_signoz_index_v3\n    WHERE serviceName IN $service_name\n      AND name = 'turn'\n    GROUP BY traceID\n)\nWHERE turn_count < toUInt64($turns_threshold)\nORDER BY turn_count ASC, traceID\n",
+                    "disabled": false,
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 3,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/04247ee1-b408-457d-ac00-47ce45e64291"
+              }
+            },
+            {
+              "x": 3,
+              "y": 0,
+              "width": 3,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570"
+              }
+            },
+            {
+              "x": 6,
+              "y": 0,
+              "width": 3,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/799913e6-fb95-497e-858a-6490b5f9d10d"
+              }
+            },
+            {
+              "x": 9,
+              "y": 0,
+              "width": 3,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/7acd2252-19fb-4734-9dd2-d1152ef6da3d"
+              }
+            },
+            {
+              "x": 0,
+              "y": 3,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/74a94376-eeaf-43c1-a273-5d8b98197138"
+              }
+            },
+            {
+              "x": 6,
+              "y": 3,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/af79b14b-5e76-47fb-a24e-a4629c642c28"
+              }
+            },
+            {
+              "x": 0,
+              "y": 9,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/066e6cd9-1f1d-4b2a-94dd-4bdafb34a31f"
+              }
+            },
+            {
+              "x": 6,
+              "y": 9,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/e9849813-832e-4661-9395-a11fd60f80d1"
+              }
+            },
+            {
+              "x": 0,
+              "y": 15,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/28bb5d45-046d-4980-ad5e-26b1aeecda2b"
+              }
+            },
+            {
+              "x": 6,
+              "y": 15,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/bc6e3017-2b44-4152-a0d7-fe11e6b7a290"
+              }
+            },
+            {
+              "x": 0,
+              "y": 21,
+              "width": 4,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/2a0d0b95-c3ee-4088-984b-9442b322713d"
+              }
+            },
+            {
+              "x": 4,
+              "y": 21,
+              "width": 4,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/3633c7ad-203a-4e25-99f4-8cc81bf15d65"
+              }
+            },
+            {
+              "x": 8,
+              "y": 21,
+              "width": 4,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/56970f2d-77c5-4765-8889-f469b9c28f87"
+              }
+            },
+            {
+              "x": 0,
+              "y": 27,
+              "width": 5,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/fe46bf68-9c77-478f-958e-36d8478ebbcd"
+              }
+            },
+            {
+              "x": 5,
+              "y": 27,
+              "width": 3,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/579f8e38-9b07-4c73-ae6c-db82b65ea4b2"
+              }
+            },
+            {
+              "x": 8,
+              "y": 27,
+              "width": 4,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/67a074ee-c46e-4a36-8f5c-10d981cae404"
+              }
+            },
+            {
+              "x": 0,
+              "y": 33,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/5e66cb8c-2219-47e6-ba71-8f82f9873bc8"
+              }
+            },
+            {
+              "x": 6,
+              "y": 33,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/05e6759b-c460-4618-86c0-5d2bf0b311c1"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "",
+    "refreshInterval": "",
+    "links": []
+  },
+  "tags": [],
+  "image": "/assets/Icons/eight-ball"
+}

--- a/pydantic-ai/pydantic-dashboard.json
+++ b/pydantic-ai/pydantic-dashboard.json
@@ -1,1 +1,1300 @@
-{"description":"","image":"data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE0Ljk0OTQgMTMuOTQyQzE2LjIzMTggMTIuNDI1OCAxNy4zMjY4IDkuNzAyMiAxNi4xOTU2IDYuNTc0ODdDMTUuNjQ0MyA1LjA1MjQ1IDE1LjAyMTkgNC4yMDI0OSAxNC4yOTY5IDMuNjYyNTJDMTMuODU1NyAzLjMzMzc5IDEyLjA5MzMgMi41MDYzMyA5Ljc1OTY1IDIuODY3NTZDOC4wNTM0OSAzLjEzMjU1IDUuNzc0ODcgNC4yMDg3NCA0LjI5MzY5IDUuOTU5OUMyLjg1NzUyIDcuNjYxMDYgMS43NDg4MyA5LjAwNDc0IDEuNjk3NTggMTAuMzA5N0MxLjYzMTMzIDExLjk4ODMgMi44OTYyNyAxMy40MzA4IDMuMDUwMDEgMTMuNjY0NUMzLjMyMzc0IDE0LjA3OTUgNS4xOTExNSAxNi40NTE4IDguNjk5NzEgMTYuNTczMUMxMS43OTcgMTYuNjc5MyAxMy44MTQ0IDE1LjI4NDQgMTQuOTQ5NCAxMy45NDJaIiBmaWxsPSIjNDAzRDNFIi8+CjxwYXRoIGQ9Ik00LjU1MzYzIDIuNzM3NDdDMi45Mzc0NiAzLjg5MTE2IDEuMTIxMzEgNi4yNTEwMyAxLjQ0NzU0IDkuNTYwODZDMS42MDYyOCAxMS4xNzIgMi4wMDI1MSAxMi4xNDk1IDIuNTcxMjMgMTIuODUwN0MyLjkxNzQ2IDEzLjI3ODIgNC40MTk4OCAxNC41NDkzIDYuNzczNTEgMTQuNzM2OEM5LjE0NTg4IDE0LjkyNTYgMTAuOTQ5NSAxNC4zOTQ0IDEyLjgzMzIgMTMuMDg0NEMxNi42NjE3IDEwLjQyMDggMTYuMDk4IDYuMzkzNTMgMTUuOTM0MyA1LjkyNDhDMTUuNzcwNSA1LjQ1NjA3IDE0LjU0NDQgMi42OTYyMiAxMS4xNzMzIDEuNzE1MDJDOC4xOTg0NCAwLjg1MDA2OCA1Ljk4MzU1IDEuNzE1MDIgNC41NTM2MyAyLjczNzQ3WiIgZmlsbD0iIzVFNjM2NyIvPgo8cGF0aCBkPSJNNy4zOTM1MyAyLjk2MTA5QzUuNjE3MzcgMi44OTczNCAzLjkxOTk2IDQuMjg4NTIgMy43NTYyMiA2LjAwNTkzQzMuNTkyNDggNy43MjIwOSA0LjY1NDkyIDkuMDI5NTIgNi4zMDk4MyA5LjI5NTc2QzcuOTY0NzUgOS41NjA3NCA5Ljg3ODM5IDguNTU1OCAxMC4yNjM0IDYuNDUwOTFDMTAuNjYwOSA0LjI4MjI3IDkuMDg5NjkgMy4wMjIzNCA3LjM5MzUzIDIuOTYxMDlaIiBmaWxsPSJ3aGl0ZSIvPgo8cGF0aCBkPSJNNy45NDIxNyA1LjkwMTE1QzcuOTQyMTcgNS45MDExNSA4LjM2OTY1IDUuODEyNCA4LjQ1NDY1IDUuMTgyNDRDOC41MzgzOSA0LjU2MjQ3IDguMjMwOTEgNC4wMzM3NSA3LjUxMzQ1IDMuODQzNzZDNi43MzM0OSAzLjYzNzUyIDYuMjA0NzcgNC4wNjYyNSA2LjA2NzI3IDQuNTE3NDdDNS44NzYwMyA1LjE0NDk0IDYuMTU4NTIgNS40NDM2NyA2LjE1ODUyIDUuNDQzNjdDNi4xNTg1MiA1LjQ0MzY3IDUuMzkzNTYgNS42Mjc0MSA1LjMzMjMxIDYuNTI5ODdDNS4yNzQ4MSA3LjM4MTA3IDUuODU2MDMgNy44Mzg1NSA2LjQzOTc1IDcuOTc4NTRDNy4xNjA5NiA4LjE1MjI4IDcuOTc4NDIgNy45NTQ3OSA4LjE3ODQxIDcuMDM0ODRDOC4zNDQ2NSA2LjI3NzM4IDcuOTQyMTcgNS45MDExNSA3Ljk0MjE3IDUuOTAxMTVaIiBmaWxsPSIjMzAzMDMwIi8+CjxwYXRoIGQ9Ik02LjczOTgzIDQuNzUzNjJDNi42NzEwOSA1LjAxMjM1IDYuODA4NTggNS4yNjIzNCA3LjA3ODU3IDUuMzMxMDlDNy4zNjk4IDUuNDA0ODMgNy42MzQ3OSA1LjMwODU5IDcuNzA2MDMgNS4wMTExQzcuNzY4NTMgNC43NDczNyA3LjY0MzU0IDQuNTE0ODggNy4zMzYwNSA0LjQzOTg4QzcuMDgzNTcgNC4zNzczOSA2LjgxNDgzIDQuNDcxMTMgNi43Mzk4MyA0Ljc1MzYyWiIgZmlsbD0id2hpdGUiLz4KPHBhdGggZD0iTTYuOTU5NzggNi4wMzk3NEM2LjYzMjMgNS45Mzg0OSA2LjE5OTgyIDYuMDY0NzMgNi4xMzEwNyA2LjUwNDcxQzYuMDYyMzMgNi45NDQ2OSA2LjMyNjA2IDcuMTY5NjggNi42NzEwNCA3LjIzMjE3QzcuMDE2MDMgNy4yOTQ2NyA3LjM0MjI2IDcuMTEzNDMgNy40MDYwMSA2Ljc2MDk1QzcuNDY4NSA2LjQwOTcyIDcuMjg2MDEgNi4xMzk3MyA2Ljk1OTc4IDYuMDM5NzRaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K","layout":[{"h":3,"i":"04247ee1-b408-457d-ac00-47ce45e64291","moved":false,"static":false,"w":3,"x":0,"y":0},{"h":3,"i":"d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570","moved":false,"static":false,"w":3,"x":3,"y":0},{"h":3,"i":"799913e6-fb95-497e-858a-6490b5f9d10d","moved":false,"static":false,"w":3,"x":6,"y":0},{"h":5,"i":"3633c7ad-203a-4e25-99f4-8cc81bf15d65","moved":false,"static":false,"w":3,"x":9,"y":0},{"h":1,"i":"__dropping-elem__","isDraggable":true,"moved":false,"static":false,"w":1,"x":1,"y":3},{"h":1,"i":"__dropping-elem__","isDraggable":true,"moved":false,"static":false,"w":1,"x":1,"y":3},{"h":1,"i":"__dropping-elem__","isDraggable":true,"moved":false,"static":false,"w":1,"x":1,"y":3},{"h":5,"i":"af79b14b-5e76-47fb-a24e-a4629c642c28","moved":false,"static":false,"w":4,"x":4,"y":3},{"h":5,"i":"28bb5d45-046d-4980-ad5e-26b1aeecda2b","moved":false,"static":false,"w":4,"x":0,"y":4},{"h":3,"i":"67a074ee-c46e-4a36-8f5c-10d981cae404","moved":false,"static":false,"w":6,"x":5,"y":8},{"h":5,"i":"74a94376-eeaf-43c1-a273-5d8b98197138","moved":false,"static":false,"w":5,"x":0,"y":9},{"h":6,"i":"5e66cb8c-2219-47e6-ba71-8f82f9873bc8","moved":false,"static":false,"w":7,"x":5,"y":11},{"h":4,"i":"bc6e3017-2b44-4152-a0d7-fe11e6b7a290","moved":false,"static":false,"w":5,"x":0,"y":14},{"h":4,"i":"1439219a-7067-4f3b-9308-1c405844cdab","moved":false,"static":false,"w":6,"x":6,"y":17},{"h":5,"i":"05e6759b-c460-4618-86c0-5d2bf0b311c1","moved":false,"static":false,"w":6,"x":0,"y":18},{"h":3,"i":"68d3a601-afac-4c63-b212-61667e0f9d70","moved":false,"static":false,"w":6,"x":6,"y":21}],"panelMap":{},"tags":[],"title":"Pydantic","uploadedGrafana":false,"uuid":"0199e900-cc5c-7e8a-8f00-071f36e10895","variables":{"10d0eca9-9253-4583-821c-d3c812d78151":{"allSelected":false,"customValue":"","defaultValue":"","description":"The service name using Anthropic API","dynamicVariablesAttribute":"service.name","dynamicVariablesSource":"All telemetry","haveCustomValuesSelected":false,"id":"10d0eca9-9253-4583-821c-d3c812d78151","key":"10d0eca9-9253-4583-821c-d3c812d78151","modificationUUID":"735355f5-c4c7-4969-ad30-eee98eeb36b8","multiSelect":true,"name":"service_name","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"1b049274-93ae-4bdd-95d4-1838abe22c30":{"allSelected":true,"customValue":"","defaultValue":"","description":"Name of agent being used","dynamicVariablesAttribute":"agent_name","dynamicVariablesSource":"All telemetry","id":"1b049274-93ae-4bdd-95d4-1838abe22c30","modificationUUID":"b91a50d2-04a0-4231-84a3-595ba15db739","multiSelect":true,"name":"agent_name","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"be7a68c4-fb97-43ea-bb94-0ded120bd3d7":{"allSelected":true,"customValue":"","defaultValue":"","description":"Model name being used in Anthropic API call","dynamicVariablesAttribute":"model_name","dynamicVariablesSource":"All telemetry","id":"be7a68c4-fb97-43ea-bb94-0ded120bd3d7","key":"be7a68c4-fb97-43ea-bb94-0ded120bd3d7","modificationUUID":"dfc5997d-c6a7-446c-a6ec-41cb59114a90","multiSelect":true,"name":"llm_model","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"}},"version":"v5","widgets":[{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"04247ee1-b408-457d-ac00-47ce45e64291","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.input_tokens) ) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name model_name in $llm_model agent_name in $agent_name"},"filters":{"items":[{"id":"484085d4-2edd-402b-80f5-db8bf05d9428","key":{"dataType":"string","id":"agent_name--string--","key":"agent_name","type":""},"op":"IN","value":"$agent_name"},{"id":"a19a1c35-d3ce-4051-be9a-9d4121f53a02","key":{"id":"service.name","key":"service.name","type":""},"op":"in","value":["$service_name"]},{"id":"c07aba2e-23ae-489d-a26a-67addb945e5d","key":{"id":"model_name","key":"model_name","type":""},"op":"in","value":["$llm_model"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"8c0c1867-8732-45c2-961c-5ddcccafe221","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Input Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.output_tokens) ) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name model_name in $llm_model agent_name in $agent_name"},"filters":{"items":[{"id":"484085d4-2edd-402b-80f5-db8bf05d9428","key":{"dataType":"string","id":"agent_name--string--","key":"agent_name","type":""},"op":"IN","value":"$agent_name"},{"id":"aa7736f9-2c2f-4bdb-9297-3bad94c8ba8f","key":{"id":"service.name","key":"service.name","type":""},"op":"in","value":["$service_name"]},{"id":"3cd23164-56fb-452a-a135-5031f36da4d1","key":{"id":"model_name","key":"model_name","type":""},"op":"in","value":["$llm_model"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"5b4e4b8c-6878-4487-b010-67eacd372079","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Output Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"799913e6-fb95-497e-858a-6490b5f9d10d","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"A","filter":{"expression":"has_error = 'true' service.name in $service_name agent_name in $agent_name"},"filters":{"items":[{"id":"484085d4-2edd-402b-80f5-db8bf05d9428","key":{"dataType":"string","id":"agent_name--string--","key":"agent_name","type":""},"op":"IN","value":"$agent_name"},{"id":"8117d482-77e5-46e3-81f4-679a6945fb30","key":{"id":"has_error","key":"has_error","type":""},"op":"=","value":"true"},{"id":"d82dd153-bfe5-4898-a2e2-14a4a32687fe","key":{"id":"service.name","key":"service.name","type":""},"op":"in","value":["$service_name"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null},{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"B","filter":{"expression":"has_error = 'false' service.name in $service_name agent_name in $agent_name"},"filters":{"items":[{"id":"484085d4-2edd-402b-80f5-db8bf05d9428","key":{"dataType":"string","id":"agent_name--string--","key":"agent_name","type":""},"op":"IN","value":"$agent_name"},{"id":"23e8e5ac-0ef4-4a44-b0ab-f189b791b91a","key":{"id":"has_error","key":"has_error","type":""},"op":"=","value":"false"},{"id":"76b4cbec-a212-4c7d-8c6a-e625f5e92945","key":{"id":"service.name","key":"service.name","type":""},"op":"in","value":["$service_name"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"B","source":"","stepInterval":null}],"queryFormulas":[{"disabled":false,"expression":"A / (A+B)","legend":"","queryName":"F1"}],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"1f523f71-e388-4789-8d92-65075bffd256","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[{"index":"e5e05d41-7479-4d60-a1cf-c433b8b61285","isEditEnabled":false,"keyIndex":1,"selectedGraph":"value","thresholdColor":"Red","thresholdFormat":"Text","thresholdLabel":"","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"percentunit","thresholdValue":10},{"index":"d74bf17b-552a-4636-8fad-c976b090d590","isEditEnabled":false,"keyIndex":0,"selectedGraph":"value","thresholdColor":"Orange","thresholdFormat":"Text","thresholdLabel":"","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"percentunit","thresholdValue":5}],"timePreferance":"GLOBAL_TIME","title":"Error Rate","yAxisUnit":"percentunit"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"3633c7ad-203a-4e25-99f4-8cc81bf15d65","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name model_name EXISTS"},"functions":[],"groupBy":[{"dataType":"","id":"model_name----","key":"model_name","type":""}],"having":{"expression":""},"legend":"{{model_name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"58bce638-d12d-4d26-9b2a-b72a8ef7c6cf","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Model Distribution","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"F1":"#eccd03"},"description":"","fillSpans":false,"id":"28bb5d45-046d-4980-ad5e-26b1aeecda2b","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.input_tokens) ) ) ) )"}],"dataSource":"traces","disabled":true,"expression":"A","filter":{"expression":"service.name in $service_name model_name in $llm_model agent_name in $agent_name"},"filters":{"items":[{"id":"484085d4-2edd-402b-80f5-db8bf05d9428","key":{"dataType":"string","id":"agent_name--string--","key":"agent_name","type":""},"op":"IN","value":"$agent_name"},{"id":"b69c8499-c09f-4d43-9bf4-3c5078d0c603","key":{"id":"service.name","key":"service.name","type":""},"op":"in","value":["$service_name"]},{"id":"136503f4-029c-4612-b762-065a7e5a12a1","key":{"id":"model_name","key":"model_name","type":""},"op":"in","value":["$llm_model"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null},{"aggregations":[{"expression":"sum(ai.usage.outputTokens) )"}],"dataSource":"traces","disabled":true,"expression":"B","filter":{"expression":"service.name in $service_name model_name in $llm_model agent_name in $agent_name"},"filters":{"items":[{"id":"484085d4-2edd-402b-80f5-db8bf05d9428","key":{"dataType":"string","id":"agent_name--string--","key":"agent_name","type":""},"op":"IN","value":"$agent_name"},{"id":"1aef95ef-3725-4de3-9a30-f85022926670","key":{"id":"service.name","key":"service.name","type":""},"op":"in","value":["$service_name"]},{"id":"196f014b-e05f-4b4c-a2f7-07eacd0a0427","key":{"id":"model_name","key":"model_name","type":""},"op":"in","value":["$llm_model"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"B","source":"","stepInterval":null}],"queryFormulas":[{"disabled":false,"expression":"A + B","legend":"","queryName":"F1"}],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"fb321ad8-d654-4dc3-87b5-932c29e383f3","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Token Usage","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"af79b14b-5e76-47fb-a24e-a4629c642c28","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"p95(duration_nano) "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name model_name in $llm_model agent_name in $agent_name"},"filters":{"items":[{"id":"484085d4-2edd-402b-80f5-db8bf05d9428","key":{"dataType":"string","id":"agent_name--string--","key":"agent_name","type":""},"op":"IN","value":"$agent_name"},{"id":"bfe03b3d-822d-4fa1-a155-5231224197a6","key":{"id":"service.name","key":"service.name","type":""},"op":"in","value":["$service_name"]},{"id":"bf2ef6dd-a342-4f9c-85e7-9779ee403b78","key":{"id":"model_name","key":"model_name","type":""},"op":"in","value":["$llm_model"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"533b7dd7-d082-41e1-9da1-53746fddad77","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Latency (P95)","yAxisUnit":"ns"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"A":"#edce64","count()":"#a403ff"},"description":"","fillSpans":false,"id":"74a94376-eeaf-43c1-a273-5d8b98197138","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name model_name in $llm_model agent_name in $agent_name"},"filters":{"items":[{"id":"484085d4-2edd-402b-80f5-db8bf05d9428","key":{"dataType":"string","id":"agent_name--string--","key":"agent_name","type":""},"op":"IN","value":"$agent_name"},{"id":"1f83e12e-6c17-4821-a34b-4d68279e75f9","key":{"id":"service.name","key":"service.name","type":""},"op":"in","value":["$service_name"]},{"id":"b4fce3a2-d62b-4fc3-b0ba-fb1818f173bc","key":{"id":"model_name","key":"model_name","type":""},"op":"in","value":["$llm_model"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"fd2c3953-e67e-409b-ad07-d54445f15c4d","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Number of Requests","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"date":145,"duration_nano":145,"http_method":145,"name":145,"response_status_code":145,"service.name":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"5e66cb8c-2219-47e6-ba71-8f82f9873bc8","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"has_error = true service.name IN $service_name"},"filters":{"items":[],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"}],"pageSize":10,"queryName":"A","selectColumns":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"b85f93b2-09b5-4fcd-8aa8-f6a2875a41b5","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Errors","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A":""},"columnWidths":{"A":145,"service.name":145,"telemetry.sdk.language":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"67a074ee-c46e-4a36-8f5c-10d981cae404","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() as 'Count of Spans' "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name = $service_name  AND telemetry.sdk.language EXISTS"},"filters":{"items":[],"op":"AND"},"functions":[],"groupBy":[{"dataType":"string","id":"service.name--string--resource","isColumn":true,"isJSON":false,"key":"service.name","type":"resource"},{"dataType":"string","id":"telemetry.sdk.language--string--resource","isColumn":false,"isJSON":false,"key":"telemetry.sdk.language","type":"resource"}],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"33cb8bea-966e-45cb-926f-6e722fef9ab7","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Services and Languages","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"A":"#5eddce"},"description":"","fillSpans":false,"id":"bc6e3017-2b44-4152-a0d7-fe11e6b7a290","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"metricName":"http.client.duration.max","reduceTo":"avg","spaceAggregation":"avg","temporality":"","timeAggregation":"avg"}],"dataSource":"metrics","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name"},"filters":{"items":[],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"5a8ddb76-cef4-4ea4-9185-1b8331ef3b5b","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"HTTP Request Duration","yAxisUnit":"ms"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"body":350,"timestamp":100},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"05e6759b-c460-4618-86c0-5d2bf0b311c1","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"logs","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name"},"filters":{"items":[],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"},{"columnName":"id","order":"desc"}],"pageSize":10,"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"d0c96eea-6c4d-4c46-92a1-9a9e2b1af925","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"API Requests","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A":""},"columnWidths":{"A":145,"gen_ai.agent.name":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"1439219a-7067-4f3b-9308-1c405844cdab","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name gen_ai.agent.name EXISTS"},"functions":[],"groupBy":[{"dataType":"string","id":"gen_ai.agent.name--string--tag","isColumn":false,"isJSON":false,"key":"gen_ai.agent.name","type":"tag"}],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"0399e928-5bbc-43a2-8f1a-14498c0d839a","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Agents","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A":""},"columnWidths":{"A":145,"gen_ai.tool.name":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"68d3a601-afac-4c63-b212-61667e0f9d70","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name gen_ai.tool.name EXISTS "},"functions":[],"groupBy":[{"dataType":"string","id":"gen_ai.tool.name--string--tag","isColumn":false,"isJSON":false,"key":"gen_ai.tool.name","type":"tag"}],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"1c6e09e0-30c6-4d27-81df-e432354d9999","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Tools","yAxisUnit":"none"}]}
+{
+  "spec": {
+    "display": {
+      "name": "Pydantic",
+      "description": ""
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "service_name",
+            "description": "The service name using Anthropic API"
+          },
+          "defaultValue": [
+            "pydantic-otel",
+            "pydantic-support-agent",
+            "pydantic-data-extractor"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "service.name",
+              "signal": "all"
+            }
+          },
+          "name": "service_name"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "agent_name",
+            "description": "Name of agent being used"
+          },
+          "defaultValue": [
+            "roulette_agent",
+            "support_agent",
+            "triage_agent",
+            "extraction_agent"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "agent_name",
+              "signal": "all"
+            }
+          },
+          "name": "agent_name"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "llm_model",
+            "description": "Model name being used in Anthropic API call"
+          },
+          "defaultValue": [
+            "openai:gpt-4.1-mini",
+            "openai:gpt-4.1",
+            "anthropic:claude-sonnet-5",
+            "google-gla:gemini-2.5-flash"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "model_name",
+              "signal": "all"
+            }
+          },
+          "name": "llm_model"
+        }
+      }
+    ],
+    "panels": {
+      "04247ee1-b408-457d-ac00-47ce45e64291": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Input Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(gen_ai.usage.input_tokens)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name model_name in $llm_model agent_name in $agent_name"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "05e6759b-c460-4618-86c0-5d2bf0b311c1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "API Requests",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "timestamp",
+                  "signal": "logs",
+                  "fieldContext": "log",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "body",
+                  "signal": "logs",
+                  "fieldContext": "log",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "logs",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "1439219a-7067-4f3b-9308-1c405844cdab": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Agents",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A": ""
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name gen_ai.agent.name EXISTS"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "gen_ai.agent.name",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "28bb5d45-046d-4980-ad5e-26b1aeecda2b": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Token Usage",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "pydantic-data-extractor": "#C230E8",
+                  "pydantic-otel": "#E5A35D",
+                  "pydantic-support-agent": "#8BE4A0"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "sum(gen_ai.usage.input_tokens)"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "service.name in $service_name model_name in $llm_model agent_name in $agent_name"
+                          },
+                          "groupBy": [
+                            {
+                              "name": "service.name",
+                              "signal": "",
+                              "fieldContext": "resource",
+                              "fieldDataType": "string"
+                            }
+                          ],
+                          "order": null,
+                          "selectFields": null,
+                          "secondaryAggregations": null,
+                          "functions": null,
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "sum(gen_ai.usage.output_tokens)"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "service.name in $service_name model_name in $llm_model agent_name in $agent_name"
+                          },
+                          "groupBy": [
+                            {
+                              "name": "service.name",
+                              "signal": "",
+                              "fieldContext": "resource",
+                              "fieldDataType": "string"
+                            }
+                          ],
+                          "order": null,
+                          "selectFields": null,
+                          "secondaryAggregations": null,
+                          "functions": null,
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "A + B",
+                          "disabled": false,
+                          "order": null,
+                          "functions": null,
+                          "legend": "{{service.name}}"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "3633c7ad-203a-4e25-99f4-8cc81bf15d65": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Model Distribution",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "anthropic:claude-sonnet-5": "#E83032",
+                  "google-gla:gemini-2.5-flash": "#5DE583",
+                  "openai:gpt-4.1": "#8BA6E4",
+                  "openai:gpt-4.1-mini": "#ADE55D"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name model_name EXISTS"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "model_name",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{model_name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "5e66cb8c-2219-47e6-ba71-8f82f9873bc8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Errors",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "service.name",
+                  "signal": "traces",
+                  "fieldContext": "resource",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "name",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "duration_nano",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "http_method",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "response_status_code",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "has_error = true service.name IN $service_name"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "name",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "duration_nano",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "http_method",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "response_status_code",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      }
+                    ],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "67a074ee-c46e-4a36-8f5c-10d981cae404": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Services and Languages",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A": ""
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()",
+                        "alias": "Count of Spans"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name = $service_name  AND telemetry.sdk.language EXISTS"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "telemetry.sdk.language",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "68d3a601-afac-4c63-b212-61667e0f9d70": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Tools",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A": ""
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name gen_ai.tool.name EXISTS "
+                    },
+                    "groupBy": [
+                      {
+                        "name": "gen_ai.tool.name",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "74a94376-eeaf-43c1-a273-5d8b98197138": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Number of Requests",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "pydantic-data-extractor": "#E830D3",
+                  "pydantic-otel": "#E5A55D",
+                  "pydantic-support-agent": "#8BE4D4"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name model_name in $llm_model agent_name in $agent_name"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "799913e6-fb95-497e-858a-6490b5f9d10d": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Error Rate",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "percentunit",
+                "decimalPrecision": "2"
+              },
+              "thresholds": [
+                {
+                  "value": 0.1,
+                  "operator": "above",
+                  "unit": "percentunit",
+                  "color": "Red",
+                  "format": "text"
+                },
+                {
+                  "value": 0.05,
+                  "operator": "above",
+                  "unit": "percentunit",
+                  "color": "Orange",
+                  "format": "text"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "has_error = 'true' service.name in $service_name agent_name in $agent_name"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "has_error = 'false' service.name in $service_name agent_name in $agent_name"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "A / (A+B)",
+                          "disabled": false,
+                          "order": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "functions": null,
+                          "legend": ""
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "af79b14b-5e76-47fb-a24e-a4629c642c28": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Latency (P95)",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ns",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "pydantic-data-extractor": "#E830D3",
+                  "pydantic-otel": "#E5A55D",
+                  "pydantic-support-agent": "#8BE4D4"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "p95(duration_nano)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name model_name in $llm_model agent_name in $agent_name"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "bc6e3017-2b44-4152-a0d7-fe11e6b7a290": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "HTTP Request Duration",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ms",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "pydantic-data-extractor": "#E830D3",
+                  "pydantic-otel": "#E5A55D",
+                  "pydantic-support-agent": "#8BE4D4"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "metrics",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "metricName": "http.client.duration.max",
+                        "temporality": "",
+                        "timeAggregation": "avg",
+                        "spaceAggregation": "avg",
+                        "reduceTo": "avg"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Output Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(gen_ai.usage.output_tokens)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name model_name in $llm_model agent_name in $agent_name"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/04247ee1-b408-457d-ac00-47ce45e64291"
+              }
+            },
+            {
+              "x": 4,
+              "y": 0,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570"
+              }
+            },
+            {
+              "x": 8,
+              "y": 0,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/799913e6-fb95-497e-858a-6490b5f9d10d"
+              }
+            },
+            {
+              "x": 0,
+              "y": 3,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/74a94376-eeaf-43c1-a273-5d8b98197138"
+              }
+            },
+            {
+              "x": 6,
+              "y": 3,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/af79b14b-5e76-47fb-a24e-a4629c642c28"
+              }
+            },
+            {
+              "x": 0,
+              "y": 9,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/28bb5d45-046d-4980-ad5e-26b1aeecda2b"
+              }
+            },
+            {
+              "x": 6,
+              "y": 9,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/bc6e3017-2b44-4152-a0d7-fe11e6b7a290"
+              }
+            },
+            {
+              "x": 0,
+              "y": 15,
+              "width": 3,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/3633c7ad-203a-4e25-99f4-8cc81bf15d65"
+              }
+            },
+            {
+              "x": 3,
+              "y": 15,
+              "width": 3,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/1439219a-7067-4f3b-9308-1c405844cdab"
+              }
+            },
+            {
+              "x": 6,
+              "y": 15,
+              "width": 3,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/68d3a601-afac-4c63-b212-61667e0f9d70"
+              }
+            },
+            {
+              "x": 9,
+              "y": 15,
+              "width": 3,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/67a074ee-c46e-4a36-8f5c-10d981cae404"
+              }
+            },
+            {
+              "x": 0,
+              "y": 21,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/5e66cb8c-2219-47e6-ba71-8f82f9873bc8"
+              }
+            },
+            {
+              "x": 6,
+              "y": 21,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/05e6759b-c460-4618-86c0-5d2bf0b311c1"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "",
+    "refreshInterval": "",
+    "links": []
+  },
+  "tags": [],
+  "image": "/assets/Icons/eight-ball"
+}

--- a/semantic-kernel/semantic-kernel-dashboard.json
+++ b/semantic-kernel/semantic-kernel-dashboard.json
@@ -1,1 +1,1230 @@
-{"description":"","image":"data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE0Ljk0OTQgMTMuOTQyQzE2LjIzMTggMTIuNDI1OCAxNy4zMjY4IDkuNzAyMiAxNi4xOTU2IDYuNTc0ODdDMTUuNjQ0MyA1LjA1MjQ1IDE1LjAyMTkgNC4yMDI0OSAxNC4yOTY5IDMuNjYyNTJDMTMuODU1NyAzLjMzMzc5IDEyLjA5MzMgMi41MDYzMyA5Ljc1OTY1IDIuODY3NTZDOC4wNTM0OSAzLjEzMjU1IDUuNzc0ODcgNC4yMDg3NCA0LjI5MzY5IDUuOTU5OUMyLjg1NzUyIDcuNjYxMDYgMS43NDg4MyA5LjAwNDc0IDEuNjk3NTggMTAuMzA5N0MxLjYzMTMzIDExLjk4ODMgMi44OTYyNyAxMy40MzA4IDMuMDUwMDEgMTMuNjY0NUMzLjMyMzc0IDE0LjA3OTUgNS4xOTExNSAxNi40NTE4IDguNjk5NzEgMTYuNTczMUMxMS43OTcgMTYuNjc5MyAxMy44MTQ0IDE1LjI4NDQgMTQuOTQ5NCAxMy45NDJaIiBmaWxsPSIjNDAzRDNFIi8+CjxwYXRoIGQ9Ik00LjU1MzYzIDIuNzM3NDdDMi45Mzc0NiAzLjg5MTE2IDEuMTIxMzEgNi4yNTEwMyAxLjQ0NzU0IDkuNTYwODZDMS42MDYyOCAxMS4xNzIgMi4wMDI1MSAxMi4xNDk1IDIuNTcxMjMgMTIuODUwN0MyLjkxNzQ2IDEzLjI3ODIgNC40MTk4OCAxNC41NDkzIDYuNzczNTEgMTQuNzM2OEM5LjE0NTg4IDE0LjkyNTYgMTAuOTQ5NSAxNC4zOTQ0IDEyLjgzMzIgMTMuMDg0NEMxNi42NjE3IDEwLjQyMDggMTYuMDk4IDYuMzkzNTMgMTUuOTM0MyA1LjkyNDhDMTUuNzcwNSA1LjQ1NjA3IDE0LjU0NDQgMi42OTYyMiAxMS4xNzMzIDEuNzE1MDJDOC4xOTg0NCAwLjg1MDA2OCA1Ljk4MzU1IDEuNzE1MDIgNC41NTM2MyAyLjczNzQ3WiIgZmlsbD0iIzVFNjM2NyIvPgo8cGF0aCBkPSJNNy4zOTM1MyAyLjk2MTA5QzUuNjE3MzcgMi44OTczNCAzLjkxOTk2IDQuMjg4NTIgMy43NTYyMiA2LjAwNTkzQzMuNTkyNDggNy43MjIwOSA0LjY1NDkyIDkuMDI5NTIgNi4zMDk4MyA5LjI5NTc2QzcuOTY0NzUgOS41NjA3NCA5Ljg3ODM5IDguNTU1OCAxMC4yNjM0IDYuNDUwOTFDMTAuNjYwOSA0LjI4MjI3IDkuMDg5NjkgMy4wMjIzNCA3LjM5MzUzIDIuOTYxMDlaIiBmaWxsPSJ3aGl0ZSIvPgo8cGF0aCBkPSJNNy45NDIxNyA1LjkwMTE1QzcuOTQyMTcgNS45MDExNSA4LjM2OTY1IDUuODEyNCA4LjQ1NDY1IDUuMTgyNDRDOC41MzgzOSA0LjU2MjQ3IDguMjMwOTEgNC4wMzM3NSA3LjUxMzQ1IDMuODQzNzZDNi43MzM0OSAzLjYzNzUyIDYuMjA0NzcgNC4wNjYyNSA2LjA2NzI3IDQuNTE3NDdDNS44NzYwMyA1LjE0NDk0IDYuMTU4NTIgNS40NDM2NyA2LjE1ODUyIDUuNDQzNjdDNi4xNTg1MiA1LjQ0MzY3IDUuMzkzNTYgNS42Mjc0MSA1LjMzMjMxIDYuNTI5ODdDNS4yNzQ4MSA3LjM4MTA3IDUuODU2MDMgNy44Mzg1NSA2LjQzOTc1IDcuOTc4NTRDNy4xNjA5NiA4LjE1MjI4IDcuOTc4NDIgNy45NTQ3OSA4LjE3ODQxIDcuMDM0ODRDOC4zNDQ2NSA2LjI3NzM4IDcuOTQyMTcgNS45MDExNSA3Ljk0MjE3IDUuOTAxMTVaIiBmaWxsPSIjMzAzMDMwIi8+CjxwYXRoIGQ9Ik02LjczOTgzIDQuNzUzNjJDNi42NzEwOSA1LjAxMjM1IDYuODA4NTggNS4yNjIzNCA3LjA3ODU3IDUuMzMxMDlDNy4zNjk4IDUuNDA0ODMgNy42MzQ3OSA1LjMwODU5IDcuNzA2MDMgNS4wMTExQzcuNzY4NTMgNC43NDczNyA3LjY0MzU0IDQuNTE0ODggNy4zMzYwNSA0LjQzOTg4QzcuMDgzNTcgNC4zNzczOSA2LjgxNDgzIDQuNDcxMTMgNi43Mzk4MyA0Ljc1MzYyWiIgZmlsbD0id2hpdGUiLz4KPHBhdGggZD0iTTYuOTU5NzggNi4wMzk3NEM2LjYzMjMgNS45Mzg0OSA2LjE5OTgyIDYuMDY0NzMgNi4xMzEwNyA2LjUwNDcxQzYuMDYyMzMgNi45NDQ2OSA2LjMyNjA2IDcuMTY5NjggNi42NzEwNCA3LjIzMjE3QzcuMDE2MDMgNy4yOTQ2NyA3LjM0MjI2IDcuMTEzNDMgNy40MDYwMSA2Ljc2MDk1QzcuNDY4NSA2LjQwOTcyIDcuMjg2MDEgNi4xMzk3MyA2Ljk1OTc4IDYuMDM5NzRaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K","layout":[{"h":3,"i":"04247ee1-b408-457d-ac00-47ce45e64291","moved":false,"static":false,"w":3,"x":0,"y":0},{"h":3,"i":"d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570","moved":false,"static":false,"w":3,"x":3,"y":0},{"h":3,"i":"799913e6-fb95-497e-858a-6490b5f9d10d","moved":false,"static":false,"w":3,"x":6,"y":0},{"h":8,"i":"3633c7ad-203a-4e25-99f4-8cc81bf15d65","moved":false,"static":false,"w":3,"x":9,"y":0},{"h":5,"i":"28bb5d45-046d-4980-ad5e-26b1aeecda2b","moved":false,"static":false,"w":4,"x":0,"y":3},{"h":5,"i":"af79b14b-5e76-47fb-a24e-a4629c642c28","moved":false,"static":false,"w":5,"x":4,"y":3},{"h":5,"i":"74a94376-eeaf-43c1-a273-5d8b98197138","moved":false,"static":false,"w":5,"x":0,"y":8},{"h":3,"i":"67a074ee-c46e-4a36-8f5c-10d981cae404","moved":false,"static":false,"w":6,"x":5,"y":8},{"h":4,"i":"389d43de-99b1-4c35-9589-f7d969abaa9d","moved":false,"static":false,"w":6,"x":5,"y":11},{"h":4,"i":"bc6e3017-2b44-4152-a0d7-fe11e6b7a290","moved":false,"static":false,"w":5,"x":0,"y":13},{"h":5,"i":"5e66cb8c-2219-47e6-ba71-8f82f9873bc8","moved":false,"static":false,"w":5,"x":6,"y":15},{"h":5,"i":"05e6759b-c460-4618-86c0-5d2bf0b311c1","moved":false,"static":false,"w":6,"x":0,"y":17},{"h":1,"i":"__dropping-elem__","isDraggable":true,"moved":false,"static":false,"w":1,"x":10,"y":20}],"panelMap":{},"tags":[],"title":"Semantic Kernel","uploadedGrafana":false,"uuid":"019a9804-6386-7863-b78b-cb7102a953ea","variables":{"10d0eca9-9253-4583-821c-d3c812d78151":{"allSelected":false,"customValue":"","defaultValue":"","description":"The service name using Semantic Kernel","dynamicVariablesAttribute":"service.name","dynamicVariablesSource":"All telemetry","id":"10d0eca9-9253-4583-821c-d3c812d78151","key":"10d0eca9-9253-4583-821c-d3c812d78151","modificationUUID":"d7fc311f-5538-48c8-bc4d-b801ec008cfb","multiSelect":true,"name":"service_name","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"93c33118-5f46-404b-b45e-8a81160c44c4":{"allSelected":true,"customValue":"","defaultValue":"","description":"Language being used for making Semantic Kernel calls","dynamicVariablesAttribute":"telemetry.sdk.language","dynamicVariablesSource":"All telemetry","id":"93c33118-5f46-404b-b45e-8a81160c44c4","key":"93c33118-5f46-404b-b45e-8a81160c44c4","modificationUUID":"d6e8d784-8471-40ef-81c5-33b3c6eb0a92","multiSelect":true,"name":"language","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"be7a68c4-fb97-43ea-bb94-0ded120bd3d7":{"allSelected":true,"customValue":"","defaultValue":"","description":"Model name being used in semantic kernel call","dynamicVariablesAttribute":"gen_ai.request.model","dynamicVariablesSource":"All telemetry","haveCustomValuesSelected":false,"id":"be7a68c4-fb97-43ea-bb94-0ded120bd3d7","modificationUUID":"7f7cbb3b-0924-412f-ae97-889931a15413","multiSelect":true,"name":"llm_model","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"}},"version":"v5","widgets":[{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"04247ee1-b408-457d-ac00-47ce45e64291","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.input_tokens) ) ) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"},"filters":{"items":[{"id":"45f6077f-8492-46fe-b146-4a31f92cd1bd","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"f81583d1-1363-4076-a133-17ae0e711efc","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]},{"id":"f09411f5-1983-406d-94bb-173f237e0b3d","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"in","value":["$llm_model"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"72eb2c4e-43e5-4b30-8138-490a9d16f1cf","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Input Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.output_tokens) ) ) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"},"filters":{"items":[{"id":"45f6077f-8492-46fe-b146-4a31f92cd1bd","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"78b1839d-6bf2-4df9-a688-08ec2fae3d2d","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]},{"id":"2f42d415-41bd-4af0-ba82-975c8376b822","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"in","value":["$llm_model"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"54e5b532-a35e-4bff-bac8-43a39c0be598","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Output Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"799913e6-fb95-497e-858a-6490b5f9d10d","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"A","filter":{"expression":"has_error = 'true' service.name in $service_name"},"filters":{"items":[{"id":"45f6077f-8492-46fe-b146-4a31f92cd1bd","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"1426bee0-f647-4d48-be3d-8d0862722f92","key":{"id":"has_error","key":"has_error","type":""},"op":"=","value":"true"}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null},{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"B","filter":{"expression":"has_error = 'false' service.name in $service_name"},"filters":{"items":[{"id":"45f6077f-8492-46fe-b146-4a31f92cd1bd","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"c3bd2eb4-ee27-4e25-81a3-218260a30494","key":{"id":"has_error","key":"has_error","type":""},"op":"=","value":"false"}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"B","source":"","stepInterval":null}],"queryFormulas":[{"disabled":false,"expression":"A / (A+B)","legend":"","queryName":"F1"}],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"06db8fa1-2559-4a1e-ae05-19f94089cb58","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[{"index":"e5e05d41-7479-4d60-a1cf-c433b8b61285","isEditEnabled":false,"keyIndex":1,"selectedGraph":"value","thresholdColor":"Red","thresholdFormat":"Text","thresholdLabel":"","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"percentunit","thresholdValue":10},{"index":"d74bf17b-552a-4636-8fad-c976b090d590","isEditEnabled":false,"keyIndex":0,"selectedGraph":"value","thresholdColor":"Orange","thresholdFormat":"Text","thresholdLabel":"","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"percentunit","thresholdValue":5}],"timePreferance":"GLOBAL_TIME","title":"Error Rate","yAxisUnit":"percentunit"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"3633c7ad-203a-4e25-99f4-8cc81bf15d65","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND gen_ai.request.model EXISTS"},"filters":{"items":[{"id":"14ee9f15-cd4f-453a-bc1f-90aa6c67ed49","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"dfad00b3-bdbc-4aa2-8de3-6fd704a859c7","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"exists","value":"undefined"}],"op":"AND"},"functions":[],"groupBy":[{"dataType":"string","id":"gen_ai.request.model--string--tag","isColumn":false,"isJSON":false,"key":"gen_ai.request.model","type":"tag"}],"having":{"expression":""},"legend":"{{gen_ai.request.model}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"d1ad853e-2d10-4b75-be1c-ef355ddf3222","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Model Distribution","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"F1":"#eccd03"},"decimalPrecision":2,"description":"","fillSpans":false,"id":"28bb5d45-046d-4980-ad5e-26b1aeecda2b","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(gen_ai.usage.input_tokens)"}],"dataSource":"traces","disabled":true,"expression":"A","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"},"filters":{"items":[{"id":"45f6077f-8492-46fe-b146-4a31f92cd1bd","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"cb36b8d6-8f4c-4b7c-b6ab-f35b779cd4c2","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]},{"id":"51606b55-f80d-434f-ba56-e3d0131489f9","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"in","value":["$llm_model"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null},{"aggregations":[{"expression":"sum(gen_ai.usage.output_tokens) ) "}],"dataSource":"traces","disabled":true,"expression":"B","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"},"filters":{"items":[{"id":"45f6077f-8492-46fe-b146-4a31f92cd1bd","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"f16e7119-fa05-49c4-90e9-ef13bf68defe","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]},{"id":"4223618c-d0d7-42a8-8671-d333bcbe577e","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"in","value":["$llm_model"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"B","source":"","stepInterval":null}],"queryFormulas":[{"disabled":false,"expression":"A + B","legend":"","queryName":"F1"}],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"dd15b2a6-a09d-44a9-b5b5-f18f03a0da89","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Token Usage","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"af79b14b-5e76-47fb-a24e-a4629c642c28","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"p95(duration_nano) "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model "},"filters":{"items":[{"id":"45f6077f-8492-46fe-b146-4a31f92cd1bd","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"d688bb32-ed8b-4da1-95c7-9582d6104687","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]},{"id":"667a4f0c-cc17-4998-9121-38095df915f2","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"in","value":["$llm_model"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"031a4043-1558-402b-873a-35269a71dcd2","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Latency (P95)","yAxisUnit":"ns"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"A":"#edce64","count()":"#a403ff"},"decimalPrecision":2,"description":"","fillSpans":false,"id":"74a94376-eeaf-43c1-a273-5d8b98197138","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model gen_ai.operation.name EXISTS "},"filters":{"items":[{"id":"45f6077f-8492-46fe-b146-4a31f92cd1bd","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"c8d22c13-6ef7-4b69-8287-c78424e92e6c","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]},{"id":"057d6ef7-5704-40a2-8f0e-93745109bb67","key":{"id":"gen_ai.request.model","key":"gen_ai.request.model","type":""},"op":"in","value":["$llm_model"]},{"id":"b8ec008f-1519-4ac7-a905-280991f1f9d8","key":{"id":"gen_ai.operation.name","key":"gen_ai.operation.name","type":""},"op":"exists","value":"undefined"}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"3112dc25-7a85-43cf-ac96-e9ecdf56ec48","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Number of Requests","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"date":145,"duration_nano":145,"http_method":145,"name":145,"response_status_code":145,"service.name":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"5e66cb8c-2219-47e6-ba71-8f82f9873bc8","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"has_error = 'true' service.name IN $service_name"},"filters":{"items":[{"id":"45f6077f-8492-46fe-b146-4a31f92cd1bd","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"cd7bce73-6b30-45bb-bd0a-0e93316a2ddd","key":{"id":"has_error","key":"has_error","type":""},"op":"=","value":"true"}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"}],"pageSize":10,"queryName":"A","selectColumns":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"b85f93b2-09b5-4fcd-8aa8-f6a2875a41b5","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Errors","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A":""},"columnWidths":{"A":145,"service.name":145,"telemetry.sdk.language":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"67a074ee-c46e-4a36-8f5c-10d981cae404","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() as 'Count of Calls' "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name AND gen_ai.operation.name = 'execute_tool'"},"filters":{"items":[{"id":"45f6077f-8492-46fe-b146-4a31f92cd1bd","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"7500fa01-5cc2-47bc-9364-ce83494fa88a","key":{"id":"gen_ai.operation.name","key":"gen_ai.operation.name","type":""},"op":"=","value":"execute_tool"}],"op":"AND"},"functions":[],"groupBy":[{"dataType":"string","id":"service.name--string--resource","isColumn":true,"isJSON":false,"key":"service.name","type":"resource"},{"dataType":"string","id":"telemetry.sdk.language--string--resource","isColumn":false,"isJSON":false,"key":"telemetry.sdk.language","type":"resource"}],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"61196e6c-1b5a-4e53-a9e3-e0f1262c873b","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Services and Languages","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"A":"#5eddce"},"decimalPrecision":2,"description":"","fillSpans":false,"id":"bc6e3017-2b44-4152-a0d7-fe11e6b7a290","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"metricName":"http.client.duration.max","reduceTo":"avg","spaceAggregation":"avg","temporality":"","timeAggregation":"avg"}],"dataSource":"metrics","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name"},"filters":{"items":[{"id":"45f6077f-8492-46fe-b146-4a31f92cd1bd","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"3e688253-85e8-4cfc-814d-5ab821a950db","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"HTTP Request Duration","yAxisUnit":"ms"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"body":350,"timestamp":100},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"05e6759b-c460-4618-86c0-5d2bf0b311c1","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"logs","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name telemetry.sdk.language in $language"},"filters":{"items":[{"id":"14ee9f15-cd4f-453a-bc1f-90aa6c67ed49","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"ad1c34b3-c49a-43e3-8ff0-d54a4fd6b6db","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"},{"columnName":"id","order":"desc"}],"pageSize":10,"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"cf4892fd-86f1-4e83-a876-db114e6e125f","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Logs","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A.avg(duration_nano)":"ns","A.count()":""},"columnWidths":{"A.avg(duration_nano)":145,"A.count()":145,"gen_ai.tool.name":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"389d43de-99b1-4c35-9589-f7d969abaa9d","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() as 'Requests' avg(duration_nano) as 'Latency'"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"gen_ai.operation.name = 'execute_tool' service.name in $service_name telemetry.sdk.language in $language"},"functions":[],"groupBy":[{"dataType":"","id":"gen_ai.tool.name----","key":"gen_ai.tool.name","type":""}],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"f7b51b57-e599-4a48-9957-6f9645c35b96","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Tools","yAxisUnit":"none"}]}
+{
+  "spec": {
+    "display": {
+      "name": "Semantic Kernel",
+      "description": ""
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "service_name",
+            "description": "The service name using Semantic Kernel"
+          },
+          "defaultValue": [
+            "semantic-kernel-otel",
+            "sk-content-pipeline",
+            "sk-support-agent"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "service.name",
+              "signal": "all"
+            }
+          },
+          "name": "service_name"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "language",
+            "description": "Language being used for making Semantic Kernel calls"
+          },
+          "defaultValue": [
+            "python"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "telemetry.sdk.language",
+              "signal": "all"
+            }
+          },
+          "name": "language"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "llm_model",
+            "description": "Model name being used in semantic kernel call"
+          },
+          "defaultValue": [
+            "gpt-5",
+            "gpt-5-mini",
+            "gpt-4.1",
+            "gpt-4.1-mini"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "gen_ai.request.model",
+              "signal": "all"
+            }
+          },
+          "name": "llm_model"
+        }
+      }
+    ],
+    "panels": {
+      "04247ee1-b408-457d-ac00-47ce45e64291": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Input Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(gen_ai.usage.input_tokens)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "05e6759b-c460-4618-86c0-5d2bf0b311c1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Logs",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "timestamp",
+                  "signal": "logs",
+                  "fieldContext": "log",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "body",
+                  "signal": "logs",
+                  "fieldContext": "log",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "logs",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name telemetry.sdk.language in $language"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "28bb5d45-046d-4980-ad5e-26b1aeecda2b": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Token Usage",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "semantic-kernel-otel": "#5DE585",
+                  "sk-content-pipeline": "#C08BE4",
+                  "sk-support-agent": "#E8D330"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "sum(gen_ai.usage.input_tokens)"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"
+                          },
+                          "groupBy": [
+                            {
+                              "name": "service.name",
+                              "signal": "",
+                              "fieldContext": "resource",
+                              "fieldDataType": "string"
+                            }
+                          ],
+                          "order": null,
+                          "selectFields": null,
+                          "secondaryAggregations": null,
+                          "functions": null,
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "sum(gen_ai.usage.output_tokens)"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"
+                          },
+                          "groupBy": [
+                            {
+                              "name": "service.name",
+                              "signal": "",
+                              "fieldContext": "resource",
+                              "fieldDataType": "string"
+                            }
+                          ],
+                          "order": null,
+                          "selectFields": null,
+                          "secondaryAggregations": null,
+                          "functions": null,
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "A + B",
+                          "disabled": false,
+                          "order": null,
+                          "functions": null,
+                          "legend": "{{service.name}}"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "3633c7ad-203a-4e25-99f4-8cc81bf15d65": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Model Distribution",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "gpt-4.1": "#5DE830",
+                  "gpt-4.1-mini": "#645DE5",
+                  "gpt-5": "#5DCDE5",
+                  "gpt-5-mini": "#E48BBB"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND gen_ai.request.model EXISTS"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "gen_ai.request.model",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{gen_ai.request.model}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "389d43de-99b1-4c35-9589-f7d969abaa9d": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Tools",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A.avg(duration_nano)": "ns",
+                  "A.count()": ""
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()",
+                        "alias": "Requests"
+                      },
+                      {
+                        "expression": "avg(duration_nano)",
+                        "alias": "Latency"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "gen_ai.operation.name = 'execute_tool' service.name in $service_name telemetry.sdk.language in $language"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "gen_ai.tool.name",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "5e66cb8c-2219-47e6-ba71-8f82f9873bc8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Errors",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "service.name",
+                  "signal": "traces",
+                  "fieldContext": "resource",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "name",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "duration_nano",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "http_method",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "response_status_code",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "has_error = 'true' service.name IN $service_name"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "name",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "duration_nano",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "http_method",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "response_status_code",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      }
+                    ],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "67a074ee-c46e-4a36-8f5c-10d981cae404": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Services and Languages",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A": ""
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()",
+                        "alias": "Count of Calls"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name AND gen_ai.operation.name = 'execute_tool'"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "telemetry.sdk.language",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "74a94376-eeaf-43c1-a273-5d8b98197138": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Number of Requests",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "semantic-kernel-otel": "#5DE585",
+                  "sk-content-pipeline": "#C08BE4",
+                  "sk-support-agent": "#E8D330"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model gen_ai.operation.name EXISTS "
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "799913e6-fb95-497e-858a-6490b5f9d10d": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Error Rate",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "percentunit",
+                "decimalPrecision": "2"
+              },
+              "thresholds": [
+                {
+                  "value": 0.1,
+                  "operator": "above",
+                  "unit": "percentunit",
+                  "color": "Red",
+                  "format": "text"
+                },
+                {
+                  "value": 0.05,
+                  "operator": "above",
+                  "unit": "percentunit",
+                  "color": "Orange",
+                  "format": "text"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "has_error = 'true' service.name in $service_name"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "has_error = 'false' service.name in $service_name"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "A / (A+B)",
+                          "disabled": false,
+                          "order": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "functions": null,
+                          "legend": ""
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "af79b14b-5e76-47fb-a24e-a4629c642c28": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Latency (P95)",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ns",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "semantic-kernel-otel": "#5DE585",
+                  "sk-content-pipeline": "#C08BE4",
+                  "sk-support-agent": "#E8D330"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "p95(duration_nano)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model "
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "bc6e3017-2b44-4152-a0d7-fe11e6b7a290": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "HTTP Request Duration",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ms",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "semantic-kernel-otel": "#5DE585",
+                  "sk-content-pipeline": "#C08BE4",
+                  "sk-support-agent": "#E8D330"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "metrics",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "metricName": "http.client.duration.max",
+                        "temporality": "",
+                        "timeAggregation": "avg",
+                        "spaceAggregation": "avg",
+                        "reduceTo": "avg"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Output Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(gen_ai.usage.output_tokens)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name telemetry.sdk.language in $language gen_ai.request.model in $llm_model"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/04247ee1-b408-457d-ac00-47ce45e64291"
+              }
+            },
+            {
+              "x": 4,
+              "y": 0,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570"
+              }
+            },
+            {
+              "x": 8,
+              "y": 0,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/799913e6-fb95-497e-858a-6490b5f9d10d"
+              }
+            },
+            {
+              "x": 0,
+              "y": 3,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/74a94376-eeaf-43c1-a273-5d8b98197138"
+              }
+            },
+            {
+              "x": 6,
+              "y": 3,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/af79b14b-5e76-47fb-a24e-a4629c642c28"
+              }
+            },
+            {
+              "x": 0,
+              "y": 9,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/28bb5d45-046d-4980-ad5e-26b1aeecda2b"
+              }
+            },
+            {
+              "x": 6,
+              "y": 9,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/bc6e3017-2b44-4152-a0d7-fe11e6b7a290"
+              }
+            },
+            {
+              "x": 0,
+              "y": 15,
+              "width": 4,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/3633c7ad-203a-4e25-99f4-8cc81bf15d65"
+              }
+            },
+            {
+              "x": 4,
+              "y": 15,
+              "width": 4,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/389d43de-99b1-4c35-9589-f7d969abaa9d"
+              }
+            },
+            {
+              "x": 8,
+              "y": 15,
+              "width": 4,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/67a074ee-c46e-4a36-8f5c-10d981cae404"
+              }
+            },
+            {
+              "x": 0,
+              "y": 21,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/5e66cb8c-2219-47e6-ba71-8f82f9873bc8"
+              }
+            },
+            {
+              "x": 6,
+              "y": 21,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/05e6759b-c460-4618-86c0-5d2bf0b311c1"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "",
+    "refreshInterval": "",
+    "links": []
+  },
+  "tags": [],
+  "image": "/assets/Icons/eight-ball"
+}

--- a/temporal-agents/temporal-dashboard.json
+++ b/temporal-agents/temporal-dashboard.json
@@ -1,1 +1,1934 @@
-{"description":"","image":"data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE0Ljk0OTQgMTMuOTQyQzE2LjIzMTggMTIuNDI1OCAxNy4zMjY4IDkuNzAyMiAxNi4xOTU2IDYuNTc0ODdDMTUuNjQ0MyA1LjA1MjQ1IDE1LjAyMTkgNC4yMDI0OSAxNC4yOTY5IDMuNjYyNTJDMTMuODU1NyAzLjMzMzc5IDEyLjA5MzMgMi41MDYzMyA5Ljc1OTY1IDIuODY3NTZDOC4wNTM0OSAzLjEzMjU1IDUuNzc0ODcgNC4yMDg3NCA0LjI5MzY5IDUuOTU5OUMyLjg1NzUyIDcuNjYxMDYgMS43NDg4MyA5LjAwNDc0IDEuNjk3NTggMTAuMzA5N0MxLjYzMTMzIDExLjk4ODMgMi44OTYyNyAxMy40MzA4IDMuMDUwMDEgMTMuNjY0NUMzLjMyMzc0IDE0LjA3OTUgNS4xOTExNSAxNi40NTE4IDguNjk5NzEgMTYuNTczMUMxMS43OTcgMTYuNjc5MyAxMy44MTQ0IDE1LjI4NDQgMTQuOTQ5NCAxMy45NDJaIiBmaWxsPSIjNDAzRDNFIi8+CjxwYXRoIGQ9Ik00LjU1MzYzIDIuNzM3NDdDMi45Mzc0NiAzLjg5MTE2IDEuMTIxMzEgNi4yNTEwMyAxLjQ0NzU0IDkuNTYwODZDMS42MDYyOCAxMS4xNzIgMi4wMDI1MSAxMi4xNDk1IDIuNTcxMjMgMTIuODUwN0MyLjkxNzQ2IDEzLjI3ODIgNC40MTk4OCAxNC41NDkzIDYuNzczNTEgMTQuNzM2OEM5LjE0NTg4IDE0LjkyNTYgMTAuOTQ5NSAxNC4zOTQ0IDEyLjgzMzIgMTMuMDg0NEMxNi42NjE3IDEwLjQyMDggMTYuMDk4IDYuMzkzNTMgMTUuOTM0MyA1LjkyNDhDMTUuNzcwNSA1LjQ1NjA3IDE0LjU0NDQgMi42OTYyMiAxMS4xNzMzIDEuNzE1MDJDOC4xOTg0NCAwLjg1MDA2OCA1Ljk4MzU1IDEuNzE1MDIgNC41NTM2MyAyLjczNzQ3WiIgZmlsbD0iIzVFNjM2NyIvPgo8cGF0aCBkPSJNNy4zOTM1MyAyLjk2MTA5QzUuNjE3MzcgMi44OTczNCAzLjkxOTk2IDQuMjg4NTIgMy43NTYyMiA2LjAwNTkzQzMuNTkyNDggNy43MjIwOSA0LjY1NDkyIDkuMDI5NTIgNi4zMDk4MyA5LjI5NTc2QzcuOTY0NzUgOS41NjA3NCA5Ljg3ODM5IDguNTU1OCAxMC4yNjM0IDYuNDUwOTFDMTAuNjYwOSA0LjI4MjI3IDkuMDg5NjkgMy4wMjIzNCA3LjM5MzUzIDIuOTYxMDlaIiBmaWxsPSJ3aGl0ZSIvPgo8cGF0aCBkPSJNNy45NDIxNyA1LjkwMTE1QzcuOTQyMTcgNS45MDExNSA4LjM2OTY1IDUuODEyNCA4LjQ1NDY1IDUuMTgyNDRDOC41MzgzOSA0LjU2MjQ3IDguMjMwOTEgNC4wMzM3NSA3LjUxMzQ1IDMuODQzNzZDNi43MzM0OSAzLjYzNzUyIDYuMjA0NzcgNC4wNjYyNSA2LjA2NzI3IDQuNTE3NDdDNS44NzYwMyA1LjE0NDk0IDYuMTU4NTIgNS40NDM2NyA2LjE1ODUyIDUuNDQzNjdDNi4xNTg1MiA1LjQ0MzY3IDUuMzkzNTYgNS42Mjc0MSA1LjMzMjMxIDYuNTI5ODdDNS4yNzQ4MSA3LjM4MTA3IDUuODU2MDMgNy44Mzg1NSA2LjQzOTc1IDcuOTc4NTRDNy4xNjA5NiA4LjE1MjI4IDcuOTc4NDIgNy45NTQ3OSA4LjE3ODQxIDcuMDM0ODRDOC4zNDQ2NSA2LjI3NzM4IDcuOTQyMTcgNS45MDExNSA3Ljk0MjE3IDUuOTAxMTVaIiBmaWxsPSIjMzAzMDMwIi8+CjxwYXRoIGQ9Ik02LjczOTgzIDQuNzUzNjJDNi42NzEwOSA1LjAxMjM1IDYuODA4NTggNS4yNjIzNCA3LjA3ODU3IDUuMzMxMDlDNy4zNjk4IDUuNDA0ODMgNy42MzQ3OSA1LjMwODU5IDcuNzA2MDMgNS4wMTExQzcuNzY4NTMgNC43NDczNyA3LjY0MzU0IDQuNTE0ODggNy4zMzYwNSA0LjQzOTg4QzcuMDgzNTcgNC4zNzczOSA2LjgxNDgzIDQuNDcxMTMgNi43Mzk4MyA0Ljc1MzYyWiIgZmlsbD0id2hpdGUiLz4KPHBhdGggZD0iTTYuOTU5NzggNi4wMzk3NEM2LjYzMjMgNS45Mzg0OSA2LjE5OTgyIDYuMDY0NzMgNi4xMzEwNyA2LjUwNDcxQzYuMDYyMzMgNi45NDQ2OSA2LjMyNjA2IDcuMTY5NjggNi42NzEwNCA3LjIzMjE3QzcuMDE2MDMgNy4yOTQ2NyA3LjM0MjI2IDcuMTEzNDMgNy40MDYwMSA2Ljc2MDk1QzcuNDY4NSA2LjQwOTcyIDcuMjg2MDEgNi4xMzk3MyA2Ljk1OTc4IDYuMDM5NzRaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K","layout":[{"h":1,"i":"0bec3659-d6dd-4f85-ae2c-d880ef0a9fd5","maxH":1,"minH":1,"minW":12,"moved":false,"static":false,"w":12,"x":0,"y":0},{"h":4,"i":"04247ee1-b408-457d-ac00-47ce45e64291","moved":false,"static":false,"w":3,"x":0,"y":1},{"h":4,"i":"d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570","moved":false,"static":false,"w":3,"x":3,"y":1},{"h":7,"i":"28409661-48e9-454c-ba5a-890e5268ef4e","moved":false,"static":false,"w":3,"x":6,"y":1},{"h":7,"i":"3633c7ad-203a-4e25-99f4-8cc81bf15d65","moved":false,"static":false,"w":3,"x":9,"y":1},{"h":3,"i":"01c76dbd-5af0-4dcc-9693-006d589112d5","moved":false,"static":false,"w":3,"x":0,"y":5},{"h":5,"i":"57a65ebe-9394-4734-88c4-73c03c02c5db","moved":false,"static":false,"w":6,"x":0,"y":8},{"h":5,"i":"28bb5d45-046d-4980-ad5e-26b1aeecda2b","moved":false,"static":false,"w":6,"x":0,"y":13},{"h":1,"i":"b5773b14-e4fd-4657-a886-4b055b97b97d","maxH":1,"minH":1,"minW":12,"moved":false,"static":false,"w":12,"x":0,"y":18},{"h":4,"i":"67a074ee-c46e-4a36-8f5c-10d981cae404","moved":false,"static":false,"w":6,"x":0,"y":19},{"h":2,"i":"799913e6-fb95-497e-858a-6490b5f9d10d","moved":false,"static":false,"w":2,"x":6,"y":19},{"h":8,"i":"05e6759b-c460-4618-86c0-5d2bf0b311c1","moved":false,"static":false,"w":6,"x":6,"y":21},{"h":5,"i":"af79b14b-5e76-47fb-a24e-a4629c642c28","moved":false,"static":false,"w":6,"x":0,"y":23},{"h":5,"i":"74a94376-eeaf-43c1-a273-5d8b98197138","moved":false,"static":false,"w":6,"x":0,"y":28},{"h":5,"i":"5e66cb8c-2219-47e6-ba71-8f82f9873bc8","moved":false,"static":false,"w":6,"x":6,"y":29},{"h":1,"i":"3b8f2191-04ca-45fd-bdaa-721148137dd4","maxH":1,"minH":1,"minW":12,"moved":false,"static":false,"w":12,"x":0,"y":34},{"h":6,"i":"389d43de-99b1-4c35-9589-f7d969abaa9d","moved":false,"static":false,"w":7,"x":0,"y":35},{"h":8,"i":"fa87c0ad-c744-4573-85b7-0c44ad738f90","moved":false,"static":false,"w":5,"x":7,"y":35},{"h":6,"i":"f08a8cc0-424d-4f60-81f1-23a681e863b0","moved":false,"static":false,"w":7,"x":0,"y":41},{"h":1,"i":"39755da9-c97e-4fa0-9eb6-0ce074c5695b","maxH":1,"minH":1,"minW":12,"moved":false,"static":false,"w":12,"x":0,"y":47},{"h":6,"i":"e8a24d56-2d9d-46c2-a0d4-642bc5f1c6ee","moved":false,"static":false,"w":6,"x":0,"y":72},{"h":6,"i":"1c360b12-cdf5-4d08-9289-f0a64ecfa7e8","moved":false,"static":false,"w":6,"x":6,"y":72},{"h":6,"i":"f0d660ea-8ddc-4edd-9760-765a1c212c72","moved":false,"static":false,"w":6,"x":0,"y":78}],"panelMap":{"0bec3659-d6dd-4f85-ae2c-d880ef0a9fd5":{"collapsed":false,"widgets":[{"h":4,"i":"04247ee1-b408-457d-ac00-47ce45e64291","moved":false,"static":false,"w":3,"x":0,"y":1},{"h":4,"i":"d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570","moved":false,"static":false,"w":3,"x":3,"y":1},{"h":7,"i":"28409661-48e9-454c-ba5a-890e5268ef4e","moved":false,"static":false,"w":3,"x":6,"y":1},{"h":7,"i":"3633c7ad-203a-4e25-99f4-8cc81bf15d65","moved":false,"static":false,"w":3,"x":9,"y":1},{"h":3,"i":"01c76dbd-5af0-4dcc-9693-006d589112d5","moved":false,"static":false,"w":3,"x":0,"y":5},{"h":5,"i":"28bb5d45-046d-4980-ad5e-26b1aeecda2b","moved":false,"static":false,"w":6,"x":0,"y":8},{"h":5,"i":"af79b14b-5e76-47fb-a24e-a4629c642c28","moved":false,"static":false,"w":6,"x":6,"y":8}]},"39755da9-c97e-4fa0-9eb6-0ce074c5695b":{"collapsed":false,"widgets":[{"h":6,"i":"e8a24d56-2d9d-46c2-a0d4-642bc5f1c6ee","moved":false,"static":false,"w":6,"x":0,"y":72},{"h":6,"i":"1c360b12-cdf5-4d08-9289-f0a64ecfa7e8","moved":false,"static":false,"w":6,"x":6,"y":72},{"h":6,"i":"f0d660ea-8ddc-4edd-9760-765a1c212c72","moved":false,"static":false,"w":6,"x":0,"y":78}]},"3b8f2191-04ca-45fd-bdaa-721148137dd4":{"collapsed":false,"widgets":[{"h":6,"i":"389d43de-99b1-4c35-9589-f7d969abaa9d","moved":false,"static":false,"w":7,"x":0,"y":35},{"h":8,"i":"fa87c0ad-c744-4573-85b7-0c44ad738f90","moved":false,"static":false,"w":5,"x":7,"y":35},{"h":6,"i":"f08a8cc0-424d-4f60-81f1-23a681e863b0","moved":false,"static":false,"w":7,"x":0,"y":41}]},"b5773b14-e4fd-4657-a886-4b055b97b97d":{"collapsed":false,"widgets":[{"h":4,"i":"67a074ee-c46e-4a36-8f5c-10d981cae404","moved":false,"static":false,"w":6,"x":0,"y":38},{"h":8,"i":"05e6759b-c460-4618-86c0-5d2bf0b311c1","moved":false,"static":false,"w":6,"x":6,"y":38},{"h":5,"i":"74a94376-eeaf-43c1-a273-5d8b98197138","moved":false,"static":false,"w":6,"x":0,"y":42},{"h":2,"i":"799913e6-fb95-497e-858a-6490b5f9d10d","moved":false,"static":false,"w":2,"x":6,"y":46},{"h":5,"i":"bc6e3017-2b44-4152-a0d7-fe11e6b7a290","moved":false,"static":false,"w":6,"x":0,"y":47},{"h":5,"i":"5e66cb8c-2219-47e6-ba71-8f82f9873bc8","moved":false,"static":false,"w":6,"x":6,"y":48}]}},"tags":[],"title":"Temporal for AI","uploadedGrafana":false,"uuid":"019b3383-0b10-70e6-b5a4-549ebd4d004e","variables":{"10d0eca9-9253-4583-821c-d3c812d78151":{"allSelected":false,"customValue":"","defaultValue":"","description":"The service name using Temporal","dynamicVariablesAttribute":"service.name","dynamicVariablesSource":"All telemetry","haveCustomValuesSelected":false,"id":"10d0eca9-9253-4583-821c-d3c812d78151","key":"10d0eca9-9253-4583-821c-d3c812d78151","modificationUUID":"9f851a2b-c079-4479-9f23-71a4dd272801","multiSelect":true,"name":"service_name","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"6af0f1f2-deb5-4456-ba1f-a9426bda5269":{"allSelected":false,"customValue":"","defaultValue":"","description":"The name of the Temporal agent being used","dynamicVariablesAttribute":"graph.node.id","dynamicVariablesSource":"All telemetry","haveCustomValuesSelected":false,"id":"6af0f1f2-deb5-4456-ba1f-a9426bda5269","key":"6af0f1f2-deb5-4456-ba1f-a9426bda5269","modificationUUID":"570d1d23-936c-4994-86d5-c639f9bfd897","multiSelect":true,"name":"agent_name","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"93c33118-5f46-404b-b45e-8a81160c44c4":{"allSelected":true,"customValue":"","defaultValue":"","description":"Language being used for making Temporal calls","dynamicVariablesAttribute":"telemetry.sdk.language","dynamicVariablesSource":"All telemetry","id":"93c33118-5f46-404b-b45e-8a81160c44c4","key":"93c33118-5f46-404b-b45e-8a81160c44c4","modificationUUID":"5a0804d8-eecc-45fc-a9c3-641ace53b5c2","multiSelect":true,"name":"language","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"},"be7a68c4-fb97-43ea-bb94-0ded120bd3d7":{"allSelected":true,"customValue":"","defaultValue":"","description":"LLM Model name being used in Temporal","dynamicVariablesAttribute":"llm.model_name","dynamicVariablesSource":"All telemetry","id":"be7a68c4-fb97-43ea-bb94-0ded120bd3d7","modificationUUID":"420fb053-13bb-4e70-b27e-99f6bf07a5e8","multiSelect":true,"name":"llm_model","order":0,"queryValue":"","showALLOption":true,"sort":"DISABLED","textboxValue":"","type":"DYNAMIC"}},"version":"v5","widgets":[{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"04247ee1-b408-457d-ac00-47ce45e64291","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(llm.token_count.prompt) ) ) ) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND telemetry.sdk.language in $language AND openinference.span.kind = 'LLM' AND llm.model_name in $llm_model"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"2db22d68-01fe-4b4a-92c5-38f46f31b125","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Input Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(llm.token_count.completion) ) ) ) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND telemetry.sdk.language in $language AND openinference.span.kind = 'LLM' AND llm.model_name in $llm_model"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"c018e629-881b-40b7-aeaf-a70f2a1adcaa","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Output Tokens","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"799913e6-fb95-497e-858a-6490b5f9d10d","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"A","filter":{"expression":"has_error = 'true' service.name in $service_name"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null},{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":true,"expression":"B","filter":{"expression":"has_error = 'false' service.name in $service_name"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"B","source":"","stepInterval":null}],"queryFormulas":[{"disabled":false,"expression":"A / (A+B)","legend":"","queryName":"F1"}],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"c396f730-a781-4335-b329-641bff27f66b","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[{"index":"e5e05d41-7479-4d60-a1cf-c433b8b61285","isEditEnabled":false,"keyIndex":1,"selectedGraph":"value","thresholdColor":"Red","thresholdFormat":"Text","thresholdLabel":"","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"percentunit","thresholdValue":10},{"index":"d74bf17b-552a-4636-8fad-c976b090d590","isEditEnabled":false,"keyIndex":0,"selectedGraph":"value","thresholdColor":"Orange","thresholdFormat":"Text","thresholdLabel":"","thresholdOperator":">","thresholdTableOptions":"A","thresholdUnit":"percentunit","thresholdValue":5}],"timePreferance":"GLOBAL_TIME","title":"Error Rate","yAxisUnit":"percentunit"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"3633c7ad-203a-4e25-99f4-8cc81bf15d65","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND openinference.span.kind = 'LLM' and llm.model_name EXISTS "},"functions":[],"groupBy":[{"dataType":"string","id":"llm.model_name--string--tag","isColumn":false,"isJSON":false,"key":"llm.model_name","type":"tag"}],"having":{"expression":""},"legend":"{{llm.model_name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"8061ca18-796e-4819-b191-7dd7af6c0131","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Model Calls","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"F1":"#eccd03"},"decimalPrecision":2,"description":"","fillSpans":false,"id":"28bb5d45-046d-4980-ad5e-26b1aeecda2b","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(llm.token_count.total) )"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND telemetry.sdk.language in $language AND openinference.span.kind = 'LLM' AND llm.model_name in $llm_model"},"functions":[],"groupBy":[{"dataType":"","id":"service.name----","key":"service.name","type":""}],"having":{"expression":""},"legend":"{{service.name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"38a194c1-c945-4291-b98a-1b785e4174ab","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Token Usage","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"af79b14b-5e76-47fb-a24e-a4629c642c28","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"p95(duration_nano) "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND telemetry.sdk.language in $language AND openinference.span.kind = 'AGENT' AND graph.node.id IN $agent_name "},"functions":[],"groupBy":[{"dataType":"","id":"service.name----","key":"service.name","type":""}],"having":{"expression":""},"legend":"{{service.name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"cfbfbd21-0098-463a-9f9d-9d18a671d2aa","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Request Duration (P95)","yAxisUnit":"ns"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"A":"#edce64","count()":"#a403ff"},"decimalPrecision":2,"description":"","fillSpans":false,"id":"74a94376-eeaf-43c1-a273-5d8b98197138","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND telemetry.sdk.language in $language AND openinference.span.kind = 'AGENT' AND graph.node.id NOT EXISTS"},"functions":[],"groupBy":[{"dataType":"string","id":"service.name--string--resource","isColumn":true,"isJSON":false,"key":"service.name","type":"resource"}],"having":{"expression":""},"legend":"{{service.name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"48fc293c-4d4d-4cac-b64a-d6cc845e5636","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Number of Requests","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"date":145,"duration_nano":145,"http_method":145,"name":145,"response_status_code":145,"service.name":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"5e66cb8c-2219-47e6-ba71-8f82f9873bc8","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"has_error = 'true' service.name IN $service_name"},"filters":{"items":[{"id":"45f6077f-8492-46fe-b146-4a31f92cd1bd","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"cd7bce73-6b30-45bb-bd0a-0e93316a2ddd","key":{"id":"has_error","key":"has_error","type":""},"op":"=","value":"true"}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"}],"pageSize":10,"queryName":"A","selectColumns":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"b85f93b2-09b5-4fcd-8aa8-f6a2875a41b5","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Errors","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A":""},"columnWidths":{"A":145,"service.name":145,"telemetry.sdk.language":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"67a074ee-c46e-4a36-8f5c-10d981cae404","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() as 'Conversation Count' "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name AND openinference.span.kind = 'AGENT' AND graph.node.id NOT EXISTS "},"functions":[],"groupBy":[{"dataType":"string","id":"service.name--string--resource","isColumn":true,"isJSON":false,"key":"service.name","type":"resource"},{"dataType":"string","id":"telemetry.sdk.language--string--resource","isColumn":false,"isJSON":false,"key":"telemetry.sdk.language","type":"resource"}],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"765a0bfd-cc60-4969-85c9-447da4eded64","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Services and Languages","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"body":350,"timestamp":100},"contextLinks":{"linksData":[]},"customLegendColors":{},"description":"","fillSpans":false,"id":"05e6759b-c460-4618-86c0-5d2bf0b311c1","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"logs","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name telemetry.sdk.language in $language"},"filters":{"items":[{"id":"14ee9f15-cd4f-453a-bc1f-90aa6c67ed49","key":{"dataType":"string","id":"service.name--string--","key":"service.name","type":""},"op":"IN","value":"$service_name"},{"id":"ad1c34b3-c49a-43e3-8ff0-d54a4fd6b6db","key":{"id":"telemetry.sdk.language","key":"telemetry.sdk.language","type":""},"op":"in","value":["$language"]}],"op":"AND"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"},{"columnName":"id","order":"desc"}],"pageSize":10,"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"cf4892fd-86f1-4e83-a876-db114e6e125f","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Logs","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{"A.avg(duration_nano)":"ns","A.count()":""},"columnWidths":{"A.avg(duration_nano)":145,"A.count()":145,"graph.node.id":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"389d43de-99b1-4c35-9589-f7d969abaa9d","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"table","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() as 'Requests' avg(duration_nano) as 'Latency'"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name telemetry.sdk.language in $language graph.node.id EXISTS and openinference.span.kind = 'AGENT' "},"functions":[],"groupBy":[{"dataType":"","id":"graph.node.id----","key":"graph.node.id","type":""}],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"7867d3f7-e4a0-4c06-85b2-1c65d41f1cb3","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Agents","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"News Agent":"#fccccc"},"decimalPrecision":2,"description":"","fillSpans":false,"id":"fa87c0ad-c744-4573-85b7-0c44ad738f90","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND graph.node.id EXISTS AND openinference.span.kind = 'AGENT' "},"functions":[],"groupBy":[{"dataType":"string","id":"graph.node.id--string--tag","isColumn":false,"isJSON":false,"key":"graph.node.id","type":"tag"}],"having":{"expression":""},"legend":"{{graph.node.id}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"856e2918-3e20-439a-a655-f50b687577f0","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Agent Distribution","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"columnWidths":{"date":145,"duration_nano":145,"http_method":145,"name":145,"response_status_code":145,"service.name":145},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"f08a8cc0-424d-4f60-81f1-23a681e863b0","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"list","query":{"builder":{"queryData":[{"aggregations":[{"expression":"count() "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name graph.node.id in $agent_name AND openinference.span.kind = 'AGENT' "},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"offset":0,"orderBy":[{"columnName":"timestamp","order":"desc"}],"pageSize":10,"queryName":"A","selectColumns":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"e3c29b9a-73ff-4362-ba90-8e5562ca3a6f","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Agent Traces","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"01c76dbd-5af0-4dcc-9693-006d589112d5","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"value","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(llm.token_count.prompt)"}],"dataSource":"traces","disabled":true,"expression":"A","filter":{"expression":"service.name in $service_name AND telemetry.sdk.language in $language AND openinference.span.kind = 'LLM' AND llm.model_name in $llm_model"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null},{"aggregations":[{"expression":"sum(llm.token_count.prompt_details.cache_read) )"}],"dataSource":"traces","disabled":true,"expression":"B","filter":{"expression":"service.name in $service_name AND telemetry.sdk.language in $language AND openinference.span.kind = 'LLM' AND llm.model_name in $llm_model"},"functions":[],"groupBy":[],"having":{"expression":""},"legend":"","limit":null,"orderBy":[],"queryName":"B","source":"","stepInterval":null}],"queryFormulas":[{"disabled":false,"expression":"(B/A) * 100","legend":"","queryName":"F1"}],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"b492d70c-b7a9-4056-915f-d041da9e6f0b","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Cache Utilization Rate","yAxisUnit":"percent"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"{llm.model_name=\"gpt-4.1-2025-04-14\"}":"#ce93ce","{llm.model_name=\"gpt-5-2025-08-07\"}":"#69aedd"},"decimalPrecision":2,"description":"","fillSpans":false,"id":"28409661-48e9-454c-ba5a-890e5268ef4e","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"pie","query":{"builder":{"queryData":[{"aggregations":[{"expression":"sum(llm.token_count.total) ) "}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name IN $service_name AND openinference.span.kind = 'LLM'"},"functions":[],"groupBy":[{"dataType":"string","id":"llm.model_name--string--tag","isColumn":false,"isJSON":false,"key":"llm.model_name","type":"tag"}],"having":{"expression":""},"legend":"{{llm.model_name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"cf4c6ded-c140-4ad7-baeb-212c54ecc953","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Token Distribution by Models","yAxisUnit":"none"},{"description":"","id":"39755da9-c97e-4fa0-9eb6-0ce074c5695b","panelTypes":"row","title":"Temporal Cloud"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"e8a24d56-2d9d-46c2-a0d4-642bc5f1c6ee","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"metricName":"temporal_cloud_v0_poll_success_count:rate2m","reduceTo":"avg","spaceAggregation":"avg","temporality":"","timeAggregation":"avg"}],"dataSource":"metrics","disabled":false,"expression":"A","filter":{"expression":""},"functions":[],"groupBy":[{"dataType":"string","id":"temporal_namespace--string--tag","isColumn":false,"isJSON":false,"key":"temporal_namespace","type":"tag"}],"having":{"expression":""},"legend":"{{temporal_namespace}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"6d00dbdb-f40f-4341-8c21-725e5ced4496","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Temporal Poll Success Rate","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"f0d660ea-8ddc-4edd-9760-765a1c212c72","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"metricName":"temporal_cloud_v0_poll_timeout_count:rate2m","reduceTo":"avg","spaceAggregation":"avg","temporality":"","timeAggregation":"avg"}],"dataSource":"metrics","disabled":false,"expression":"A","filter":{"expression":""},"functions":[],"groupBy":[{"dataType":"string","id":"temporal_namespace--string--tag","isColumn":false,"isJSON":false,"key":"temporal_namespace","type":"tag"}],"having":{"expression":""},"legend":"{{temporal_namespace}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":60}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"10bb7a39-a9ad-4210-8b5a-e5cd5f584247","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Worker Poll Timeout Rate","yAxisUnit":"none"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{},"decimalPrecision":2,"description":"","fillSpans":false,"id":"1c360b12-cdf5-4d08-9289-f0a64ecfa7e8","isLogScale":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"metricName":"temporal_cloud_v0_poll_success_sync_count:rate2m","reduceTo":"avg","spaceAggregation":"avg","temporality":"","timeAggregation":"avg"}],"dataSource":"metrics","disabled":false,"expression":"A","filter":{"expression":""},"functions":[],"groupBy":[{"dataType":"string","id":"temporal_namespace--string--tag","isColumn":false,"isJSON":false,"key":"temporal_namespace","type":"tag"}],"having":{"expression":""},"legend":"{{temporal_namespace}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":null}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"74cc17ad-c45e-4ab8-b558-bd13f07dbf05","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"Worker Poll Success Sync Rate","yAxisUnit":"none"},{"description":"","id":"3b8f2191-04ca-45fd-bdaa-721148137dd4","panelTypes":"row","title":"Agents"},{"description":"","id":"0bec3659-d6dd-4f85-ae2c-d880ef0a9fd5","panelTypes":"row","title":"LLM"},{"description":"","id":"b5773b14-e4fd-4657-a886-4b055b97b97d","panelTypes":"row","title":"App"},{"bucketCount":30,"bucketWidth":0,"columnUnits":{},"contextLinks":{"linksData":[]},"customLegendColors":{"A":"#5eddce"},"decimalPrecision":2,"description":"","fillSpans":false,"id":"57a65ebe-9394-4734-88c4-73c03c02c5db","isLogScale":false,"isStacked":false,"legendPosition":"bottom","mergeAllActiveQueries":false,"nullZeroValues":"zero","opacity":"1","panelTypes":"graph","query":{"builder":{"queryData":[{"aggregations":[{"expression":"avg(duration_nano)"}],"dataSource":"traces","disabled":false,"expression":"A","filter":{"expression":"service.name in $service_name AND openinference.span.kind = 'LLM'"},"functions":[],"groupBy":[{"dataType":"string","id":"service.name--string--resource","isColumn":true,"isJSON":false,"key":"service.name","type":"resource"}],"having":{"expression":""},"legend":"{{service.name}}","limit":null,"orderBy":[],"queryName":"A","source":"","stepInterval":0}],"queryFormulas":[],"queryTraceOperator":[]},"clickhouse_sql":[{"disabled":false,"legend":"","name":"A","query":""}],"id":"3bdba0f5-28e6-41ba-9bbe-dc7ef22a5589","promql":[{"disabled":false,"legend":"","name":"A","query":""}],"queryType":"builder"},"selectedLogFields":[{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"timestamp","signal":"logs","type":"log"},{"dataType":"","fieldContext":"log","fieldDataType":"","isIndexed":false,"name":"body","signal":"logs","type":"log"}],"selectedTracesFields":[{"fieldContext":"resource","fieldDataType":"string","name":"service.name","signal":"traces"},{"fieldContext":"span","fieldDataType":"string","name":"name","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"duration_nano","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"http_method","signal":"traces"},{"fieldContext":"span","fieldDataType":"","name":"response_status_code","signal":"traces"}],"softMax":0,"softMin":0,"stackedBarChart":false,"thresholds":[],"timePreferance":"GLOBAL_TIME","title":"HTTP Request Duration Traces","yAxisUnit":"ns"}]}
+{
+  "spec": {
+    "display": {
+      "name": "Temporal for AI",
+      "description": ""
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "service_name",
+            "description": "The service name using Temporal"
+          },
+          "defaultValue": [
+            "temporal-otel1",
+            "temporal-otel"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "service.name",
+              "signal": "all"
+            }
+          },
+          "name": "service_name"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "agent_name",
+            "description": "The name of the Temporal agent being used"
+          },
+          "defaultValue": [
+            "Search agent",
+            "Summary agent",
+            "Triage agent"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "graph.node.id",
+              "signal": "all"
+            }
+          },
+          "name": "agent_name"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "language",
+            "description": "Language being used for making Temporal calls"
+          },
+          "defaultValue": [
+            "python"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "telemetry.sdk.language",
+              "signal": "all"
+            }
+          },
+          "name": "language"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "llm_model",
+            "description": "LLM Model name being used in Temporal"
+          },
+          "defaultValue": [
+            "gpt-5-2025-08-07",
+            "gpt-5-mini",
+            "gpt-4.1-2025-04-14"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": "",
+          "capturingRegexp": "",
+          "sort": "none",
+          "plugin": {
+            "kind": "signoz/DynamicVariable",
+            "spec": {
+              "name": "llm.model_name",
+              "signal": "all"
+            }
+          },
+          "name": "llm_model"
+        }
+      }
+    ],
+    "panels": {
+      "01c76dbd-5af0-4dcc-9693-006d589112d5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cache Utilization Rate",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "percent",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "sum(llm.token_count.prompt)"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "service.name in $service_name AND telemetry.sdk.language in $language AND openinference.span.kind = 'LLM' AND llm.model_name in $llm_model"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "sum(llm.token_count.prompt_details.cache_read)"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "service.name in $service_name AND telemetry.sdk.language in $language AND openinference.span.kind = 'LLM' AND llm.model_name in $llm_model"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "(B/A) * 100",
+                          "disabled": false,
+                          "order": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "functions": null,
+                          "legend": ""
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "04247ee1-b408-457d-ac00-47ce45e64291": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Input Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(llm.token_count.prompt)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND telemetry.sdk.language in $language AND openinference.span.kind = 'LLM' AND llm.model_name in $llm_model"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "05e6759b-c460-4618-86c0-5d2bf0b311c1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Logs",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "timestamp",
+                  "signal": "logs",
+                  "fieldContext": "log",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "body",
+                  "signal": "logs",
+                  "fieldContext": "log",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "logs",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name telemetry.sdk.language in $language"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "1c360b12-cdf5-4d08-9289-f0a64ecfa7e8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Worker Poll Success Sync Rate",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "signoz-demo.a1b2c": "#E830D5",
+                  "signoz-staging.a1b2c": "#AFE55D"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "metrics",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "metricName": "temporal_cloud_v0_poll_success_sync_count:rate2m",
+                        "temporality": "",
+                        "timeAggregation": "avg",
+                        "spaceAggregation": "avg",
+                        "reduceTo": "avg"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": ""
+                    },
+                    "groupBy": [
+                      {
+                        "name": "temporal_namespace",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{temporal_namespace}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "28409661-48e9-454c-ba5a-890e5268ef4e": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Token Distribution by Models",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "gpt-4.1-2025-04-14": "#91E48B",
+                  "gpt-5-2025-08-07": "#30A8E8",
+                  "gpt-5-mini": "#E55D8D"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(llm.token_count.total)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name AND openinference.span.kind = 'LLM'"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "llm.model_name",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{llm.model_name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "28bb5d45-046d-4980-ad5e-26b1aeecda2b": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Token Usage",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "temporal-otel": "#C55DE5",
+                  "temporal-otel1": "#DFE48B"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(llm.token_count.total)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND telemetry.sdk.language in $language AND openinference.span.kind = 'LLM' AND llm.model_name in $llm_model"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "traces",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "3633c7ad-203a-4e25-99f4-8cc81bf15d65": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Model Calls",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "gpt-4.1-2025-04-14": "#91E48B",
+                  "gpt-5-2025-08-07": "#30A8E8",
+                  "gpt-5-mini": "#E55D8D"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND openinference.span.kind = 'LLM' and llm.model_name EXISTS "
+                    },
+                    "groupBy": [
+                      {
+                        "name": "llm.model_name",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{llm.model_name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "389d43de-99b1-4c35-9589-f7d969abaa9d": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Agents",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A.avg(duration_nano)": "ns",
+                  "A.count()": ""
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()",
+                        "alias": "Requests"
+                      },
+                      {
+                        "expression": "avg(duration_nano)",
+                        "alias": "Latency"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name telemetry.sdk.language in $language graph.node.id EXISTS and openinference.span.kind = 'AGENT' "
+                    },
+                    "groupBy": [
+                      {
+                        "name": "graph.node.id",
+                        "signal": "",
+                        "fieldContext": "",
+                        "fieldDataType": ""
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "57a65ebe-9394-4734-88c4-73c03c02c5db": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "HTTP Request Duration Traces",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ns",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "temporal-otel": "#C55DE5",
+                  "temporal-otel1": "#DFE48B"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "avg(duration_nano)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND openinference.span.kind = 'LLM'"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "5e66cb8c-2219-47e6-ba71-8f82f9873bc8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Errors",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "service.name",
+                  "signal": "traces",
+                  "fieldContext": "resource",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "name",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "duration_nano",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "http_method",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "response_status_code",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "has_error = 'true' service.name IN $service_name"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "name",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "duration_nano",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "http_method",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "response_status_code",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      }
+                    ],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "67a074ee-c46e-4a36-8f5c-10d981cae404": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Services and Languages",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "columnUnits": {
+                  "A": ""
+                },
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()",
+                        "alias": "Conversation Count"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name AND openinference.span.kind = 'AGENT' AND graph.node.id NOT EXISTS "
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "telemetry.sdk.language",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "74a94376-eeaf-43c1-a273-5d8b98197138": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Number of Requests",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "temporal-otel": "#C55DE5",
+                  "temporal-otel1": "#DFE48B"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND telemetry.sdk.language in $language AND openinference.span.kind = 'AGENT' AND graph.node.id NOT EXISTS"
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "799913e6-fb95-497e-858a-6490b5f9d10d": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Error Rate",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "percentunit",
+                "decimalPrecision": "2"
+              },
+              "thresholds": [
+                {
+                  "value": 10,
+                  "operator": "above",
+                  "unit": "percentunit",
+                  "color": "Red",
+                  "format": "text"
+                },
+                {
+                  "value": 5,
+                  "operator": "above",
+                  "unit": "percentunit",
+                  "color": "Orange",
+                  "format": "text"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "has_error = 'true' service.name in $service_name"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "stepInterval": 0,
+                          "signal": "traces",
+                          "source": "",
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ],
+                          "disabled": true,
+                          "filter": {
+                            "expression": "has_error = 'false' service.name in $service_name"
+                          },
+                          "groupBy": [],
+                          "order": [],
+                          "selectFields": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "secondaryAggregations": null,
+                          "functions": [],
+                          "legend": ""
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "A / (A+B)",
+                          "disabled": false,
+                          "order": null,
+                          "having": {
+                            "expression": ""
+                          },
+                          "functions": null,
+                          "legend": ""
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "af79b14b-5e76-47fb-a24e-a4629c642c28": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Request Duration (P95)",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "ns",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "temporal-otel": "#C55DE5",
+                  "temporal-otel1": "#DFE48B"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "p95(duration_nano)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND telemetry.sdk.language in $language AND openinference.span.kind = 'AGENT' AND graph.node.id IN $agent_name "
+                    },
+                    "groupBy": [
+                      {
+                        "name": "service.name",
+                        "signal": "traces",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{service.name}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Output Tokens",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "sum(llm.token_count.completion)"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND telemetry.sdk.language in $language AND openinference.span.kind = 'LLM' AND llm.model_name in $llm_model"
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "e8a24d56-2d9d-46c2-a0d4-642bc5f1c6ee": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Temporal Poll Success Rate",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "signoz-demo.a1b2c": "#E830D5",
+                  "signoz-staging.a1b2c": "#AFE55D"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "metrics",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "metricName": "temporal_cloud_v0_poll_success_count:rate2m",
+                        "temporality": "",
+                        "timeAggregation": "avg",
+                        "spaceAggregation": "avg",
+                        "reduceTo": "avg"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": ""
+                    },
+                    "groupBy": [
+                      {
+                        "name": "temporal_namespace",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{temporal_namespace}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "f08a8cc0-424d-4f60-81f1-23a681e863b0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Agent Traces",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/ListPanel",
+            "spec": {
+              "selectFields": [
+                {
+                  "name": "service.name",
+                  "signal": "traces",
+                  "fieldContext": "resource",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "name",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": "string"
+                },
+                {
+                  "name": "duration_nano",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "http_method",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                },
+                {
+                  "name": "response_status_code",
+                  "signal": "traces",
+                  "fieldContext": "span",
+                  "fieldDataType": ""
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "raw",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name IN $service_name graph.node.id in $agent_name AND openinference.span.kind = 'AGENT' "
+                    },
+                    "groupBy": [],
+                    "order": [],
+                    "selectFields": [
+                      {
+                        "name": "service.name",
+                        "signal": "",
+                        "fieldContext": "resource",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "name",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": "string"
+                      },
+                      {
+                        "name": "duration_nano",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "http_method",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      },
+                      {
+                        "name": "response_status_code",
+                        "signal": "",
+                        "fieldContext": "span",
+                        "fieldDataType": ""
+                      }
+                    ],
+                    "limit": 10,
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": ""
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "f0d660ea-8ddc-4edd-9760-765a1c212c72": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Worker Poll Timeout Rate",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time",
+                "fillSpans": false
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "chartAppearance": {
+                "lineInterpolation": "spline",
+                "showPoints": false,
+                "lineStyle": "solid",
+                "fillMode": "none",
+                "spanGaps": {
+                  "fillOnlyBelow": false,
+                  "fillLessThan": ""
+                }
+              },
+              "axes": {
+                "softMin": 0,
+                "softMax": 0,
+                "isLogScale": false
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "signoz-demo.a1b2c": "#E830D5",
+                  "signoz-staging.a1b2c": "#AFE55D"
+                }
+              },
+              "thresholds": null
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "stepInterval": 60,
+                    "signal": "metrics",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "metricName": "temporal_cloud_v0_poll_timeout_count:rate2m",
+                        "temporality": "",
+                        "timeAggregation": "avg",
+                        "spaceAggregation": "avg",
+                        "reduceTo": "avg"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": ""
+                    },
+                    "groupBy": [
+                      {
+                        "name": "temporal_namespace",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{temporal_namespace}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      },
+      "fa87c0ad-c744-4573-85b7-0c44ad738f90": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Agent Distribution",
+            "description": ""
+          },
+          "plugin": {
+            "kind": "signoz/PieChartPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "formatting": {
+                "unit": "none",
+                "decimalPrecision": "2"
+              },
+              "legend": {
+                "position": "bottom",
+                "mode": "list",
+                "customColors": {
+                  "Search agent": "#704CEB",
+                  "Summary agent": "#E5A35D",
+                  "Triage agent": "#8BE4D3"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "name": "A",
+                "plugin": {
+                  "kind": "signoz/BuilderQuery",
+                  "spec": {
+                    "name": "A",
+                    "signal": "traces",
+                    "source": "",
+                    "aggregations": [
+                      {
+                        "expression": "count()"
+                      }
+                    ],
+                    "disabled": false,
+                    "filter": {
+                      "expression": "service.name in $service_name AND graph.node.id EXISTS AND openinference.span.kind = 'AGENT' "
+                    },
+                    "groupBy": [
+                      {
+                        "name": "graph.node.id",
+                        "signal": "",
+                        "fieldContext": "attribute",
+                        "fieldDataType": "string"
+                      }
+                    ],
+                    "order": [],
+                    "having": {
+                      "expression": ""
+                    },
+                    "functions": [],
+                    "legend": "{{graph.node.id}}"
+                  }
+                }
+              }
+            }
+          ],
+          "links": []
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "LLM",
+            "collapse": {
+              "open": true
+            }
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/04247ee1-b408-457d-ac00-47ce45e64291"
+              }
+            },
+            {
+              "x": 4,
+              "y": 0,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/d6cf07ab-f06e-43ce-a3fd-48ef0c3c9570"
+              }
+            },
+            {
+              "x": 8,
+              "y": 0,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/01c76dbd-5af0-4dcc-9693-006d589112d5"
+              }
+            },
+            {
+              "x": 0,
+              "y": 3,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/28bb5d45-046d-4980-ad5e-26b1aeecda2b"
+              }
+            },
+            {
+              "x": 6,
+              "y": 3,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/57a65ebe-9394-4734-88c4-73c03c02c5db"
+              }
+            },
+            {
+              "x": 0,
+              "y": 9,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/28409661-48e9-454c-ba5a-890e5268ef4e"
+              }
+            },
+            {
+              "x": 6,
+              "y": 9,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/3633c7ad-203a-4e25-99f4-8cc81bf15d65"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "App",
+            "collapse": {
+              "open": true
+            }
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 3,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/799913e6-fb95-497e-858a-6490b5f9d10d"
+              }
+            },
+            {
+              "x": 3,
+              "y": 0,
+              "width": 9,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/67a074ee-c46e-4a36-8f5c-10d981cae404"
+              }
+            },
+            {
+              "x": 0,
+              "y": 4,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/74a94376-eeaf-43c1-a273-5d8b98197138"
+              }
+            },
+            {
+              "x": 6,
+              "y": 4,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/af79b14b-5e76-47fb-a24e-a4629c642c28"
+              }
+            },
+            {
+              "x": 0,
+              "y": 10,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/5e66cb8c-2219-47e6-ba71-8f82f9873bc8"
+              }
+            },
+            {
+              "x": 0,
+              "y": 16,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/05e6759b-c460-4618-86c0-5d2bf0b311c1"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Agents",
+            "collapse": {
+              "open": true
+            }
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/389d43de-99b1-4c35-9589-f7d969abaa9d"
+              }
+            },
+            {
+              "x": 6,
+              "y": 0,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/fa87c0ad-c744-4573-85b7-0c44ad738f90"
+              }
+            },
+            {
+              "x": 0,
+              "y": 6,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/f08a8cc0-424d-4f60-81f1-23a681e863b0"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Temporal Cloud",
+            "collapse": {
+              "open": true
+            }
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/e8a24d56-2d9d-46c2-a0d4-642bc5f1c6ee"
+              }
+            },
+            {
+              "x": 6,
+              "y": 0,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/1c360b12-cdf5-4d08-9289-f0a64ecfa7e8"
+              }
+            },
+            {
+              "x": 0,
+              "y": 6,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/f0d660ea-8ddc-4edd-9760-765a1c212c72"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "",
+    "refreshInterval": "",
+    "links": []
+  },
+  "tags": [],
+  "image": "/assets/Icons/eight-ball"
+}


### PR DESCRIPTION
Re-exports the LLM dashboard templates from SigNoz so the committed JSON matches the current dashboards. These pick up a round of work that was never reflected here.

## What changed in the dashboards

- **Panel layouts** tidied into uniform rows. Several had panels at mismatched heights starting at odd offsets, which rendered as a ragged staircase with gaps.
- **Per-dashboard legend colour themes.** Previously every template drew from the same palette, so a three-service board looked identical whether it was Ollama, Mastra or Haystack. Each now anchors on its own hue, while staying distinguishable within a panel.
- **Template variable defaults corrected.** Several listed services and models that do not exist in any data — e.g. Groq resolved `$llm_model` against 12 values including `gpt-3.5-turbo` and `gpt-4o`, none of which are Groq models, so panels filtering on it rendered empty on import. Temporal had the same issue.
- **Panel fixes**: `service.name` groupBy left in `attribute` context (silently drops grouping), error-rate formulas returning a 0-1 fraction against a `%` unit, error-rate numerators double-counting spans, and composite-query formula legends left blank so series rendered as `F1`.

## Note on schema version

These are exported from current SigNoz, which emits the **v6** format (top-level `spec`). The existing 122 templates here are **v5** (`widgets` / `layout` / `panelMap`).

This is not a mistake or a hand-conversion — the v1 dashboards API now returns `501 Not Implemented`, and the in-product JSON export produces v6. So v6 is simply what SigNoz exports today. These are the first v6 templates in the repo.

Worth confirming that is acceptable before merge. If you would rather keep the repo uniformly v5, I can hold this until a converter exists — but note the v5 files can no longer be regenerated from the product.

## Dashboards updated (22)

Amazon Bedrock, AutoGen, Azure OpenAI, Crew AI, Dify, Gemini, Google ADK, Grok, Groq, Hermes, Inkeep, LiteLLM Proxy, LiteLLM SDK, LiveKit, Mastra, Ollama, OpenAI, OpenCode, Pipecat, Pydantic AI, Semantic Kernel, Temporal.

Each file was validated as parseable, carries its panels and variables, and contains no server metadata (`createdAt`, `orgId`, `updatedBy`) or credentials.

Screenshots for these same dashboards are being refreshed in SigNoz/signoz.io#3865.