### PR TITLE
fix(openai): correct Error Rate filter and Token Usage token sum

### DIFF
--- a/openai/openai-dashboard.json
+++ b/openai/openai-dashboard.json
@@ -411,7 +411,7 @@
                           "source": "",
                           "aggregations": [
                             {
-                              "expression": "sum(gen_ai.usage.input_tokens)"
+                              "expression": "sum(gen_ai.usage.output_tokens)"
                             }
                           ],
                           "disabled": true,
@@ -422,8 +422,8 @@
                             {
                               "name": "service.name",
                               "signal": "",
-                              "fieldContext": "",
-                              "fieldDataType": ""
+                              "fieldContext": "resource",
+                              "fieldDataType": "string"
                             }
                           ],
                           "order": [],
@@ -851,7 +851,7 @@
                           ],
                           "disabled": true,
                           "filter": {
-                            "expression": "has_error = 'true' service.name in $service_name AND gen_ai.system EXISTS"
+                            "expression": "has_error = 'true' service.name in $service_name AND gen_ai.request.model EXISTS"
                           },
                           "groupBy": [],
                           "order": [],
@@ -878,7 +878,7 @@
                           ],
                           "disabled": true,
                           "filter": {
-                            "expression": "has_error = 'false' service.name in $service_name AND gen_ai.system EXISTS "
+                            "expression": "has_error = 'false' service.name in $service_name AND gen_ai.request.model EXISTS "
                           },
                           "groupBy": [],
                           "order": [],


### PR DESCRIPTION
## Summary

Two panels in the OpenAI dashboard return wrong values against real `gen_ai` telemetry. Both were found while importing this template against a live `openai-otel` service, and both fixes are verified against that data.

## 1. Error Rate renders no value

Both queries backing the Error Rate panel scoped their spans with:

```
gen_ai.system EXISTS
```

Recent OpenTelemetry GenAI semantic conventions renamed `gen_ai.system` to `gen_ai.provider.name`. On current instrumentation the old key does not exist, so both the numerator and denominator count 0 and the panel renders nothing. The backend says so explicitly:

> key `gen_ai.system` not found in metadata; querying the underlying data directly. If this is unexpected, check the key name for typos.

**Fix:** scope on `gen_ai.request.model EXISTS` instead.

I chose `gen_ai.request.model` over `gen_ai.provider.name` deliberately:

- it selects exactly the same spans (verified: both return an identical `0.667` on the same window),
- it is present in **both** the old and new semconv, so this does not break users still on older instrumentation, which swapping to `gen_ai.provider.name` would have,
- it is already the scoping predicate used by **Model Calls**, **Token Distribution by Models**, and **Services and Languages** in this same dashboard, so it is internally consistent.

## 2. Token Usage double-counts input tokens

The Token Usage panel is a composite of query A + query B. Both summed the same attribute:

```
A: sum(gen_ai.usage.input_tokens)
B: sum(gen_ai.usage.input_tokens)   <- should be output_tokens
```

So the `A + B` formula plotted **twice the input tokens** and never showed output tokens at all, on a panel titled "Token Usage".

**Fix:** query B now sums `gen_ai.usage.output_tokens`.

Query B's `groupBy` also left `fieldContext` and `fieldDataType` empty where query A set `resource`/`string`. Both sides of a formula need to group identically for the series to align, so B now matches A.

## Verification

Both corrected queries were executed against a live `openai-otel` service (OpenAI Python SDK, OTel Python instrumentation, models `gpt-5` and `gpt-4.1-turbo`):

| Panel | Before | After |
|---|---|---|
| Error Rate | no data (count 0, key-not-found warning) | `0.667` |
| Token Usage | double-counted input, no output | `162` total tokens |

The diff is 5 lines across 2 panels. No layout, variable, or panel-type changes.

## Noted but deliberately not changed here

- **`llm_model` default is `["gpt-5", "gpt-4.1"]`.** Any user whose models differ gets empty panels on every `$llm_model`-filtered panel until they change the dropdown. That is what initially masked bug #2 for me. However, roughly half the LLM templates in this repo ship hardcoded demo defaults and half ship `null` with `allowAllValue: true` (the latter works for everyone out of the box). That is a repo-wide convention question, not an OpenAI bug, so it is out of scope for this PR. Happy to open a separate one if the `null` + `allowAllValue` pattern is the preferred direction.
- **`huggingface/huggingface-dashboard.json` has the same class of bug as #2**: its "Token Distribution by Models" panel sums `gen_ai.usage.output_tokens` in both A and B (plus a stray newline inside the expression). I have not validated it against live HuggingFace telemetry, so I left it out rather than ship an unverified fix. Worth a follow-up.
